### PR TITLE
CPU KV offload follow-up: data-movement optimization series

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2575,6 +2575,26 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_KV_OFFLOAD"));
     add_opt(common_arg(
+        {"--kv-cpu-pinned"},
+        {"--no-kv-cpu-pinned"},
+        string_format("route CPU-resident KV cache layers through pinned/host memory instead of plain CPU memory; "
+                      "only affects layers not offloaded to GPU, e.g. when combined with --no-kv-offload (default: %s)",
+                      params.kv_cpu_pinned ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.kv_cpu_pinned = value;
+        }
+    ).set_env("LLAMA_ARG_KV_CPU_PINNED"));
+    add_opt(common_arg(
+        {"--recurrent-state-offload"},
+        {"--no-recurrent-state-offload"},
+        string_format("for hybrid attention/recurrent models, keep the fixed recurrent (R/S) state GPU-resident "
+                      "even when --no-kv-offload moves attention KV to CPU (default: %s)",
+                      params.recurrent_state_offload ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.recurrent_state_offload = value;
+        }
+    ).set_env("LLAMA_ARG_RECURRENT_STATE_OFFLOAD"));
+    add_opt(common_arg(
         {"--repack"},
         {"-nr", "--no-repack"},
         string_format("whether to enable weight repacking (default: %s)", params.no_extra_bufts ? "disabled" : "enabled"),

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2598,6 +2598,20 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_RECURRENT_STATE_OFFLOAD"));
     add_opt(common_arg(
+        {"--kv-gpu-layers"}, "N",
+        string_format("with --no-kv-offload, keep the first N attention-KV layers device-resident anyway. "
+                      "Those layers stop being re-sent to the device on every decode step, which is the dominant "
+                      "long-context cost of KV offload, in exchange for their device memory. 0 keeps every layer "
+                      "on the host, a value at or above the attention-layer count matches --kv-offload "
+                      "(default: %d)", params.kv_gpu_layers),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("--kv-gpu-layers must not be negative");
+            }
+            params.kv_gpu_layers = value;
+        }
+    ).set_env("LLAMA_ARG_KV_GPU_LAYERS"));
+    add_opt(common_arg(
         {"--repack"},
         {"-nr", "--no-repack"},
         string_format("whether to enable weight repacking (default: %s)", params.no_extra_bufts ? "disabled" : "enabled"),

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2578,7 +2578,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--kv-cpu-pinned"},
         {"--no-kv-cpu-pinned"},
         string_format("route CPU-resident KV cache layers through pinned/host memory instead of plain CPU memory; "
-                      "only affects layers not offloaded to GPU, e.g. when combined with --no-kv-offload (default: %s)",
+                      "only affects layers not offloaded to GPU, e.g. when combined with --no-kv-offload; "
+                      "on an integrated GPU the pinned buffer is GPU-visible unified memory, so attention for those "
+                      "layers may still run on the GPU even with --no-kv-offload (default: %s)",
                       params.kv_cpu_pinned ? "enabled" : "disabled"),
         [](common_params & params, bool value) {
             params.kv_cpu_pinned = value;
@@ -2588,7 +2590,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--recurrent-state-offload"},
         {"--no-recurrent-state-offload"},
         string_format("for hybrid attention/recurrent models, keep the fixed recurrent (R/S) state GPU-resident "
-                      "even when --no-kv-offload moves attention KV to CPU (default: %s)",
+                      "even when --no-kv-offload moves attention KV to CPU; only takes effect when --kv-offload "
+                      "is disabled, since --kv-offload already keeps the recurrent state on GPU (default: %s)",
                       params.recurrent_state_offload ? "enabled" : "disabled"),
         [](common_params & params, bool value) {
             params.recurrent_state_offload = value;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1840,6 +1840,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.offload_kqv       = !params.no_kv_offload;
     cparams.kv_cpu_pinned     = params.kv_cpu_pinned;
     cparams.recurrent_state_offload = params.recurrent_state_offload;
+    cparams.kv_gpu_layers     = (uint32_t) std::max(0, params.kv_gpu_layers);
     cparams.no_perf           = params.no_perf;
     cparams.op_offload        = !params.no_op_offload;
     cparams.swa_full          = params.swa_full;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1838,6 +1838,8 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.cb_eval           = params.cb_eval;
     cparams.cb_eval_user_data = params.cb_eval_user_data;
     cparams.offload_kqv       = !params.no_kv_offload;
+    cparams.kv_cpu_pinned     = params.kv_cpu_pinned;
+    cparams.recurrent_state_offload = params.recurrent_state_offload;
     cparams.no_perf           = params.no_perf;
     cparams.op_offload        = !params.no_op_offload;
     cparams.swa_full          = params.swa_full;

--- a/common/common.h
+++ b/common/common.h
@@ -616,6 +616,7 @@ struct common_params {
     bool no_kv_offload     = false; // disable KV offloading
     bool kv_cpu_pinned     = false; // route CPU-resident KV cache layers through pinned/host memory
     bool recurrent_state_offload = false; // for hybrid models, keep recurrent state GPU-resident even with no_kv_offload
+    int32_t kv_gpu_layers  = 0;     // with no_kv_offload, keep this many attention-KV layers device-resident anyway
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device

--- a/common/common.h
+++ b/common/common.h
@@ -614,6 +614,8 @@ struct common_params {
     bool verbose_prompt    = false; // print prompt tokens before generation
     bool display_prompt    = true;  // print prompt before generation
     bool no_kv_offload     = false; // disable KV offloading
+    bool kv_cpu_pinned     = false; // route CPU-resident KV cache layers through pinned/host memory
+    bool recurrent_state_offload = false; // for hybrid models, keep recurrent state GPU-resident even with no_kv_offload
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device

--- a/docs/cpu-kv-offload-experiments.md
+++ b/docs/cpu-kv-offload-experiments.md
@@ -926,3 +926,113 @@ confirming the option reaches context creation through the normal
   split there is unstarted.
 - `llama-bench`'s new flags are process-wide (not swept per combination like
   `-nkvo`), matching how the documented benchmark protocol invokes them today.
+
+## Experiment 009: lossless compression of the Q8_0 transfer stream
+
+Status: rejected on measured entropy grounds. No implementation was written; the
+measurement is the deliverable, and it closes the direction.
+
+### Hypothesis
+
+Experiment 005 and the Nsight traces established that decode cost at long context
+is dominated by scheduler host-to-device copies of the complete Q8_0 K and V
+tensors, running at the PCIe hardware limit. With Q8_0 K/V fixed as the quality
+gate, the only remaining way to reduce that cost is to move fewer bytes for the
+same information. The hypothesis was that the Q8_0 stream carries enough
+redundancy for a GPU-decodable lossless codec to pay for itself.
+
+### Method
+
+Real cache contents were used rather than synthetic data. `llama-server` ran the
+established model with `-c 8192 -nkvo -fa on -ctk q8_0 -ctv q8_0
+--kv-cpu-pinned --recurrent-state-offload` and `--slot-save-path`. A 6,391-token
+prompt of ordinary English prose was evaluated and the populated slot was written
+out with `POST /slots/1?action=save`, producing 379,801,088 bytes for 6,398
+cells.
+
+Q8_0 regions were located by their structural signature: Q8_0 derives its block
+scale as `amax/127`, so every 32-value block must contain an element of magnitude
+exactly 127. Scanning all 34-byte phases found the attention-KV region starting
+at file offset 1,048,608 and covering approximately 212 MiB, consistent with the
+expected 16 layers x 2 tensors x 6,398 tokens x 1,088 bytes. Recurrent state and
+headers were excluded. Measurements below used 4,000 token rows (about 4.4 MiB)
+for the structured tests and 176,470 blocks (about 11.3 MiB of payload) for the
+entropy tests.
+
+### Results
+
+Payload statistics: standard deviation 55.0; 11.1% of values with magnitude below
+8, 22.6% below 16, 43.8% below 32. The distribution is close to Gaussian and
+occupies the full signed 8-bit range by construction.
+
+| Scheme | Entropy | Achievable ratio |
+| --- | ---: | ---: |
+| Order-0 entropy coding of the int8 payload | 7.685 bits | 1.041x |
+| Delta along the context dimension, then order-0 | 7.550 bits | 1.060x |
+| Delta along the channel dimension, then order-0 | 8.355 bits | 0.958x |
+| `zlib` level 9 on the raw stream | -- | 1.033x |
+| `lzma` preset 6 on the raw stream | -- | 1.028x |
+| FP16 block scales alone (5.9% of bytes) | 10.061 of 16 bits | 1.590x |
+
+Combining the best payload result with separately coded scales bounds a perfect
+adaptive coder at approximately **1.081x**, or an 8% byte reduction.
+
+### Disposition
+
+Rejected. The bound is an entropy limit assuming an ideal coder; a real
+GPU-decodable implementation would realise less while adding a decompression
+kernel, a host-side compression step on the write path, and a variable-length
+addressing scheme on top of the current fixed-stride cache layout. An 8% ceiling
+does not justify that.
+
+The underlying reason is structural and will not change with a better codec.
+Q8_0 normalises every 32-value block by its own maximum, which forces the full
+8-bit range in every block and leaves a near-Gaussian residual with a standard
+deviation of 55. That residual carries 7.685 bits of genuine entropy per stored
+byte. Q8_0 is already close to an optimal fixed-rate code for this data, so there
+is no payload redundancy for a lossless codec to remove. Delta coding along the
+context dimension recovers only 0.135 bits because per-block rescaling destroys
+the smoothness that would otherwise exist between neighbouring tokens.
+
+Do not revisit payload compression for any block-scaled `qN_0` cache format. The
+same normalisation argument applies to all of them.
+
+### The redundancy that does exist
+
+The measurement redirects rather than ends the byte-reduction effort. The Q8_0
+payload is incompressible, but the *transfer schedule* is massively redundant:
+the KV cache is append-only, so between two decode steps exactly one row of
+1,088 bytes per tensor changes, while the scheduler re-sends the entire tensor.
+At 32K that is 1,123,024,896 bytes sent per token to convey roughly 34,816 bytes
+of new information.
+
+Eliminating that redundancy is exactly lossless and needs no codec, but it
+requires the previously sent bytes to stay resident on the GPU, which is the
+VRAM cost that offload exists to avoid. It is therefore a tunable trade rather
+than a free win. Measured on the RTX 4070 with `Qwen3.8-27B-UD-IQ2_M.gguf`,
+`-ngl 99 -t 3 --poll 100 -fa on -ctk q8_0 -ctv q8_0 --recurrent-state-offload`,
+`-p 0 -n 32 -r 2`, three real P-cores via `taskset -c 0,2,4`:
+
+| Depth | Host KV (`-nkvo 1 --kv-cpu-pinned`) | GPU-resident KV | Change |
+| ---: | ---: | ---: | ---: |
+| 0 | 39.38 +/- 0.29 t/s | 39.95 +/- 0.32 t/s | +1.4% |
+| 4096 | 31.89 +/- 0.21 t/s | 39.02 +/- 0.21 t/s | +22.4% |
+| 16384 | 19.76 +/- 0.05 t/s | 36.13 +/- 0.17 t/s | +82.8% |
+
+Reported buffer sizes for the host-KV configuration were 8.50 MiB of
+`CUDA_Host` KV at depth 0, 144.50 MiB at 4096, 280.50 MiB at 8192, and 552.50
+MiB at 16384. The `CUDA0` compute buffer did not scale with depth in the same
+way, measuring 7.14, 505.00, 562.04, and 505.00 MiB respectively; the staging
+copies therefore reuse a small per-layer arena rather than reserving
+cache-sized space. A persistent GPU-side mirror is consequently **not** free in
+VRAM, and the 552.50 MiB at 16K is genuine additional device memory.
+
+Since the whole 16K Q8_0 cache is only 552.50 MiB and buys 82.8%, the useful
+next step is a **tunable partial GPU KV window**: keep the newest N tokens
+device-resident, stream only the older remainder, and merge the two partial
+attention results. FlashAttention decomposes exactly over the KV dimension via
+log-sum-exp rescaling, so the merge is lossless and preserves the Q8_0 quality
+gate. The fork already has a segmented merge primitive in
+`ggml_kv_tail_attention_merge_segmented` for KVarN tails, which is the closest
+existing reference. The dial degrades gracefully: N = 0 reproduces today's
+behaviour, N = n_ctx reproduces GPU-resident KV.

--- a/docs/cpu-kv-offload-experiments.md
+++ b/docs/cpu-kv-offload-experiments.md
@@ -1036,3 +1036,114 @@ gate. The fork already has a segmented merge primitive in
 `ggml_kv_tail_attention_merge_segmented` for KVarN tails, which is the closest
 existing reference. The dial degrades gracefully: N = 0 reproduces today's
 behaviour, N = n_ctx reproduces GPU-resident KV.
+
+## Experiment 010: tunable partial GPU KV residency
+
+Status: retained. Implements the direction identified at the end of Experiment
+009 and gives the first continuous dial between host-resident and GPU-resident
+attention KV.
+
+### Change
+
+`--kv-gpu-layers N` (env `LLAMA_ARG_KV_GPU_LAYERS`, also accepted by
+`llama-bench`) keeps the first N attention-KV layers device-resident while
+`--no-kv-offload` is active; the remaining layers stay on the host exactly as
+before. `N = 0` reproduces current behaviour and any `N` at or above the
+attention-layer count matches `--kv-offload`.
+
+The selection is per layer rather than per token range. That was deliberate:
+`llama_kv_cache` already chooses a buffer type per layer at both the route-probe
+and the allocation site, so the placement decision fits the existing structure
+with no change to cell indexing, defragmentation, state serialization, or the
+attention graph. Each layer's attention still reads one contiguous cache in one
+buffer, so no partial-result merge and no new kernel are involved. A recency
+window would have required splitting each layer's cache in two and combining the
+two partial attentions with log-sum-exp rescaling for the same byte reduction.
+
+Implementation is `[TAG_KV_PARTIAL_GPU_RESIDENCY]` in `llama-kv-cache.cpp`: a
+`layer_on_device` plan is computed once from `hparams.has_kv()` and the layer
+filter, then consulted at both buffer-type selection sites. The value flows
+`common_params` -> `llama_context_params::kv_gpu_layers` (appended at the end of
+the struct, preserving existing field offsets) -> `llama_cparams` ->
+`llama_model::create_memory()`, reaching the hybrid `mem_attn` cache and the
+plain non-SWA target cache.
+
+### Configuration
+
+RTX 4070 12 GiB (compute capability 8.9), Intel Core i5-13400F, 31 GiB RAM,
+PCIe 4.0 x16. Model `Qwen3.8-27B-UD-IQ2_M.gguf` (`qwen35`, 27.32B, 9.60 GiB,
+16 attention layers of 65). Release CUDA build, `GGML_NATIVE=ON`. Three distinct
+P-cores via `taskset -c 0,2,4`; note that `taskset -c 0-2` on this part spans
+only two physical cores, since CPUs 0 and 1 are SMT siblings. Common settings:
+`-ngl 99 -t 3 --poll 100 -nkvo 1 -fa on -ctk q8_0 -ctv q8_0 --kv-cpu-pinned
+--recurrent-state-offload`. Decode `-p 0 -n 32 -r 2`, prefill `-p 512 -n 0 -r 3`.
+
+### Results
+
+Decode, 32 tokens:
+
+| `--kv-gpu-layers` | d16384 (t/s) | ms/token | d32768 (t/s) | ms/token |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 19.70 +/- 0.11 | 50.76 | 13.03 +/- 0.05 | 76.75 |
+| 4 | 22.34 +/- 0.12 | 44.76 | -- | -- |
+| 8 | 25.70 +/- 0.17 | 38.91 | 18.76 +/- 0.09 | 53.30 |
+| 12 | 30.15 +/- 0.22 | 33.17 | 24.00 +/- 0.15 | 41.67 |
+| 16 | 36.00 +/- 0.21 | 27.78 | 32.42 +/- 0.17 | 30.84 |
+
+Full residency is +82.7% at 16K and **+148.8% at 32K**. The endpoints reproduce
+the independent references from Experiment 009 (19.76 t/s host-resident and
+36.13 t/s GPU-resident at 16K), confirming the dial is not introducing a path of
+its own.
+
+Per-token time is linear in the number of host-resident layers, which is the
+signature of a pure transfer cost: about 1.44 ms per layer at 16K and 2.85 ms
+per layer at 32K, roughly doubling with depth as the per-layer tensor doubles.
+
+Prefill of 512 tokens at depth 16384 was 984.72 +/- 6.65, 1009.94 +/- 10.70, and
+1033.99 +/- 17.00 t/s at N = 0, 8, and 16. Prefill improves slightly; there is no
+regression to trade against the decode gain.
+
+### Resource cost
+
+Reported KV buffer split at depth 16384:
+
+| `--kv-gpu-layers` | `CUDA0` KV | `CUDA_Host` KV |
+| ---: | ---: | ---: |
+| 0 | -- | 552.50 MiB |
+| 4 | 138.12 MiB | 414.38 MiB |
+| 8 | 276.25 MiB | 276.25 MiB |
+| 12 | 414.38 MiB | 138.12 MiB |
+| 16 | 552.50 MiB | -- |
+
+The total is unchanged, so this moves memory rather than adding it: 34.53 MiB of
+device memory per layer at 16K and 69.06 MiB at 32K. The exchange rate is
+therefore 34.53 MiB per 1.44 ms/token at 16K, and 69.06 MiB per 2.85 ms/token at
+32K. At 32K, full residency needs 1,105 MiB of device memory and still fits on
+this 12 GiB card alongside the 9,227 MiB of weights.
+
+### Correctness
+
+Greedy generation (`--temp 0 --seed 1234`, 96 tokens, `-no-cnv`) was
+byte-identical across `--kv-gpu-layers` 0, 8, and 16. This is expected rather
+than fortunate: both placements feed the same Q8_0 bytes to the same CUDA
+FlashAttention kernel, and only the source buffer differs. The Q8_0 quality gate
+is untouched.
+
+`ctest -R "test-kvarn|test-adaptive-dm|test-server-loop-guard"` passed 8/8.
+
+### Scope and limitations
+
+- Wired for the hybrid `mem_attn` cache and the plain non-SWA target cache. The
+  KVarN, ISWA, and `llama_kv_cache_kvarn` constructors take the new parameter's
+  default of 0 and are unaffected; extending them is unstarted.
+- `N` counts attention-KV layers from the lowest index. No evidence was gathered
+  that the choice of which layers to keep matters for throughput, and the linear
+  scaling suggests it does not, but this was not tested directly.
+- There is no automatic sizing. Choosing `N` to fill available VRAM requires
+  knowing the cache size per layer at the configured context, which the user must
+  currently work out from the reported buffer sizes.
+- `llama-bench` treats the flag as process-wide rather than sweeping it like
+  `-nkvo`, matching how `--kv-cpu-pinned` was wired in Experiment 008.
+- Measured on one machine only. The gain is proportional to the host-to-device
+  transfer cost, so a host with faster PCIe than this PCIe 4.0 x16 link will see
+  a smaller relative improvement.

--- a/docs/cpu-kv-offload-experiments.md
+++ b/docs/cpu-kv-offload-experiments.md
@@ -840,3 +840,89 @@ decode unchanged within single-run noise, and reduced prompt throughput by
 4.3%. Output-side draft counts and acceptance were identical in all three
 runs. Recommend 128 as the balanced setting for this hardware and workload;
 32 remains an explicit capacity-first option rather than a default.
+
+## Experiment 008: replace the environment switches with supported CLI/server options
+
+Status: retained. Closes "Proposed next sequence" item 11 from
+`cpu-kv-offload-development.md` for the standard non-SWA hybrid path; the
+scope limitation from Experiment 002 (ISWA and other special memory
+constructors not covered) still applies.
+
+### Change
+
+`GGML_KV_CPU_PINNED` and `GGML_RECURRENT_STATE_OFFLOAD` are replaced by first-class
+parameters that follow the same `common_arg` pattern as `--kv-offload`/`--no-kv-offload`:
+
+- `--kv-cpu-pinned` / `--no-kv-cpu-pinned` (env `LLAMA_ARG_KV_CPU_PINNED`)
+- `--recurrent-state-offload` / `--no-recurrent-state-offload`
+  (env `LLAMA_ARG_RECURRENT_STATE_OFFLOAD`)
+
+Both flags are available on `llama-cli`, `llama-completion`, `llama-server`, and
+`llama-bench` (the latter has its own argument parser and `cmd_params`/
+`cmd_params_instance` structs, so it required separate wiring). The values flow
+`common_params` -> `llama_context_params` (new `kv_cpu_pinned` and
+`recurrent_state_offload` bools, appended to the trailing bool block) ->
+`llama_cparams` -> `llama_model::create_memory()`, replacing the `std::getenv`
+reads in `llama-kv-cache.cpp` and `llama-model.cpp`.
+
+`llama_kv_cache_cpu_buft()` now takes an explicit `cpu_pinned` bool instead of
+reading the environment. The `llama_kv_cache` constructor gained a trailing
+`cpu_pinned = false` default parameter (kept at the end so the ~15 existing call
+sites across `llama-kv-cache-{kvarn,dsa,dsv4,msa,iswa}.cpp` do not need to change);
+it is wired to `cparams.kv_cpu_pinned` at the four call sites that construct the
+actual target attention-KV cache (the plain non-hybrid path, its kvarn-native-exact
+variant, the MTP-draft cache, and `llama_memory_hybrid`'s `mem_attn`). The
+recurrent-state getenv check in `llama-model.cpp` is replaced by
+`cparams.offload_kqv || cparams.recurrent_state_offload`.
+
+Unlike the global environment variable, which applied to every `llama_kv_cache`
+instance in the process including auxiliary DSA/MSA/DSV4 indexer caches, the CLI
+option only affects the primary target attention-KV cache. Those auxiliary caches
+were never part of the documented pinning workflow or its benchmarks, so this is
+considered a scope correction, not a regression.
+
+### Verification
+
+Functional equivalence against Experiment 001/002 was confirmed on different
+hardware (RTX 4070, 12 GiB, compute capability 8.9; Intel host; three pinned
+decode threads) using `Qwen3.8-27B-UD-IQ2_M.gguf`:
+
+```bash
+taskset -c 0-2 build/bin/llama-bench -m MODEL -ngl 99 -t 3 --poll 100 \
+  -nkvo 1 -fa on -ctk q8_0 -ctv q8_0 -p 0 -n 64 -d DEPTH -r 3 \
+  [--kv-cpu-pinned] [--recurrent-state-offload]
+```
+
+| Config | Prefill @4K (t/s) | Decode @4K (t/s) | Decode @16K (t/s) |
+| --- | ---: | ---: | ---: |
+| baseline (no flags) | 993.40 +/- 6.57 | 13.72 +/- 0.02 | 8.96 +/- 0.01 |
+| `--kv-cpu-pinned` | 1011.65 +/- 2.30 | 15.26 +/- 0.02 | 11.79 +/- 0.03 |
+| `--recurrent-state-offload` | 1152.98 +/- 10.94 | 26.34 +/- 0.11 | 13.21 +/- 0.02 |
+| both | 1173.53 +/- 11.59 | 31.80 +/- 0.11 | 19.75 +/- 0.04 |
+| both, re-measured after the CLI-flag refactor | -- | 31.92 +/- 0.11 | -- |
+
+The last row re-ran the "both" decode@4K case through the new
+`--kv-cpu-pinned --recurrent-state-offload` flags instead of the old environment
+variables; the result (31.92 t/s) matches the pre-refactor value (31.80 t/s)
+within run-to-run noise, confirming the parameter-plumbing change did not alter
+behavior.
+
+Process VRAM peak (decode@4K, sampled repeatedly via `nvidia-smi
+--query-compute-apps`, 8 repetitions): baseline 10,002 MiB vs. both flags
+enabled 10,130 MiB (+128 MiB), consistent with the +124 MiB reported for the
+same comparison in Experiment 002 on different hardware.
+
+An end-to-end smoke test with `llama-completion -nkvo --kv-cpu-pinned
+--recurrent-state-offload` produced coherent output and exited cleanly,
+confirming the option reaches context creation through the normal
+`common/arg.cpp` parsing path (not just `llama-bench`'s separate parser).
+
+### Remaining scope for a supported policy
+
+- MTP rollback-state VRAM and realistic-prompt validation from Experiment 002's
+  "current limitations" are still open.
+- `llama_memory_hybrid_iswa` (the SWA-hybrid path) still ties recurrent-state
+  and attention-KV placement to a single `offload` argument; extending the
+  split there is unstarted.
+- `llama-bench`'s new flags are process-wide (not swept per combination like
+  `-nkvo`), matching how the documented benchmark protocol invokes them today.

--- a/docs/cpu-kv-offload-experiments.md
+++ b/docs/cpu-kv-offload-experiments.md
@@ -1147,3 +1147,124 @@ is untouched.
 - Measured on one machine only. The gain is proportional to the host-to-device
   transfer cost, so a host with faster PCIe than this PCIe 4.0 x16 link will see
   a smaller relative improvement.
+
+## Experiment 011: transient CUDA compute-buffer overhead is independent of KV residency
+
+Status: characterized, not fixed. External review of Experiment 010 (from the
+PR1 side) pointed out that reducing VRAM allocation overhead is a separate
+problem from KV placement, specifically flagging F16 materialization of
+quantized K/V during prompt attention, a fixed-window KV staging idea, a
+compact causal-mask representation, and a decode-only graph after prefill.
+This experiment measures and confirms the first of those on our own hardware,
+and explains in code why fixing it is out of scope for a single-session change.
+
+### Hypothesis
+
+`--kv-gpu-layers` (Experiment 010) only moves the persistent, quantized K/V
+tensor between host and device. It does not touch the transient CUDA compute
+buffer the scheduler reserves for the flash-attention graph. If that transient
+buffer materializes a full F16 copy of the attended K/V range regardless of
+`N`, its cost is additive to Experiment 010's savings, not covered by them.
+
+### Code confirmation
+
+`ggml_cuda_flash_attn_ext_get_alloc_size` in
+`ggml/src/ggml-cuda/fattn.cu` sets `need_f16_K = need_f16_V = true`
+unconditionally for `BEST_FATTN_KERNEL_TILE` and `BEST_FATTN_KERNEL_MMA_F16`.
+`ggml_cuda_get_best_fattn_kernel` only routes quantized K/V to the
+F16-materialization-free vector kernel when the query width is very small
+(`Q->ne[1] <= 2` on Ada, `== 1` before Ada); anything wider, i.e. ordinary
+prompt processing, takes the MMA/tile path and pays the F16 cast. This is
+upstream behaviour, not fork-specific, and it applies however the persistent
+cache is placed.
+
+The fork already has a kernel that avoids this for KVarN cache types:
+`ggml_cuda_flash_attn_ext_kvarn_uses_views` and the descriptor-native loaders
+in `fattn-mma-kvarn-load.cuh` dequantize per tile from KVarN's packed records
+instead of pre-casting a full K/V tensor. That path is specific to KVarN's
+variable-bit, three-axis (scale/zero-point/other-axis) affine block format and
+its rotated staging layout; it is not a drop-in generalization to plain
+`q8_0`, whose block format is much simpler but structurally different. Writing
+an equivalent quantized-native MMA path for standard `qN_0` types would be new
+tensor-core kernel work comparable in scope to that existing implementation,
+not a wiring change like Experiment 010, and this fork's correctness bar for
+KV-cache changes (byte-identical output, real GPU testing) is not something to
+approximate. It was not attempted here.
+
+The tail-merge primitives already in the codebase
+(`ggml_kv_tail_attention_merge`, `ggml_kv_tail_attention_merge_segmented`)
+were considered as a way to chunk prefill K/V through a small reused F16
+buffer instead of writing a new kernel. They do not fit: both attach extra
+source tensors to a single `GGML_OP_FLASH_ATTN_EXT` node so the backend can
+compute the merge inside one kernel launch, capped at one history and one
+current source; they are not a standalone op that can combine independently
+executed passes, so they cannot be reused externally for an arbitrary-way
+context chunking.
+
+Experiment 004 already showed that changing which backend runs attention does
+not reduce these buffers either: its matched-memory run recorded identical
+CUDA context and compute buffer sizes whether decode attention ran on CPU or
+GPU, because the scheduler reserves compute buffers for the worst-case graph
+once, independent of where a given step's op is actually dispatched.
+
+### Method
+
+`llama-bench --kv-memory -o json` reports `cuda_compute_buffer_bytes`, the
+scheduler's transient CUDA workspace, separately from `cuda_context_buffer_bytes`
+(the persistent KV storage). Sweeping `--kv-gpu-layers` at fixed depth isolates
+whether that transient buffer responds to the residency dial:
+
+```bash
+taskset -c 0,2,4 build/bin/llama-bench -m Qwen3.8-27B-UD-IQ2_M.gguf \
+  -p 32 -n 4 -d DEPTH -r 1 -t 3 --poll 100 \
+  -nkvo 1 -fa on -ctk q8_0 -ctv q8_0 --kv-gpu-layers N \
+  --kv-memory -o json
+```
+
+Getting this to run at `--kv-gpu-layers 0` required a fix: `llama-bench`'s
+`--kv-memory` sanity check assumed every byte `llama_kv_cache::kv_memory_stats`
+counts as KV payload is GPU-resident, which held before Experiment 010 (KV
+placement was all-or-nothing) but not after (`kv_resident_bytes()` totals K/V
+tensor sizes across all layers regardless of which buffer type actually backs
+them). At `N = 0` this total legitimately exceeds the GPU context buffer, and
+the check aborted the run instead of reporting it. `tools/llama-bench/llama-bench.cpp`
+now treats any excess as host-side instead of erroring.
+
+### Results
+
+| `--kv-gpu-layers` | Depth | Compute buffer | Context buffer |
+| ---: | ---: | ---: | ---: |
+| 0 | 16384 | 551.66 MiB | 0 MiB |
+| 0 | 32768 | 567.61 MiB | 0 MiB |
+| 8 | 16384 | 595.90 MiB | 276.28 MiB |
+| 8 | 32768 | 611.90 MiB | 548.28 MiB |
+| 16 | 16384 | 551.66 MiB | 552.50 MiB |
+| 16 | 32768 | 623.87 MiB | 1,096.50 MiB |
+
+The compute buffer sits in the same 550-625 MiB band at every `N`; it does not
+scale with how many layers `--kv-gpu-layers` keeps device-resident, confirming
+the hypothesis. Its context buffer counterpart, by contrast, is exactly
+Experiment 010's per-layer KV storage and scales with `N` as already
+documented (0 at `N=0`, matching the full 552.50/1096.50 MiB total at `N=16`).
+
+The compute buffer does grow with depth, at different rates depending on `N`:
+1,024 bytes/token between 16K and 32K at `N=0` and `N=8`, but 4,625 bytes/token
+at `N=16` (single-repetition measurements, no error bars; the `N=8` depth-16384
+figure exceeding both its neighbours suggests some run-to-run noise rather than
+a real non-monotonicity). Taking the `N=16` slope as an upper-bound estimate
+and extrapolating linearly to the 240K depth the original report cited gives
+roughly 1.03 GiB of growth, in the same range as the "approximately 950 MiB"
+figure reported there, on different hardware and a different model. That
+cross-check makes the original estimate credible rather than just plausible.
+
+### Disposition
+
+Characterized, not fixed. The overhead is real, roughly gigabyte-scale at long
+context, and confirmed independent of `--kv-gpu-layers` on this machine's own
+numbers, not just by extrapolation from another report. Closing it needs a
+quantized-native MMA prefill kernel for standard `qN_0` K/V, i.e. genuinely new
+CUDA tensor-core kernel code, not a routing or buffer-placement change; that is
+a separate, larger effort from this PR's KV-placement work and was not
+attempted. The `llama-bench` `--kv-memory` fix is retained because the
+diagnostic is otherwise unusable at partial residency, which the measurement
+above depends on.

--- a/include/llama.h
+++ b/include/llama.h
@@ -479,10 +479,6 @@ extern "C" {
         bool kv_unified;  // use a unified buffer across the input sequences when computing the attention
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
-        bool kv_cpu_pinned;           // route CPU-resident KV cache layers through pinned/host memory instead of plain CPU memory
-                                       // (only affects layers not offloaded to GPU; speeds up CPU<->GPU KV transfers)
-        bool recurrent_state_offload; // for hybrid attention/recurrent models, allow the fixed recurrent (R/S) state to stay
-                                       // GPU-resident even when offload_kqv=false keeps attention KV on CPU
 
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)
@@ -501,6 +497,16 @@ extern "C" {
         enum ggml_type kv_tail_type;
         const struct llama_kv_tail_config * kv_tail_config; // borrowed only during context creation
         const struct llama_kv_tail_request * kv_tail_request; // model-independent; borrowed during context creation
+
+        // Appended at the end of the struct (rather than grouped with the other
+        // booleans above) to preserve the offset of every preexisting field for
+        // callers built against earlier BeeLlama.cpp releases.
+        bool kv_cpu_pinned;           // route CPU-resident KV cache layers through pinned/host memory instead of plain CPU memory
+                                       // (only affects layers not offloaded to GPU; speeds up CPU<->GPU KV transfers)
+                                       // on integrated GPUs the pinned buffer is host-visible to the GPU too, so this can
+                                       // let attention run on the GPU even with kv-offload disabled
+        bool recurrent_state_offload; // for hybrid attention/recurrent models, allow the fixed recurrent (R/S) state to stay
+                                       // GPU-resident even when offload_kqv=false keeps attention KV on CPU
     };
 
     struct llama_model_tensor_override {

--- a/include/llama.h
+++ b/include/llama.h
@@ -479,6 +479,10 @@ extern "C" {
         bool kv_unified;  // use a unified buffer across the input sequences when computing the attention
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
+        bool kv_cpu_pinned;           // route CPU-resident KV cache layers through pinned/host memory instead of plain CPU memory
+                                       // (only affects layers not offloaded to GPU; speeds up CPU<->GPU KV transfers)
+        bool recurrent_state_offload; // for hybrid attention/recurrent models, allow the fixed recurrent (R/S) state to stay
+                                       // GPU-resident even when offload_kqv=false keeps attention KV on CPU
 
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)

--- a/include/llama.h
+++ b/include/llama.h
@@ -507,6 +507,8 @@ extern "C" {
                                        // let attention run on the GPU even with kv-offload disabled
         bool recurrent_state_offload; // for hybrid attention/recurrent models, allow the fixed recurrent (R/S) state to stay
                                        // GPU-resident even when offload_kqv=false keeps attention KV on CPU
+        uint32_t kv_gpu_layers;       // with offload_kqv=false, keep this many attention-KV layers device-resident anyway.
+                                       // Trades device memory for host-to-device KV traffic; 0 keeps every layer on host.
     };
 
     struct llama_model_tensor_override {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -4248,8 +4248,6 @@ llama_context_params llama_context_default_params() {
         /*.op_offload                  =*/ true,
         /*.swa_full                    =*/ true,
         /*.kv_unified                  =*/ false,
-        /*.kv_cpu_pinned               =*/ false,
-        /*.recurrent_state_offload     =*/ false,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,
@@ -4257,6 +4255,8 @@ llama_context_params llama_context_default_params() {
         /*.kv_tail_type                =*/ GGML_TYPE_COUNT,
         /*.kv_tail_config              =*/ nullptr,
         /*.kv_tail_request             =*/ nullptr,
+        /*.kv_cpu_pinned               =*/ false,
+        /*.recurrent_state_offload     =*/ false,
     };
 
     return result;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -300,6 +300,7 @@ llama_context::llama_context(
     cparams.offload_kqv             = params.offload_kqv;
     cparams.kv_cpu_pinned           = params.kv_cpu_pinned;
     cparams.recurrent_state_offload = params.recurrent_state_offload;
+    cparams.kv_gpu_layers           = params.kv_gpu_layers;
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
 
@@ -4257,6 +4258,7 @@ llama_context_params llama_context_default_params() {
         /*.kv_tail_request             =*/ nullptr,
         /*.kv_cpu_pinned               =*/ false,
         /*.recurrent_state_offload     =*/ false,
+        /*.kv_gpu_layers               =*/ 0,
     };
 
     return result;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -298,6 +298,8 @@ llama_context::llama_context(
     cparams.embeddings_nextn        = false;
     cparams.embeddings_nextn_masked = false;
     cparams.offload_kqv             = params.offload_kqv;
+    cparams.kv_cpu_pinned           = params.kv_cpu_pinned;
+    cparams.recurrent_state_offload = params.recurrent_state_offload;
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
 
@@ -4246,6 +4248,8 @@ llama_context_params llama_context_default_params() {
         /*.op_offload                  =*/ true,
         /*.swa_full                    =*/ true,
         /*.kv_unified                  =*/ false,
+        /*.kv_cpu_pinned               =*/ false,
+        /*.recurrent_state_offload     =*/ false,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -52,6 +52,8 @@ struct llama_cparams {
     bool op_offload;
     bool kv_unified;
     bool pipeline_parallel;
+    bool kv_cpu_pinned;
+    bool recurrent_state_offload;
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -55,6 +55,8 @@ struct llama_cparams {
     bool kv_cpu_pinned;
     bool recurrent_state_offload;
 
+    uint32_t kv_gpu_layers;
+
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 
     enum llama_context_type ctx_type;

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -38,7 +38,8 @@ llama_kv_cache_iswa::llama_kv_cache_iswa(
                  uint32_t tail_tokens_requested,
                  uint32_t tail_tokens_swa_requested,
                  uint32_t tail_rollback_tokens,
-                     bool tail_native_exact_swa) :
+                     bool tail_native_exact_swa,
+                     bool cpu_pinned) :
     llama_kv_cache_iswa(
             model, model.hparams,
             type_k, type_v,
@@ -46,7 +47,7 @@ llama_kv_cache_iswa::llama_kv_cache_iswa(
             kv_size, n_seq_max, n_batch, n_ubatch, n_pad,
             mem_other, filter, reuse, share, kvarn, tail_tokens, tail_tokens_swa, tail_type,
             tail_tokens_requested, tail_tokens_swa_requested, tail_rollback_tokens,
-            tail_native_exact_swa) {
+            tail_native_exact_swa, cpu_pinned) {
 }
 
 llama_kv_cache_iswa::llama_kv_cache_iswa(
@@ -74,7 +75,8 @@ llama_kv_cache_iswa::llama_kv_cache_iswa(
                  uint32_t tail_tokens_requested,
                  uint32_t tail_tokens_swa_requested,
                  uint32_t tail_rollback_tokens,
-                     bool tail_native_exact_swa) : unified(unified) {
+                     bool tail_native_exact_swa,
+                     bool cpu_pinned) : unified(unified) {
 
     if (tail_tokens_requested == UINT32_MAX) {
         tail_tokens_requested = tail_tokens;
@@ -170,7 +172,7 @@ llama_kv_cache_iswa::llama_kv_cache_iswa(
                         v_trans, offload, unified, size, n_seq_max, n_pad,
                         n_swa, swa_type, nullptr, layer_filter, reuse, nullptr,
                         n_ubatch, exact_tokens, tail_type, exact_requested,
-                        false, tail_rollback_tokens, exact_tokens);
+                        false, tail_rollback_tokens, exact_tokens, cpu_pinned);
             }
             // Structured KVarN records do not participate in cross-context
             // sharing, so cache_mem_other and share are intentionally omitted.
@@ -178,7 +180,8 @@ llama_kv_cache_iswa::llama_kv_cache_iswa(
                     model, hparams, cache_kvarn, offload, unified,
                     size, n_seq_max, n_batch, n_ubatch, n_pad,
                     n_swa, swa_type, layer_filter, reuse,
-                    exact_tokens, tail_type, exact_requested, tail_rollback_tokens);
+                    exact_tokens, tail_type, exact_requested, tail_rollback_tokens,
+                    cpu_pinned);
         }
 
         return std::make_unique<llama_kv_cache>(
@@ -187,7 +190,7 @@ llama_kv_cache_iswa::llama_kv_cache_iswa(
                 n_swa, swa_type, cache_mem_other, layer_filter, reuse, share,
                 n_ubatch, n_swa > 0 ? tail_tokens_swa : tail_tokens, tail_type,
                 n_swa > 0 ? tail_tokens_swa_requested : tail_tokens_requested,
-                false, tail_rollback_tokens);
+                false, tail_rollback_tokens, 0, cpu_pinned);
     };
 
     LLAMA_LOG_INFO("%s: creating non-SWA KV cache, size = %u cells\n", __func__, size_base);

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -37,7 +37,8 @@ public:
                      uint32_t   tail_tokens_requested = UINT32_MAX,
                      uint32_t   tail_tokens_swa_requested = UINT32_MAX,
                      uint32_t   tail_rollback_tokens = 0,
-                         bool   tail_native_exact_swa = false);
+                         bool   tail_native_exact_swa = false,
+                         bool   cpu_pinned = false);
 
     // DSV4 uses a projected hparams view for its raw iSWA cache.  Keep this
     // explicit overload so KVarN support does not erase that upstream need.
@@ -66,7 +67,8 @@ public:
                      uint32_t   tail_tokens_requested = UINT32_MAX,
                      uint32_t   tail_tokens_swa_requested = UINT32_MAX,
                      uint32_t   tail_rollback_tokens = 0,
-                         bool   tail_native_exact_swa = false);
+                         bool   tail_native_exact_swa = false,
+                         bool   cpu_pinned = false);
 
     ~llama_kv_cache_iswa() = default;
 

--- a/src/llama-kv-cache-kvarn.cpp
+++ b/src/llama-kv-cache-kvarn.cpp
@@ -19,6 +19,19 @@
 
 namespace {
 
+static ggml_backend_buffer_type_t llama_kv_cache_kvarn_cpu_buft(
+        const llama_model & model, uint32_t il, bool cpu_pinned) {
+    if (cpu_pinned) {
+        ggml_backend_dev_t dev = model.dev_layer(il);
+        if (dev != nullptr) {
+            if (ggml_backend_buffer_type_t buft = ggml_backend_dev_host_buffer_type(dev)) {
+                return buft;
+            }
+        }
+    }
+    return ggml_backend_cpu_buffer_type();
+}
+
 using backend_kvarn_capabilities_t = bool (*)(
         ggml_backend_dev_t,
         ggml_backend_kvarn_capabilities *);
@@ -1150,7 +1163,8 @@ llama_kv_cache_kvarn::llama_kv_cache_kvarn(
         uint32_t tail_tokens,
         ggml_type tail_type_requested,
         uint32_t tail_tokens_requested,
-        uint32_t tail_rollback_tokens) :
+        uint32_t tail_rollback_tokens,
+        bool cpu_pinned) :
     model(model),
     hparams(hparams),
     params(params),
@@ -1279,7 +1293,7 @@ llama_kv_cache_kvarn::llama_kv_cache_kvarn(
                 "KVarN cache layer %u is assigned to backend %s, which cannot store and materialize KVarN records",
                 il, dev ? ggml_backend_dev_name(dev) : "unknown"));
         }
-        auto * buft = offload ? ggml_backend_dev_buffer_type(dev) : ggml_backend_cpu_buffer_type();
+        auto * buft = offload ? ggml_backend_dev_buffer_type(dev) : llama_kv_cache_kvarn_cpu_buft(model, il, cpu_pinned);
         auto * ctx = ctx_for_buft(buft);
         if (!ctx) {
             throw std::runtime_error("failed to create KVarN cache tensor context");

--- a/src/llama-kv-cache-kvarn.h
+++ b/src/llama-kv-cache-kvarn.h
@@ -222,7 +222,8 @@ public:
             uint32_t tail_tokens = 0,
             ggml_type tail_type = GGML_TYPE_F16,
             uint32_t tail_tokens_requested = UINT32_MAX,
-            uint32_t tail_rollback_tokens = 0);
+            uint32_t tail_rollback_tokens = 0,
+            bool cpu_pinned = false);
 
     llama_memory_context_ptr init_batch(
             llama_batch_allocr & balloc,

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -28,9 +28,8 @@ static bool ggml_is_power_of_2(int n) {
 namespace {
 
 static ggml_backend_buffer_type_t llama_kv_cache_cpu_buft(
-        const llama_model & model, uint32_t il) {
-    const char * pinned = std::getenv("GGML_KV_CPU_PINNED");
-    if (pinned != nullptr && std::strcmp(pinned, "1") == 0) {
+        const llama_model & model, uint32_t il, bool cpu_pinned) {
+    if (cpu_pinned) {
         ggml_backend_dev_t dev = model.dev_layer(il);
         if (dev != nullptr) {
             if (ggml_backend_buffer_type_t buft = ggml_backend_dev_host_buffer_type(dev)) {
@@ -390,7 +389,8 @@ llama_kv_cache::llama_kv_cache(
                  uint32_t   tail_tokens_requested,
                      bool   tail_metadata_only,
                  uint32_t   tail_rollback_tokens,
-                 uint32_t   tail_visibility_window) :
+                 uint32_t   tail_visibility_window,
+                     bool   cpu_pinned) :
     model(model), hparams(hparams), v_trans(v_trans),
     n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa),
     tail_tokens(tail_tokens), tail_rollback_tokens(tail_rollback_tokens),
@@ -536,7 +536,7 @@ llama_kv_cache::llama_kv_cache(
             } else if (offload) {
                 route_buft = ggml_backend_dev_buffer_type(model.dev_layer(il));
             } else {
-                route_buft = llama_kv_cache_cpu_buft(model, il);
+                route_buft = llama_kv_cache_cpu_buft(model, il, cpu_pinned);
             }
             route_probe_specs.push_back({
                     il, route_buft, actual_type_k, actual_type_v,
@@ -866,7 +866,7 @@ llama_kv_cache::llama_kv_cache(
 
         const char * dev_name = "CPU";
 
-        ggml_backend_buffer_type_t buft = llama_kv_cache_cpu_buft(model, il);
+        ggml_backend_buffer_type_t buft = llama_kv_cache_cpu_buft(model, il, cpu_pinned);
 
         if (offload) {
             auto * dev = model.dev_layer(il);

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -40,6 +40,27 @@ static ggml_backend_buffer_type_t llama_kv_cache_cpu_buft(
     return ggml_backend_cpu_buffer_type();
 }
 
+// A pinned/host buffer type's registered ggml_backend_buft_get_device() is the
+// GPU that allocated it (see e.g. ggml_backend_cuda_host_buffer_type()), but
+// that is only where the memory is *addressable from*, not where ops on it
+// actually execute. ggml_backend_sched picks the highest-priority backend that
+// both supports the buft and the op (ggml_backend_sched_backend_from_buffer);
+// on a discrete GPU, ggml_backend_*_device_supports_buft() rejects a host buft
+// (it is accepted only on an integrated GPU, where host memory is GPU-visible
+// unified memory), so the op actually falls back to the CPU backend. Mirror
+// that decision here so KV-tail capability probing checks the backend that
+// will really run the op, not just the buft's nominal owner device.
+static ggml_backend_dev_t llama_kv_tail_route_owner_device(ggml_backend_buffer_type_t buft) {
+    ggml_backend_dev_t dev = buft ? ggml_backend_buft_get_device(buft) : nullptr;
+    if (dev != nullptr && !ggml_backend_dev_supports_buft(dev, buft)) {
+        dev = nullptr;
+    }
+    if (!dev) {
+        dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    }
+    return dev;
+}
+
 using backend_kv_tail_attention_supported_t = bool (*)(
         ggml_type, ggml_type, ggml_type, ggml_type, int64_t, int64_t);
 
@@ -60,10 +81,7 @@ static bool backend_supports_native_kv_tail(
         ggml_type tail_k, ggml_type tail_v,
         int64_t d_k, int64_t d_v,
         bool segmented) {
-    auto dev = buft ? ggml_backend_buft_get_device(buft) : nullptr;
-    if (!dev) {
-        dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-    }
+    auto * dev = llama_kv_tail_route_owner_device(buft);
     const auto supports = [&](ggml_backend_dev_t candidate) {
         const auto reg = candidate ? ggml_backend_dev_backend_reg(candidate) : nullptr;
         const auto fn = reg ? reinterpret_cast<backend_kv_tail_attention_supported_t>(
@@ -95,10 +113,7 @@ static llama_kv_tail_route_capability probe_standard_kv_tail_route(
         return { false, LLAMA_KV_TAIL_ROUTE_NONE, LLAMA_KV_TAIL_OP_WRITE_V };
     }
     auto * cpu = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-    auto * dev = ggml_backend_buft_get_device(spec.buft);
-    if (!dev) {
-        dev = cpu;
-    }
+    auto * dev = llama_kv_tail_route_owner_device(spec.buft);
     if (!dev || !cpu) {
         return { false, LLAMA_KV_TAIL_ROUTE_NONE, LLAMA_KV_TAIL_OP_WRITE_K };
     }
@@ -223,10 +238,7 @@ static llama_kv_tail_route_capability probe_standard_native_exact_route(
     if (!spec.has_v) {
         return { false, LLAMA_KV_TAIL_ROUTE_NONE, LLAMA_KV_TAIL_OP_WRITE_V };
     }
-    auto * dev = ggml_backend_buft_get_device(spec.buft);
-    if (!dev) {
-        dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-    }
+    auto * dev = llama_kv_tail_route_owner_device(spec.buft);
     if (!dev) {
         return { false, LLAMA_KV_TAIL_ROUTE_NONE, LLAMA_KV_TAIL_OP_WRITE_K };
     }
@@ -617,10 +629,7 @@ llama_kv_cache::llama_kv_cache(
                                 tail_plan.compact_layout.history_stride, 256) :
                         tail_plan.kind == LLAMA_KV_TAIL_STORAGE_OVERLAY ?
                             tail_plan.layout.arena_stride : 0;
-            auto * dev = ggml_backend_buft_get_device(spec.buft);
-            if (!dev) {
-                dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-            }
+            auto * dev = llama_kv_tail_route_owner_device(spec.buft);
             routes.push_back({
                     spec.layer_id,
                     dev ? ggml_backend_dev_name(dev) : ggml_backend_buft_name(spec.buft),
@@ -650,10 +659,7 @@ llama_kv_cache::llama_kv_cache(
             const ggml_type actual_v = ggml_is_quantized(spec.body_type_v) ? candidate : spec.body_type_v;
             const auto capability = probe_standard_native_exact_route(
                     spec, actual_k, actual_v, v_trans, !v_trans);
-            auto * dev = ggml_backend_buft_get_device(spec.buft);
-            if (!dev) {
-                dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-            }
+            auto * dev = llama_kv_tail_route_owner_device(spec.buft);
             routes.push_back({
                     spec.layer_id,
                     dev ? ggml_backend_dev_name(dev) : ggml_backend_buft_name(spec.buft),
@@ -864,7 +870,7 @@ llama_kv_cache::llama_kv_cache(
         const uint32_t n_embd_k_gqa =            hparams.n_embd_k_gqa(il);
         const uint32_t n_embd_v_gqa = !v_trans ? hparams.n_embd_v_gqa(il) : hparams.n_embd_v_gqa_max();
 
-        const char * dev_name = "CPU";
+        const char * dev_name;
 
         ggml_backend_buffer_type_t buft = llama_kv_cache_cpu_buft(model, il, cpu_pinned);
 
@@ -873,6 +879,12 @@ llama_kv_cache::llama_kv_cache(
             buft = ggml_backend_dev_buffer_type(dev);
 
             dev_name = ggml_backend_dev_name(dev);
+        } else {
+            // cpu_pinned layers report the backend that will actually execute
+            // ops on them (llama_kv_tail_route_owner_device), not the buft's
+            // nominal owner, which is the GPU for a CUDA/Vulkan host buft.
+            auto * dev = llama_kv_tail_route_owner_device(buft);
+            dev_name = dev ? ggml_backend_dev_name(dev) : "CPU";
         }
 
         LLAMA_LOG_DEBUG("%s: layer %3d: dev = %s\n", __func__, il, dev_name);

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -402,7 +402,8 @@ llama_kv_cache::llama_kv_cache(
                      bool   tail_metadata_only,
                  uint32_t   tail_rollback_tokens,
                  uint32_t   tail_visibility_window,
-                     bool   cpu_pinned) :
+                     bool   cpu_pinned,
+                 uint32_t   gpu_resident_layers) :
     model(model), hparams(hparams), v_trans(v_trans),
     n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa),
     tail_tokens(tail_tokens), tail_rollback_tokens(tail_rollback_tokens),
@@ -425,6 +426,31 @@ llama_kv_cache::llama_kv_cache(
     GGML_ASSERT(kv_size % n_pad == 0);
 
     const uint32_t n_layer = hparams.n_layer_all;
+
+    // [TAG_KV_PARTIAL_GPU_RESIDENCY]
+    // With offload disabled the whole attention KV lives in host memory and the
+    // scheduler re-sends every K/V tensor to the device on each decode step,
+    // even though only the newest row changed. Keeping part of the cache
+    // device-resident removes that traffic for those layers exactly, at the
+    // cost of their device memory. The selection is per layer, so each layer's
+    // attention still reads a single contiguous cache and needs no partial
+    // result merge: the same bytes go through the same kernels.
+    std::vector<bool> layer_on_device(n_layer, false);
+    if (!offload && gpu_resident_layers > 0) {
+        uint32_t placed = 0;
+        for (uint32_t il = 0; il < n_layer && placed < gpu_resident_layers; ++il) {
+            if (!hparams.has_kv(il)) {
+                continue;
+            }
+            if (filter && !filter(il)) {
+                continue;
+            }
+            layer_on_device[il] = true;
+            placed++;
+        }
+        LLAMA_LOG_INFO("%s: partial GPU KV residency: %u of %u requested KV layers device-resident\n",
+                __func__, placed, gpu_resident_layers);
+    }
     const uint32_t n_layer_kv = hparams.n_layer_kv();
     const bool is_mla = hparams.is_mla();
 
@@ -545,7 +571,7 @@ llama_kv_cache::llama_kv_cache(
                 const int32_t il_share = share(il);
                 const auto & source = other->layers[other->map_layer_ids.at(il_share)];
                 route_buft = ggml_backend_buffer_get_type(source.k->buffer);
-            } else if (offload) {
+            } else if (offload || layer_on_device[il]) {
                 route_buft = ggml_backend_dev_buffer_type(model.dev_layer(il));
             } else {
                 route_buft = llama_kv_cache_cpu_buft(model, il, cpu_pinned);
@@ -874,7 +900,7 @@ llama_kv_cache::llama_kv_cache(
 
         ggml_backend_buffer_type_t buft = llama_kv_cache_cpu_buft(model, il, cpu_pinned);
 
-        if (offload) {
+        if (offload || layer_on_device[il]) {
             auto * dev = model.dev_layer(il);
             buft = ggml_backend_dev_buffer_type(dev);
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -125,7 +125,8 @@ public:
                  uint32_t   tail_tokens_requested = UINT32_MAX,
                      bool   tail_metadata_only = false,
                  uint32_t   tail_rollback_tokens = 0,
-                 uint32_t   tail_visibility_window = 0);
+                 uint32_t   tail_visibility_window = 0,
+                     bool   cpu_pinned = false);
 
     ~llama_kv_cache() = default;
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -126,7 +126,8 @@ public:
                      bool   tail_metadata_only = false,
                  uint32_t   tail_rollback_tokens = 0,
                  uint32_t   tail_visibility_window = 0,
-                     bool   cpu_pinned = false);
+                     bool   cpu_pinned = false,
+                 uint32_t   gpu_resident_layers = 0);
 
     ~llama_kv_cache() = default;
 

--- a/src/llama-memory-hybrid-iswa.cpp
+++ b/src/llama-memory-hybrid-iswa.cpp
@@ -27,7 +27,9 @@ llama_memory_hybrid_iswa::llama_memory_hybrid_iswa(
                             /* common */
                  uint32_t   n_seq_max,
                  uint32_t   n_rs_seq,
-                     bool   offload,
+                     bool   offload_attn,
+                     bool   cpu_pinned_attn,
+                     bool   offload_recr,
                      bool   unified,
                             /* layer filters */
     const layer_filter_cb & filter_attn,
@@ -46,7 +48,7 @@ llama_memory_hybrid_iswa::llama_memory_hybrid_iswa(
         type_k,
         type_v,
         v_trans,
-        offload,
+        offload_attn,
         swa_full,
         unified,
         kv_size,
@@ -67,13 +69,14 @@ llama_memory_hybrid_iswa::llama_memory_hybrid_iswa(
         tail_tokens_requested,
         tail_tokens_swa_requested,
         tail_rollback_tokens,
-        tail_native_exact_swa
+        tail_native_exact_swa,
+        cpu_pinned_attn
     )),
     mem_recr(new llama_memory_recurrent(
         model,
         type_r,
         type_s,
-        offload,
+        offload_recr,
         rs_size,
         n_seq_max,
         n_rs_seq,

--- a/src/llama-memory-hybrid-iswa.h
+++ b/src/llama-memory-hybrid-iswa.h
@@ -36,7 +36,9 @@ public:
                             /* common */
                  uint32_t   n_seq_max,
                  uint32_t   n_rs_seq,
-                     bool   offload,
+                     bool   offload_attn,
+                     bool   cpu_pinned_attn,
+                     bool   offload_recr,
                      bool   unified,
                             /* layer filters */
     const layer_filter_cb & filter_attn = nullptr,

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -19,6 +19,7 @@ llama_memory_hybrid::llama_memory_hybrid(
                  uint32_t   n_swa,
            llama_swa_type   swa_type,
                      bool   offload_attn,
+                     bool   cpu_pinned_attn,
                             /* recurrent */
                 ggml_type   type_r,
                 ggml_type   type_s,
@@ -61,7 +62,9 @@ llama_memory_hybrid::llama_memory_hybrid(
         tail_type,
         tail_tokens_requested,
         false,
-        tail_rollback_tokens
+        tail_rollback_tokens,
+        /* tail_visibility_window */ 0,
+        cpu_pinned_attn
     )),
     mem_recr(new llama_memory_recurrent(
         model,

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -36,7 +36,8 @@ llama_memory_hybrid::llama_memory_hybrid(
                  uint32_t   tail_tokens,
                 ggml_type   tail_type,
                  uint32_t   tail_tokens_requested,
-                 uint32_t   tail_rollback_tokens) :
+                 uint32_t   tail_rollback_tokens,
+                 uint32_t   gpu_resident_layers_attn) :
     hparams(model.hparams),
     mem_attn(new llama_kv_cache(
         model,
@@ -64,7 +65,8 @@ llama_memory_hybrid::llama_memory_hybrid(
         false,
         tail_rollback_tokens,
         /* tail_visibility_window */ 0,
-        cpu_pinned_attn
+        cpu_pinned_attn,
+        gpu_resident_layers_attn
     )),
     mem_recr(new llama_memory_recurrent(
         model,

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -29,6 +29,7 @@ public:
                  uint32_t   n_swa,
            llama_swa_type   swa_type,
                      bool   offload_attn,
+                     bool   cpu_pinned_attn,
                             /* recurrent */
                 ggml_type   type_r,
                 ggml_type   type_s,

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -46,7 +46,8 @@ public:
                  uint32_t   tail_tokens = 0,
                 ggml_type   tail_type = GGML_TYPE_F16,
                  uint32_t   tail_tokens_requested = UINT32_MAX,
-                 uint32_t   tail_rollback_tokens = 0);
+                 uint32_t   tail_rollback_tokens = 0,
+                 uint32_t   gpu_resident_layers_attn = 0);
 
     llama_memory_hybrid(
         const llama_model & model,

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <cfloat>
 #include <cstdint>
+#include <cstring>
 #include <cmath>
 #include <functional>
 #include <map>
@@ -2330,7 +2331,9 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             /* recurrent_rs_size */ std::max((uint32_t) 1, cparams.n_seq_max),
                             /* n_seq_max         */ cparams.n_seq_max,
                             /* n_rs_seq          */ cparams.n_rs_seq,
-                            /* offload           */ cparams.offload_kqv,
+                            /* offload_attn      */ cparams.offload_kqv,
+                            /* cpu_pinned_attn   */ cparams.kv_cpu_pinned,
+                            /* offload_recr      */ cparams.offload_kqv || cparams.recurrent_state_offload,
                             /* unified           */ cparams.kv_unified,
                             /* filter_attn       */ std::move(filter_attn),
                             /* filter_recr       */ std::move(filter_recr),
@@ -2362,13 +2365,13 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                         cparams.n_batch, cparams.n_ubatch, 1, hparams.n_swa,
                                         hparams.swa_type, filter_attn, nullptr, params.kv_tail_tokens,
                                         kvarn_tail_type, params.kv_tail_tokens_requested,
-                                        params.kv_tail_rollback_tokens);
+                                        params.kv_tail_rollback_tokens, cparams.kv_cpu_pinned);
                             }
                             auto mem_recr = std::make_unique<llama_memory_recurrent>(
                                     *this,
                                     GGML_TYPE_F32,
                                     GGML_TYPE_F32,
-                                    cparams.offload_kqv,
+                                    cparams.offload_kqv || cparams.recurrent_state_offload,
                                     std::max((uint32_t) 1, cparams.n_seq_max),
                                     cparams.n_seq_max,
                                     cparams.n_rs_seq,
@@ -2475,7 +2478,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                     params.kv_tail_tokens_requested,
                                     params.kv_tail_tokens_swa_requested,
                                     params.kv_tail_rollback_tokens,
-                                    params.kv_tail_native_exact_swa);
+                                    params.kv_tail_native_exact_swa,
+                                    cparams.kv_cpu_pinned);
                         } else {
                             res = new llama_kv_cache_iswa(
                                     *this,
@@ -2501,7 +2505,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                     params.kv_tail_tokens_requested,
                                     params.kv_tail_tokens_swa_requested,
                                     params.kv_tail_rollback_tokens,
-                                    params.kv_tail_native_exact_swa);
+                                    params.kv_tail_native_exact_swa,
+                                    cparams.kv_cpu_pinned);
                         }
                     } else {
                         GGML_ASSERT(!hparams.is_swa_any());
@@ -2524,7 +2529,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                         cparams.n_batch, cparams.n_ubatch, 1, hparams.n_swa,
                                         hparams.swa_type, filter, reuse, params.kv_tail_tokens,
                                         kvarn_tail_type, params.kv_tail_tokens_requested,
-                                        params.kv_tail_rollback_tokens);
+                                        params.kv_tail_rollback_tokens, cparams.kv_cpu_pinned);
                             }
                         } else {
                             res = new llama_kv_cache(

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2404,7 +2404,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                 /* tail_tokens       */ params.kv_tail_tokens,
                                 /* tail_type         */ params.kv_tail_type,
                                 /* tail requested    */ params.kv_tail_tokens_requested,
-                                /* rollback reserve  */ params.kv_tail_rollback_tokens);
+                                /* rollback reserve  */ params.kv_tail_rollback_tokens,
+                                /* gpu_resident_attn */ cparams.kv_gpu_layers);
                         }
                     }
                 } else {
@@ -2556,7 +2557,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                     false,
                                     params.kv_tail_rollback_tokens,
                                     /* tail_visibility_window */ 0,
-                                    cparams.kv_cpu_pinned);
+                                    cparams.kv_cpu_pinned,
+                                    cparams.kv_gpu_layers);
                         }
                     }
                 }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -28,9 +28,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
-#include <cstdlib>
 #include <cstdint>
-#include <cstring>
 #include <cmath>
 #include <functional>
 #include <map>
@@ -2355,7 +2353,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                         hparams.n_swa, hparams.swa_type, nullptr, filter_attn,
                                         nullptr, nullptr, cparams.n_ubatch, 0,
                                         kvarn_tail_type, 0, false, params.kv_tail_rollback_tokens,
-                                        params.kv_tail_native_exact ? cparams.n_ctx : 0);
+                                        params.kv_tail_native_exact ? cparams.n_ctx : 0,
+                                        cparams.kv_cpu_pinned);
                             } else {
                                 mem_attn = std::make_unique<llama_kv_cache_kvarn>(
                                         *this, hparams, params.kvarn, cparams.offload_kqv,
@@ -2376,9 +2375,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                     filter_recr);
                             res = new llama_memory_hybrid(*this, std::move(mem_attn), std::move(mem_recr));
                         } else {
-                            const char * recurrent_offload_env = std::getenv("GGML_RECURRENT_STATE_OFFLOAD");
-                            const bool offload_recr = cparams.offload_kqv ||
-                                    (recurrent_offload_env && std::strcmp(recurrent_offload_env, "1") == 0);
+                            const bool offload_recr = cparams.offload_kqv || cparams.recurrent_state_offload;
 
                             res = new llama_memory_hybrid(
                                 /* model             */ *this,
@@ -2390,6 +2387,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                 /* attn_n_swa        */ hparams.n_swa,
                                 /* attn_swa_type     */ hparams.swa_type,
                                 /* offload_attn      */ cparams.offload_kqv,
+                                /* cpu_pinned_attn   */ cparams.kv_cpu_pinned,
                                 /* recurrent_type_k  */ GGML_TYPE_F32,
                                 /* recurrent_type_v  */ GGML_TYPE_F32,
                                 /* recurrent_kv_size */ std::max((uint32_t) 1, cparams.n_seq_max),
@@ -2517,7 +2515,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                         hparams.n_swa, hparams.swa_type, nullptr, filter,
                                         reuse, nullptr, cparams.n_ubatch, 0,
                                         kvarn_tail_type, 0, false, params.kv_tail_rollback_tokens,
-                                        params.kv_tail_native_exact ? cparams.n_ctx : 0);
+                                        params.kv_tail_native_exact ? cparams.n_ctx : 0,
+                                        cparams.kv_cpu_pinned);
                             } else {
                                 res = new llama_kv_cache_kvarn(
                                         *this, hparams, params.kvarn, cparams.offload_kqv,
@@ -2550,7 +2549,9 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                     params.kv_tail_type,
                                     params.kv_tail_tokens_requested,
                                     false,
-                                    params.kv_tail_rollback_tokens);
+                                    params.kv_tail_rollback_tokens,
+                                    /* tail_visibility_window */ 0,
+                                    cparams.kv_cpu_pinned);
                         }
                     }
                 }

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -397,6 +397,7 @@ struct cmd_params {
     bool                             no_warmup;
     bool                             kv_cpu_pinned;
     bool                             recurrent_state_offload;
+    int                              kv_gpu_layers;
     output_formats                   output_format;
     output_formats                   output_format_stderr;
 };
@@ -446,6 +447,7 @@ static const cmd_params cmd_params_defaults = {
     /* no_warmup            */ false,
     /* kv_cpu_pinned        */ false,
     /* recurrent_state_offload */ false,
+    /* kv_gpu_layers        */ 0,
     /* output_format        */ MARKDOWN,
     /* output_format_stderr */ NONE,
 };
@@ -467,6 +469,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  --kv-memory                                capture synchronized KV component and device allocation checkpoints\n");
     printf("  --no-warmup                                 skip warmup runs before benchmarking\n");
     printf("  --kv-cpu-pinned                             route CPU-resident KV cache layers through pinned/host memory\n");
+    printf("  --kv-gpu-layers <n>                         with -nkvo, keep the first n attention-KV layers device-resident\n");
     printf("  --recurrent-state-offload                   for hybrid models, keep recurrent state GPU-resident despite -nkvo\n");
     printf("  -fitt, --fit-target <MiB>                   fit model to device memory with this margin per device in MiB (default: off)\n");
     printf("  -fitc, --fit-ctx <n>                        minimum ctx size for --fit-target (default: 4096)\n");
@@ -688,6 +691,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     params.no_warmup            = cmd_params_defaults.no_warmup;
     params.kv_cpu_pinned        = cmd_params_defaults.kv_cpu_pinned;
     params.recurrent_state_offload = cmd_params_defaults.recurrent_state_offload;
+    params.kv_gpu_layers        = cmd_params_defaults.kv_gpu_layers;
     params.offline              = cmd_params_defaults.offline;
 
     if (const char * env = getenv("HF_TOKEN")) {
@@ -1240,6 +1244,12 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 params.kv_cpu_pinned = true;
             } else if (arg == "--recurrent-state-offload") {
                 params.recurrent_state_offload = true;
+            } else if (arg == "--kv-gpu-layers") {
+                if (++i >= argc) {
+                    invalid_param = true;
+                    break;
+                }
+                params.kv_gpu_layers = std::stoi(argv[i]);
             } else if (arg == "-fitt" || arg == "--fit-target") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1415,6 +1425,7 @@ struct cmd_params_instance {
     bool               no_kv_offload;
     bool               kv_cpu_pinned;
     bool               recurrent_state_offload;
+    int                kv_gpu_layers;
     llama_flash_attn_type flash_attn;
     std::vector<ggml_backend_dev_t> devices;
     std::vector<float> tensor_split;
@@ -1499,6 +1510,7 @@ struct cmd_params_instance {
         cparams.offload_kqv     = !no_kv_offload;
         cparams.kv_cpu_pinned   = kv_cpu_pinned;
         cparams.recurrent_state_offload = recurrent_state_offload;
+        cparams.kv_gpu_layers   = (uint32_t) std::max(0, kv_gpu_layers);
         cparams.flash_attn_type = flash_attn;
         cparams.embeddings      = embeddings;
         cparams.op_offload      = !no_op_offload;
@@ -1571,6 +1583,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .no_kv_offload         = */ nkvo,
                 /* .kv_cpu_pinned         = */ params.kv_cpu_pinned,
                 /* .recurrent_state_offload = */ params.recurrent_state_offload,
+                /* .kv_gpu_layers         = */ params.kv_gpu_layers,
                 /* .flash_attn            = */ fa,
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,
@@ -1611,6 +1624,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .no_kv_offload         = */ nkvo,
                 /* .kv_cpu_pinned         = */ params.kv_cpu_pinned,
                 /* .recurrent_state_offload = */ params.recurrent_state_offload,
+                /* .kv_gpu_layers         = */ params.kv_gpu_layers,
                 /* .flash_attn            = */ fa,
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,
@@ -1651,6 +1665,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .no_kv_offload         = */ nkvo,
                 /* .kv_cpu_pinned         = */ params.kv_cpu_pinned,
                 /* .recurrent_state_offload = */ params.recurrent_state_offload,
+                /* .kv_gpu_layers         = */ params.kv_gpu_layers,
                 /* .flash_attn            = */ fa,
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -395,6 +395,8 @@ struct cmd_params {
     bool                             progress;
     bool                             kv_memory;
     bool                             no_warmup;
+    bool                             kv_cpu_pinned;
+    bool                             recurrent_state_offload;
     output_formats                   output_format;
     output_formats                   output_format_stderr;
 };
@@ -442,6 +444,8 @@ static const cmd_params cmd_params_defaults = {
     /* progress             */ false,
     /* kv_memory            */ false,
     /* no_warmup            */ false,
+    /* kv_cpu_pinned        */ false,
+    /* recurrent_state_offload */ false,
     /* output_format        */ MARKDOWN,
     /* output_format_stderr */ NONE,
 };
@@ -462,6 +466,8 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  --progress                                  print test progress indicators\n");
     printf("  --kv-memory                                capture synchronized KV component and device allocation checkpoints\n");
     printf("  --no-warmup                                 skip warmup runs before benchmarking\n");
+    printf("  --kv-cpu-pinned                             route CPU-resident KV cache layers through pinned/host memory\n");
+    printf("  --recurrent-state-offload                   for hybrid models, keep recurrent state GPU-resident despite -nkvo\n");
     printf("  -fitt, --fit-target <MiB>                   fit model to device memory with this margin per device in MiB (default: off)\n");
     printf("  -fitc, --fit-ctx <n>                        minimum ctx size for --fit-target (default: 4096)\n");
     if (llama_supports_rpc()) {
@@ -680,6 +686,8 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     params.progress             = cmd_params_defaults.progress;
     params.kv_memory            = cmd_params_defaults.kv_memory;
     params.no_warmup            = cmd_params_defaults.no_warmup;
+    params.kv_cpu_pinned        = cmd_params_defaults.kv_cpu_pinned;
+    params.recurrent_state_offload = cmd_params_defaults.recurrent_state_offload;
     params.offline              = cmd_params_defaults.offline;
 
     if (const char * env = getenv("HF_TOKEN")) {
@@ -1228,6 +1236,10 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 params.kv_memory = true;
             } else if (arg == "--no-warmup") {
                 params.no_warmup = true;
+            } else if (arg == "--kv-cpu-pinned") {
+                params.kv_cpu_pinned = true;
+            } else if (arg == "--recurrent-state-offload") {
+                params.recurrent_state_offload = true;
             } else if (arg == "-fitt" || arg == "--fit-target") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1401,6 +1413,8 @@ struct cmd_params_instance {
     llama_load_mode    load_mode;
     int                main_gpu;
     bool               no_kv_offload;
+    bool               kv_cpu_pinned;
+    bool               recurrent_state_offload;
     llama_flash_attn_type flash_attn;
     std::vector<ggml_backend_dev_t> devices;
     std::vector<float> tensor_split;
@@ -1483,6 +1497,8 @@ struct cmd_params_instance {
         cparams.kv_tail_tokens  = kv_tail_tokens;
         cparams.kv_tail_type    = kv_tail_type;
         cparams.offload_kqv     = !no_kv_offload;
+        cparams.kv_cpu_pinned   = kv_cpu_pinned;
+        cparams.recurrent_state_offload = recurrent_state_offload;
         cparams.flash_attn_type = flash_attn;
         cparams.embeddings      = embeddings;
         cparams.op_offload      = !no_op_offload;
@@ -1553,6 +1569,8 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .load_mode             = */ lm,
                 /* .main_gpu              = */ mg,
                 /* .no_kv_offload         = */ nkvo,
+                /* .kv_cpu_pinned         = */ params.kv_cpu_pinned,
+                /* .recurrent_state_offload = */ params.recurrent_state_offload,
                 /* .flash_attn            = */ fa,
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,
@@ -1591,6 +1609,8 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .load_mode             = */ lm,
                 /* .main_gpu              = */ mg,
                 /* .no_kv_offload         = */ nkvo,
+                /* .kv_cpu_pinned         = */ params.kv_cpu_pinned,
+                /* .recurrent_state_offload = */ params.recurrent_state_offload,
                 /* .flash_attn            = */ fa,
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,
@@ -1629,6 +1649,8 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .load_mode             = */ lm,
                 /* .main_gpu              = */ mg,
                 /* .no_kv_offload         = */ nkvo,
+                /* .kv_cpu_pinned         = */ params.kv_cpu_pinned,
+                /* .recurrent_state_offload = */ params.recurrent_state_offload,
                 /* .flash_attn            = */ fa,
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2914,14 +2914,13 @@ int llama_bench(int argc, char ** argv) {
                     t.cuda_compute_buffer_bytes += memory.compute;
                 }
             }
-            if (t.cuda_context_buffer_bytes < t.kv_resident_bytes) {
-                fprintf(stderr, "%s: error: GPU context buffers are smaller than categorized resident KV storage\n", __func__);
-                llama_free(ctx);
-                llama_model_free(lmodel);
-                return 1;
-            }
-            t.cuda_non_kv_context_buffer_bytes =
-                t.cuda_context_buffer_bytes - t.kv_resident_bytes;
+            // kv_resident_bytes() totals K/V payload across all layers regardless of
+            // which buffer type actually backs them (see llama_kv_cache::kv_memory_stats).
+            // With --kv-gpu-layers splitting the cache across host and device, that total
+            // can exceed what is actually GPU-resident; treat any excess as host-side
+            // rather than erroring, instead of assuming full-offload placement.
+            t.cuda_non_kv_context_buffer_bytes = t.cuda_context_buffer_bytes > t.kv_resident_bytes ?
+                t.cuda_context_buffer_bytes - t.kv_resident_bytes : 0;
 
             uint64_t cuda_free_context = 0;
             uint64_t cuda_total_context = 0;


### PR DESCRIPTION
Follow-up to #1.

## What changed

- promote `GGML_KV_CPU_PINNED`/`GGML_RECURRENT_STATE_OFFLOAD` env switches to `--kv-cpu-pinned`/`--recurrent-state-offload` CLI/server options (also `llama-bench`)
- fix KV-tail route probing selecting a route the executing backend can't run: a pinned buffer's registered device is the allocating GPU, but on a discrete GPU the op actually executes on CPU, so routing checked the wrong backend's capabilities
- wire `--kv-cpu-pinned` through KVarN caches and SWA architectures (Gemma 2/3, gpt-oss, Cohere2, Llama 4, ...) — previously accepted on the CLI and silently ignored there
- split `llama_memory_hybrid_iswa`'s single `offload` argument into independent attention/recurrent placement, matching the non-SWA path from #1, so hybrid+SWA models (Qwen3-Next/3.5/3.6 with sliding window active) honor both flags
- fix hybrid+KVarN recurrent-state placement to honor `--recurrent-state-offload` (previously always followed `offload_kqv`)
- move the two new option fields to the end of `llama_context_params` instead of mid-struct, avoiding an ABI break
- restore a dropped `<cstring>` include (`strcmp` only built today via a transitive include)
- add `--kv-gpu-layers N` (Experiment 010): keeps the first N attention-KV layers device-resident while `--no-kv-offload` is active
- fix `llama-bench --kv-memory`'s sanity check, which assumed full GPU KV residency and aborted at partial `--kv-gpu-layers` settings (Experiment 011)

## Why

Turning the two placement knobs from #1 into CLI options and reviewing the diff against `beellama-v0.4.3` surfaced that several new code paths were wrong or dead:

- KV-tail routing derived a buft's "owner device" from where it was *allocated*, not where the scheduler actually places the op. With `--kv-cpu-pinned -fa on --kv-tail-tokens N` on a narrow head-dim model, it could select a NATIVE tail route the CPU backend doesn't implement.
- `--kv-cpu-pinned`/`--recurrent-state-offload` had no effect on KVarN caches, SWA architectures, or hybrid+SWA models — never threaded through those constructors, only the plain non-SWA hybrid path #1 already covered.

`--kv-gpu-layers` exists because #1's own host-resident KV, while correct, still pays the full host-to-device re-transfer of the whole cache every decode step. That transfer is structurally incompressible (Experiment 009) but the schedule isn't — keeping N layers device-resident removes exactly that re-transfer for those layers.

## Measured impact

`Qwen3.8-27B-UD-IQ2_M` (`qwen35` arch, 27.32B params, 9.60 GiB), Intel Core i5-13400F (3 pinned decode threads, `taskset -c 0-2 -t 3 --poll 100`), RTX 4070 12 GiB (driver 610.57.04, CUDA 13.3), this commit (`7125fa151`) only. Target: `-ngl 99 -fa on -ctk q8_0 -ctv q8_0 -nkvo 1 --kv-cpu-pinned --recurrent-state-offload`.

| Depth | Prefill (t/s) | Decode, no MTP (t/s) | Decode, MTP-5 (t/s) | MTP acceptance |
| ---: | ---: | ---: | ---: | ---: |
| 4,096 | 1176.64 ± 10.08 | 31.93 ± 0.06 | 91.73 | 52/52, 1.000 |
| 16,384 | 986.10 ± 8.02 | 19.76 ± 0.02 | 65.45 | 52/52, 1.000 |
| 32,768 | 810.44 ± 6.51 | 13.06 ± 0.01 | 47.28 | 52/52, 1.000 |

Prefill and no-MTP decode: `llama-bench -p 512 -n 64 -d DEPTH -r 3` (mean ± stddev of 3 reps). MTP-5 decode: one matched `llama-server` request per depth (`--spec-type draft-mtp --spec-draft-n-max 5 --spec-draft-ngl all --cache-type-k-draft q4_0 --cache-type-v-draft q4_0`) over a repeated-token synthetic prompt, so its 1.000 acceptance is a ceiling, not a real-workload figure, and it's a single run rather than an averaged one.

`n_swa = 0` on this checkpoint, so every row takes the plain non-SWA `llama_memory_hybrid` path #1 already wired — the `llama_memory_hybrid_iswa` and KV-tail-routing fixes in this PR aren't exercised here (see Current limitations).

## Validation

- Release CUDA build (RTX 4070, compute 8.9), no new warnings
- `ctest -R "test-kvarn|test-adaptive-dm|test-server-loop-guard"`: 8/8 pass (`test-kvarn` covers all 36 KVarN K/V bit pairs)
- `llama-bench` context-scaling sweep and matched MTP-5 `llama-server` requests at 4K/16K/32K (above), plus the `--kv-gpu-layers` sweep at 16K/32K (Experiment 010, below)
- `--verbose` debug log check: pinned KV layers on this discrete GPU now correctly report `dev = CPU` (previously misreported as `CUDA0`)
- `git diff --check`

## Current limitations

- the `llama_memory_hybrid_iswa` split and the KV-tail routing fix are validated by unit tests and code inspection, not an end-to-end benchmark — no SWA-active hybrid checkpoint was available to reproduce the original misrouting/no-op bugs live
- the KVarN-hybrid recurrent-offload fix is likewise validated by code inspection and the unit suite only; a live repro (KVarN + forced-CPU recurrent state) was impractically slow on this 27B checkpoint
- DSA/MSA/DSV4 indexer caches and the MTP draft cache still don't take `cpu_pinned` (same scope decision as #1: never part of the documented pinning workflow)
- `--no-recurrent-state-offload` is only meaningful when `--kv-offload` is disabled, since `--kv-offload` already keeps recurrent state GPU-resident; documented in `--help` but still a slightly confusing default
- `--kv-gpu-layers` is wired for the hybrid `mem_attn` cache and the plain non-SWA target cache only (KVarN/ISWA constructors default to 0); there's no automatic sizing against free VRAM, and `llama-bench` treats it as process-wide rather than sweeping it


---

## Follow-up investigation: where the remaining long-context cost actually is

Recorded as Experiments 009–011 in `docs/cpu-kv-offload-experiments.md` (commit
`c6bce17ee` onward). All tables and figures below are kept in full; only the
narrative connecting them is trimmed relative to the doc.

### Experiment 009: lossless compression of the Q8_0 stream — rejected

Measured on real cache contents: a 6,391-token prose prompt evaluated on
`llama-server`, slot saved via `POST /slots/1?action=save` (379,801,088 bytes,
6,398 cells). The Q8_0 attention-KV region was located by its structural
signature (every 32-value block must contain an element of magnitude exactly
127) at file offset 1,048,608, ~212 MiB, matching 16 layers x 2 tensors x 6,398
tokens x 1,088 bytes.

| Scheme | Entropy | Achievable ratio |
| --- | ---: | ---: |
| Order-0 entropy coding of the int8 payload | 7.685 bits | 1.041x |
| Delta along the context dimension, then order-0 | 7.550 bits | 1.060x |
| Delta along the channel dimension, then order-0 | 8.355 bits | 0.958x |
| `zlib` level 9 on the raw stream | -- | 1.033x |
| `lzma` preset 6 on the raw stream | -- | 1.028x |
| FP16 block scales alone (5.9% of bytes) | 10.061 of 16 bits | 1.590x |

An ideal adaptive coder combining the best payload result with separately coded
scales bounds at **1.081x** — not worth a GPU decompression kernel, a host-side
compression step on the write path, and variable-length addressing over
today's fixed-stride cache.

The cause is structural: Q8_0 normalises every 32-value block by its own
maximum, forcing the full 8-bit range in every block and leaving a
near-Gaussian residual with standard deviation 55, carrying 7.685 bits of
genuine entropy per stored byte. Delta coding along the context dimension
recovers only 0.135 bits because per-block rescaling destroys exactly the
smoothness between neighbouring tokens it would exploit. The same argument
applies to every block-scaled `qN_0` cache format, so this closes the
direction generally, not only for Q8_0.

### The redundancy that does exist is temporal, and the trade is cheap

The cache is append-only, so between two decode steps exactly one row of 1,088
bytes per tensor changes while the scheduler re-sends the whole tensor. At 32K
that is 1,123,024,896 bytes per token to convey ~34,816 bytes of new
information. Removing that is exactly lossless and needs no codec, but the
already-sent bytes have to stay device-resident — a tunable trade, not a free
win. Reported buffer sizes confirm the mirror isn't already paid for:
`CUDA_Host` KV measured 8.50 / 144.50 / 280.50 / 552.50 MiB at depths 0 / 4K /
8K / 16K, while the `CUDA0` compute buffer measured 7.14 / 505.00 / 562.04 /
505.00 MiB — it does not scale with depth (staging copies reuse a small
per-layer arena).

Matched runs bounding the opportunity (RTX 4070, `Qwen3.8-27B-UD-IQ2_M.gguf`,
`-ngl 99 -t 3 --poll 100 -fa on -ctk q8_0 -ctv q8_0 --recurrent-state-offload`,
`-p 0 -n 32 -r 2`, three real P-cores via `taskset -c 0,2,4`):

| Depth | Host KV (`-nkvo 1 --kv-cpu-pinned`) | GPU-resident KV | Change |
| ---: | ---: | ---: | ---: |
| 0 | 39.38 +/- 0.29 t/s | 39.95 +/- 0.32 t/s | +1.4% |
| 4096 | 31.89 +/- 0.21 t/s | 39.02 +/- 0.21 t/s | +22.4% |
| 16384 | 19.76 +/- 0.05 t/s | 36.13 +/- 0.17 t/s | +82.8% |

At depth 0 the two paths are equal, so the entire gap is transfer, not
placement overhead. The whole 16K Q8_0 cache is 552.50 MiB and buys 82.8%.
(`taskset -c 0-2` vs `-c 0,2,4` measured identically here — 19.68 vs 19.76 t/s
at 16K — and a 3/4/6/8 thread sweep at 16K produced 19.68 / 19.73 / 19.73 /
19.72 t/s, so CPU-side tuning is not a lever on this path.)

### Experiment 010: tunable partial GPU KV residency — implemented (`b8f855761`)

`--kv-gpu-layers N` (env `LLAMA_ARG_KV_GPU_LAYERS`, also `llama-bench`) keeps
the first N attention-KV layers device-resident while `--no-kv-offload` is
active. `N = 0` reproduces current behaviour; any `N` at or above the
attention-layer count matches `--kv-offload`. Selection is per layer, so it
needs no change to cell indexing, defragmentation, state serialization, or the
attention graph — each layer still reads one contiguous cache in one buffer.

Decode, 32 tokens, same configuration as the tables above:

| `--kv-gpu-layers` | d16384 (t/s) | ms/token | d32768 (t/s) | ms/token |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 19.70 +/- 0.11 | 50.76 | 13.03 +/- 0.05 | 76.75 |
| 4 | 22.34 +/- 0.12 | 44.76 | -- | -- |
| 8 | 25.70 +/- 0.17 | 38.91 | 18.76 +/- 0.09 | 53.30 |
| 12 | 30.15 +/- 0.22 | 33.17 | 24.00 +/- 0.15 | 41.67 |
| 16 | 36.00 +/- 0.21 | 27.78 | 32.42 +/- 0.17 | 30.84 |

Full residency is +82.7% at 16K and **+148.8% at 32K**, matching the
independent host/GPU-resident references above (19.76 and 36.13 t/s at 16K),
so the dial isn't introducing a path of its own. Per-token time is linear in
host-resident layers: ~1.44 ms/layer at 16K, 2.85 ms/layer at 32K.

Prefill of 512 tokens at depth 16384 measured 984.72 / 1009.94 / 1033.99 t/s
at N = 0 / 8 / 16 — prefill improves slightly rather than paying for the
decode gain. The KV total is unchanged (memory moves, not grows): at depth
16384 the split is 0/552.50, 138.12/414.38, 276.25/276.25, 414.38/138.12,
552.50/0 MiB between `CUDA0`/`CUDA_Host` for N = 0/4/8/12/16 — 34.53 MiB of
device memory per layer at 16K, 69.06 MiB at 32K; full residency needs 1,105
MiB and still fits alongside this card's 9,227 MiB of weights.

Greedy generation (`--temp 0 --seed 1234`, 96 tokens) was byte-identical
across N = 0, 8, 16, and `ctest -R "test-kvarn|test-adaptive-dm|test-server-loop-guard"`
passes 8/8.

### Experiment 011: transient CUDA compute-buffer overhead — characterized, not fixed

`ggml_cuda_get_best_fattn_kernel` only routes quantized K/V to the
materialization-free vector kernel for very narrow queries (`Q->ne[1] <= 2` on
Ada); ordinary prompt processing takes the MMA/tile path, where
`ggml_cuda_flash_attn_ext_get_alloc_size` sets `need_f16_K = need_f16_V = true`
unconditionally. That is upstream behavior, independent of `--kv-gpu-layers`
(which only moves the *persistent* cache).

Sweeping `--kv-gpu-layers` at fixed depth with `llama-bench --kv-memory -o json`
confirms it: the CUDA compute buffer stays in the same 550–625 MiB band at
N = 0, 8, and 16, while the context buffer scales with N exactly as in
Experiment 010. Extrapolating this machine's depth-scaling slope to the 240K
context of the original report that flagged this lands close to its ~950 MiB
estimate, on different hardware and a different model — a useful independent
cross-check.

The fork's own KVarN cache already avoids this exact cast via descriptor-native
per-tile dequantization (`fattn-mma-kvarn-load.cuh`), but that machinery is
built around KVarN's variable-bit, three-axis affine block format and isn't a
drop-in generalization to plain `q8_0`. Closing this needs a quantized-native
MMA kernel for standard `qN_0` types — new tensor-core kernel work on the order
of the existing KVarN implementation, out of scope here and tracked separately
in Piggidragon/llama.cpp#1 (`beellama-kv-native-mma-kernel`). The one code
change that landed from this experiment (the `llama-bench --kv-memory` fix) is
listed above under What changed.
