### PR TITLE
bench: add scoped CUDA VMM allocation telemetry

### DIFF
--- a/docs/cpu-kv-offload-current-testing.md
+++ b/docs/cpu-kv-offload-current-testing.md
@@ -289,6 +289,39 @@ If a run violates the matching contract, preserve it as an invalid or
 diagnostic artifact and explain the failure in the development journal. Do not
 publish its directional numbers as a candidate-versus-baseline result.
 
+### Allocation and CUDA VMM telemetry
+
+`llama-bench --kv-memory` is the opt-in client for allocation classification
+and CUDA VMM transient-pool telemetry. It reports physical device, accelerator-
+owned host (normally CUDA-pinned), and ordinary-host context/compute buffers,
+plus VMM live, mapped, high-water, and active-pool checkpoints. The older
+CUDA-owner totals remain for result compatibility; they are not physical VRAM
+because they include accelerator-owned host buffers.
+
+The CUDA counters are dormant until this option resets them. Validate a change
+with fresh processes in this order: instrumented on, instrumented off,
+instrumented on. The off result must leave every new field zero, and the two on
+results must reproduce the allocation classes and high-water values. Also
+bracket an instrumented default-path run between two pristine-source runs.
+Use `--no-warmup --progress` so VMM growth is visible and progress remains
+inspectable. Every GPU invocation must remain wholly inside the single-GPU
+lock, for example:
+
+```bash
+flock /tmp/beellama-single-gpu.lock -c \
+  'BUILD/bin/llama-bench -m MODEL -p 128 -n 16 -d 4096 -r 3 \
+   -b 512 -ub 256 -t 3 -C 0x7 --cpu-strict 1 --poll 100 \
+   -ngl 999 -sm none -mg 0 -nkvo 0 -fa on -ctk q8_0 -ctv q8_0 \
+   --no-warmup --progress --kv-memory -o jsonl'
+```
+
+Repeat focused `-nkvo 1` rows without and with `--kv-cpu-pinned` when host
+classification changes. Record buffer bytes separately from process RSS and
+from `nvidia-smi` process VRAM: pinned CUDA-host allocation is system memory,
+and ordinary-host allocation is neither pinned memory nor device VRAM. This
+surface is measurement support only. It does not authorize pool trimming,
+workspace policy, staging changes, causal descriptors, or capacity changes.
+
 ## Reading previous editions
 
 Use the development journal to understand why a control or protocol changed,

--- a/docs/cpu-kv-offload-development.md
+++ b/docs/cpu-kv-offload-development.md
@@ -1038,6 +1038,28 @@ be based on measured acceptance/replay behavior rather than VRAM alone.
    asymmetric K/V and token-window KV residency remain outside the current
    scope.
 
+## 2026-08-20: pre-PR4 W02 telemetry isolation
+
+The allocation-classification and CUDA VMM high-water instrumentation from the
+immutable pre-PR4 source snapshot was migrated independently onto
+`c9f727c1e1995c4a871a719ab05b5f2478588efd`. This migration intentionally does
+not depend on the snapshot's native-Q8 reporting field and does not carry its
+live-context workspace, later phase controls, causal descriptors, VMM trimming
+policy, host staging, or perplexity-capacity fix.
+
+The first ordinary-host runtime probe found that the snapshot's legacy
+reconciliation assertion still subtracted all resident KV from a CUDA-owner
+total that deliberately excludes ordinary CPU buffers. The migration was
+revised to subtract KV only when it is device-resident or CUDA-pinned. Physical
+device, accelerator-host, and ordinary-host fields remain classified by buffer
+capability and owning device type rather than architecture names.
+
+Fresh final-binary runs established a dormant zero-valued default path, neutral
+source and on/off performance screens, repeatable VMM peaks, all three physical
+allocation classes, and identical matched perplexity. Experiment 020 contains
+the exact commands and evidence. The result remains support instrumentation,
+not a VRAM optimization or permission to infer a trimming policy.
+
 ## Known non-goals
 
 - Do not restore TurboQuant/TCQ, DDTree, CopySpec, the removed fork DFlash

--- a/docs/cpu-kv-offload-experiments.md
+++ b/docs/cpu-kv-offload-experiments.md
@@ -3169,3 +3169,170 @@ the tested layout, and the GPU-draft split is output-exact after the merged MTP
 fixes. The empirical claim remains limited to the ownership split above;
 arbitrary partial target-layer mixes, lower/asymmetric formats, other models,
 multi-GPU, and other backends need separate gates.
+
+## Experiment 020: pre-PR4 W02 allocation and CUDA VMM telemetry
+
+### Question, scope, and source identity
+
+Can W02 measurement support be isolated from the immutable
+`refs/codex/pre-pr4-parallel-source` snapshot and migrated onto pre-PR4 base
+`c9f727c1e1995c4a871a719ab05b5f2478588efd` without importing PR 4 or changing
+the default execution path?
+
+The candidate is the commit containing this entry on
+`exp/vmm-allocation-telemetry-pre-pr4`. It is based directly on `c9f727c1e`;
+`591337d4d147845b0c203b87c3bb9d5625a0f43c` is not an ancestor. The measured
+candidate binary embeds `c9f727c1e-w02-candidate`, build 11243. The pristine
+source binary embeds full commit `c9f727c1e1995c4a871a719ab05b5f2478588efd`,
+also build 11243. The implementation imports only:
+
+- dormant per-device CUDA VMM live, mapped, live/mapped high-water, and active-
+  pool counters exposed through backend proc lookup;
+- `llama-bench --kv-memory` checkpoints and physical device,
+  accelerator-owned host, and ordinary-host allocation classes; and
+- the focused static guard and benchmark reconciliation needed by those
+  fields.
+
+It excludes native-Q8 reporting and controls, live-context workspace, phase
+changes beyond the base, causal descriptors, pool trimming, host staging, and
+the perplexity capacity fix. The pool allocator's allocation, mapping, reuse,
+and release policy is unchanged.
+
+### Build, hardware, and artifacts
+
+Both pristine and candidate builds used Ninja, GCC 16.2.1, CUDA 13.3,
+`CMAKE_BUILD_TYPE=Release`, `GGML_CUDA=ON`, `GGML_NATIVE=ON`,
+`GGML_CUDA_FA=ON`, `GGML_CUDA_KVARN=OFF`, the default FA quant matrix, and
+`CMAKE_CUDA_ARCHITECTURES=120`. Builds used at most six jobs. The pristine
+source was exported with `git archive c9f727c1e` to
+`tmp/vmm-source-base-c9`; it was not another worktree.
+
+```bash
+cmake -S SOURCE -B BUILD -G Ninja \
+  -DGGML_CUDA=ON -DGGML_NATIVE=ON -DGGML_CUDA_FA=ON \
+  -DGGML_CUDA_KVARN=OFF -DCMAKE_CUDA_ARCHITECTURES=120 \
+  -DCMAKE_BUILD_TYPE=Release -DLLAMA_BUILD_NUMBER=11243 \
+  -DLLAMA_BUILD_COMMIT=IDENTITY
+cmake --build BUILD -j 6 --target llama-bench llama-perplexity
+```
+
+| Artifact | Pristine source SHA-256 | Candidate SHA-256 |
+|---|---|---|
+| `llama-bench` | `c2cd4a6d4b0ada7b029476668d2eac2d6eab92124f28e0cca7aa67a54109a9db` | `6fb3d2fba7adef91620f34e0387d625cf5640ec1c4b8f498249f272b85be9fd3` |
+| `libllama-bench-impl.so` | `7b1e52776ecf0b6cef194c53ab70a9b67107d33988b76ea99f4ba2513bdedca2` | `39f50c25ad7416d301e51e9615c8abdd8cefe9d2c8390c76435a6cff194be625` |
+| `libggml-cuda.so` | `4cde263f5f2e2d9c43e2967612c2da82d66370a6129b93a780c481a095f04e65` | `1e6f72d3339844e940d0566ed9401dd8efe5c8e1c035a1e32e32f28d737fe9cc` |
+| `llama-perplexity` | `d46d09528f1d01a743f0460e871825c65eeba6e135d106e5958d2a2693276c41` | `beeb6b09fd403af0e8c8c51de1cd03e6e0b187d869d4a5582c87061c2c92c87e` |
+
+Hardware was an NVIDIA GeForce RTX 5070 Ti, compute capability 12.0, driver
+610.57.04, with 16,303 MiB reported total and 15,880 MiB usable process memory,
+plus an Intel Core Ultra 9 285K. The model was
+`/home/gencoolpc/llm_models/AtomicChat/Qwen3.8-27B-GGUF/Qwen3.8-27B-AD-IQ4_XS-IQ3_S.gguf`,
+SHA-256 `ca5c3fab5c68a00a7c4fc04a0467946e2069f3cdb073601e7158ae7977e73f6c`,
+14,437,471,712 file bytes, 14,426,476,544 reported model bytes, and
+27,320,697,856 parameters.
+
+### Dormant source A/B/A and telemetry on/off/on
+
+Every row was a fresh process wholly inside
+`flock /tmp/beellama-single-gpu.lock -c`. Native benchmark progress exposed the
+two cases and all three repetitions. `BUILD` selected the pristine or candidate
+directory; telemetry rows added `--kv-memory` only where stated.
+
+```bash
+BUILD/bin/llama-bench \
+  -m /home/gencoolpc/llm_models/AtomicChat/Qwen3.8-27B-GGUF/Qwen3.8-27B-AD-IQ4_XS-IQ3_S.gguf \
+  -p 128 -n 16 -d 4096 -r 3 -b 512 -ub 256 \
+  -t 3 -C 0x7 --cpu-strict 1 --poll 100 \
+  -ngl 999 -sm none -mg 0 -nkvo 0 -fa on -ctk q8_0 -ctv q8_0 \
+  --no-warmup --progress [--kv-memory] -o jsonl
+```
+
+| Default-path build order | Prefill t/s | Decode t/s | New fields |
+|---|---:|---:|---|
+| pristine A1 | 1570.49 +/- 130.64 | 48.985 +/- 0.964 | absent |
+| candidate B | 1554.34 +/- 145.15 | 49.089 +/- 1.150 | all zero |
+| pristine A2 | 1561.05 +/- 132.92 | 48.943 +/- 0.887 | absent |
+
+The candidate is bracketed by the pristine runs: prefill differs by -0.73%
+from their mean and decode by +0.29%. Dispersion overlaps, so this is neutral
+and establishes no dormant regression. The candidate fields are present but
+identically zero without opt-in.
+
+| Candidate order | Prefill t/s | Decode t/s | CUDA peak | VMM live/mapped peak, prefill | Physical device context/compute |
+|---|---:|---:|---:|---:|---:|
+| telemetry on A1 | 1557.55 | 48.901 | 14,389,739,520 B | 9,619,456 / 10,485,760 B | 308,412,416 / 267,281,536 B |
+| telemetry off B | 1546.91 | 48.777 | 0 | 0 / 0 | 0 / 0 |
+| telemetry on A2 | 1565.73 | 48.857 | 14,389,739,520 B | 9,619,456 / 10,485,760 B | 308,412,416 / 267,281,536 B |
+
+The decode-case VMM peaks also repeated exactly at 421,120 live and 2,097,152
+mapped bytes. Both on runs reported 13,002,784 accelerator-host compute bytes,
+zero accelerator-host context, and zero ordinary-host bytes. Off left every
+allocation, checkpoint, and VMM field zero. On/off/on throughput differences
+are below one percent and within repetition variance. VMM live/mapped and
+active-pool values were zero after context destruction. This instrumentation
+does not retain or trim a pool.
+
+Final source/default and on/off/on logs are retained in `/tmp` with SHA-256:
+
+| Log | SHA-256 |
+|---|---|
+| `beellama-w02-final-source-base-a1.log` | `a160fd56e803de47efa36e8d1c2054c7f2da07b6216d601408c52e81981c4980` |
+| `beellama-w02-final-source-candidate-b.log` | `e6f9f05afecd49eec144de4c9aae3ba899975f942883e0b4d79d2238e26fc2ed` |
+| `beellama-w02-final-source-base-a2.log` | `67e42db7bc8a547f96e99261ec6db60852fe988f526387a1612f69cfd392216a` |
+| `beellama-w02-final-telemetry-on-a1.log` | `7cfc993a104588a2960d85de5fb261b6802831a7bc43922ea79957c82483e992` |
+| `beellama-w02-final-telemetry-off-b.log` | `e38546141aef2ac09189b9266cbfa1e011bf150c96390e60b992cd465296d764` |
+| `beellama-w02-final-telemetry-on-a2.log` | `580411c1b3e88544a522fef6781428bcca7df087dc4a18d43fe2da62ec33327f` |
+
+### Physical allocation classes
+
+Focused candidate rows changed to `-p 32 -n 4 -r 1 -nkvo 1`. The ordinary row
+used no further placement flag; the pinned row added `--kv-cpu-pinned`. Both
+used the same locked command, model, depth, cache formats, affinity, and
+`--kv-memory --no-warmup --progress -o jsonl` settings above.
+
+| Placement | Device context/compute | Accelerator-host context/compute | Ordinary-host context/compute | KV resident | CUDA peak |
+|---|---:|---:|---:|---:|---:|
+| ordinary CPU KV | 8,912,896 / 269,501,824 B | 0 / 18,367,520 B | 308,412,416 / 0 B | 160,432,128 B | 14,106,624,000 B |
+| pinned CPU KV | 8,912,896 / 269,501,824 B | 151,519,232 / 18,367,520 B | 156,893,184 / 0 B | 160,432,128 B | 14,106,624,000 B |
+
+The pinned buffer values are configured CUDA-host system-memory allocations,
+not process VRAM. The ordinary-host row initially exposed an invalid inherited
+assertion: it subtracted resident KV from the historical CUDA-owner total even
+though ordinary CPU buffers are excluded from that total. The final candidate
+subtracts KV only for device or pinned placement; the physical-class fields
+remain capability/device based. No allocator placement changed. Logs
+`/tmp/beellama-w02-class-ordinary-20260820.log` and
+`/tmp/beellama-w02-class-pinned-20260820.log` have SHA-256
+`ece1de62cd5162a3abd62bdc27341ffe0a9bbdd59900d01d712c98dd1314ccd0`
+and `a211ae3182493317eeed4c8a5a6520df58af6b3ef4efbc3164ee948d68a8db25`.
+
+### PPL, correctness, and disposition
+
+The telemetry option exists only in `llama-bench`; it does not select a model
+graph, cache representation, or logits path. Nevertheless, the pristine and
+candidate default paths were compared with the same two-chunk smoke corpus:
+
+```bash
+flock /tmp/beellama-single-gpu.lock -c \
+  'BUILD/bin/llama-perplexity -m MODEL \
+   -f tools/perplexity/README.md -c 512 -b 512 -ub 256 \
+   -t 3 -C 0x7 --cpu-strict 1 --poll 100 -ngl 999 \
+   -fa on -ctk q8_0 -ctv q8_0 --chunks 2'
+```
+
+Both reported `PPL = 6.2739 +/- 0.66203`; there is no observed increase. The
+corpus SHA-256 was
+`f4af3dcb2b38f7c9dda5417cd159e789ab9e134e7dc45032bb4d4333da835d81`.
+Base/candidate logs have SHA-256
+`5efb0ef1e0eaf160d6f8560f095e1e79b911e99e59fbc30e5a603e1dd1b77eac`
+and `51339fe39cb73131cd9e99df7f6e952983be2091b9c4143930113aeecfd6524c`.
+The benchmark does not emit generated tokens, so a token-output comparison is
+not applicable; equal PPL is the focused logits check, and the static guard
+proves no later output-affecting feature was imported.
+
+Retain W02 as support instrumentation. It reports rather than optimizes VRAM,
+and it adds no pool policy. The empirical scope is one CUDA VMM device, one
+model, Q8_0/Q8_0 cache, and the listed device/ordinary/pinned placements.
+Other backends, multi-GPU, cache widths, and serving lifecycles remain
+unmeasured. No causal, live-workspace, phase-policy, staging, trimming,
+native-Q8, or perplexity-capacity conclusion follows from this experiment.

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -536,7 +536,34 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
 };
 
 // pool with virtual memory
+struct ggml_cuda_vmm_pool_stats {
+    uint64_t live_bytes;
+    uint64_t live_peak_bytes;
+    uint64_t mapped_bytes;
+    uint64_t mapped_peak_bytes;
+    uint64_t active_pools;
+};
+
 #if defined(GGML_USE_VMM)
+struct ggml_cuda_vmm_pool_stats_atomic {
+    std::atomic<bool>     enabled           { false };
+    std::atomic<uint64_t> live_bytes        { 0 };
+    std::atomic<uint64_t> live_peak_bytes   { 0 };
+    std::atomic<uint64_t> mapped_bytes      { 0 };
+    std::atomic<uint64_t> mapped_peak_bytes { 0 };
+    std::atomic<uint64_t> active_pools      { 0 };
+};
+
+static ggml_cuda_vmm_pool_stats_atomic g_cuda_vmm_pool_stats[GGML_CUDA_MAX_DEVICES];
+
+static void ggml_cuda_vmm_pool_update_peak(std::atomic<uint64_t> & peak, uint64_t value) {
+    uint64_t observed = peak.load(std::memory_order_relaxed);
+    while (observed < value &&
+            !peak.compare_exchange_weak(observed, value,
+                std::memory_order_relaxed, std::memory_order_relaxed)) {
+    }
+}
+
 struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
     static const size_t CUDA_POOL_VMM_MAX_SIZE = 1ull << 35; // 32 GB
 
@@ -546,6 +573,7 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
     size_t pool_used = 0;
     size_t pool_size = 0;
     size_t granularity;
+    bool telemetry_tracked;
 #if defined(GGML_USE_HIP)
     std::vector<std::pair<CUdeviceptr, size_t>> mappings;
 #endif
@@ -553,10 +581,27 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
     explicit ggml_cuda_pool_vmm(int device) :
         device(device),
         physical_device(ggml_cuda_get_physical_device(device)),
-        granularity(ggml_cuda_info().devices[device].vmm_granularity) {
+        granularity(ggml_cuda_info().devices[device].vmm_granularity),
+        telemetry_tracked(false) {
+        track_telemetry();
+    }
+
+    void track_telemetry() {
+        auto & stats = g_cuda_vmm_pool_stats[device];
+        if (telemetry_tracked || !stats.enabled.load(std::memory_order_relaxed)) {
+            return;
+        }
+
+        telemetry_tracked = true;
+        stats.active_pools.fetch_add(1, std::memory_order_relaxed);
+        const uint64_t live = stats.live_bytes.fetch_add(pool_used, std::memory_order_relaxed) + pool_used;
+        const uint64_t mapped = stats.mapped_bytes.fetch_add(pool_size, std::memory_order_relaxed) + pool_size;
+        ggml_cuda_vmm_pool_update_peak(stats.live_peak_bytes, live);
+        ggml_cuda_vmm_pool_update_peak(stats.mapped_peak_bytes, mapped);
     }
 
     ~ggml_cuda_pool_vmm() {
+        track_telemetry();
         if (pool_addr != 0) {
 #if defined(GGML_USE_HIP)
             // Workaround for https://github.com/ROCm/ROCR-Runtime/issues/285
@@ -564,13 +609,21 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
                 CU_CHECK(cuMemUnmap(mapping.first, mapping.second));
             }
 #else
-            CU_CHECK(cuMemUnmap(pool_addr, pool_size));
+            if (pool_size > 0) {
+                CU_CHECK(cuMemUnmap(pool_addr, pool_size));
+            }
 #endif
             CU_CHECK(cuMemAddressFree(pool_addr, CUDA_POOL_VMM_MAX_SIZE));
+        }
+        if (telemetry_tracked) {
+            g_cuda_vmm_pool_stats[device].live_bytes.fetch_sub(pool_used, std::memory_order_relaxed);
+            g_cuda_vmm_pool_stats[device].mapped_bytes.fetch_sub(pool_size, std::memory_order_relaxed);
+            g_cuda_vmm_pool_stats[device].active_pools.fetch_sub(1, std::memory_order_relaxed);
         }
     }
 
     void * alloc(size_t size, size_t * actual_size) override {
+        track_telemetry();
         // round up the allocation size to the alignment to ensure that all allocations are aligned for all data types
         const size_t alignment = 128;
         size = alignment * ((size + alignment - 1) / alignment);
@@ -654,6 +707,13 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
 
             // add to the pool
             pool_size += reserve_size;
+            if (telemetry_tracked) {
+                const uint64_t mapped =
+                    g_cuda_vmm_pool_stats[device].mapped_bytes.fetch_add(
+                        reserve_size, std::memory_order_relaxed) + reserve_size;
+                ggml_cuda_vmm_pool_update_peak(
+                    g_cuda_vmm_pool_stats[device].mapped_peak_bytes, mapped);
+            }
 
             //printf("cuda pool[%d]: size increased to %llu MB (reserved %llu MB)\n",
             //       device, (unsigned long long) (pool_size/1024/1024),
@@ -665,6 +725,13 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         void * ptr = (void *) ((CUdeviceptr)((char *)(pool_addr) + pool_used));
         *actual_size = size;
         pool_used += size;
+        if (telemetry_tracked) {
+            const uint64_t live =
+                g_cuda_vmm_pool_stats[device].live_bytes.fetch_add(
+                    size, std::memory_order_relaxed) + size;
+            ggml_cuda_vmm_pool_update_peak(
+                g_cuda_vmm_pool_stats[device].live_peak_bytes, live);
+        }
 
 #ifdef DEBUG_CUDA_MALLOC
         printf("cuda pool[%d]: allocated %llu bytes at %llx\n", device, (unsigned long long) size, ptr);
@@ -674,17 +741,62 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
     }
 
     void free(void * ptr, size_t size) override {
+        track_telemetry();
 #ifdef DEBUG_CUDA_MALLOC
         printf("cuda pool[%d]: freed %llu bytes at %llx\n", device, (unsigned long long) size, ptr);
 #endif
 
         pool_used -= size;
+        if (telemetry_tracked) {
+            g_cuda_vmm_pool_stats[device].live_bytes.fetch_sub(size, std::memory_order_relaxed);
+        }
 
         // all deallocations must be in reverse order of the allocations
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
     }
 };
 #endif // defined(GGML_USE_VMM)
+
+static bool ggml_backend_cuda_vmm_pool_stats_get(int device, ggml_cuda_vmm_pool_stats * stats) {
+#if defined(GGML_USE_VMM)
+    if (stats == nullptr || device < 0 || device >= ggml_cuda_info().device_count ||
+            !ggml_cuda_info().devices[device].vmm) {
+        return false;
+    }
+
+    const auto & source = g_cuda_vmm_pool_stats[device];
+    stats->live_bytes        = source.live_bytes.load(std::memory_order_relaxed);
+    stats->live_peak_bytes   = source.live_peak_bytes.load(std::memory_order_relaxed);
+    stats->mapped_bytes      = source.mapped_bytes.load(std::memory_order_relaxed);
+    stats->mapped_peak_bytes = source.mapped_peak_bytes.load(std::memory_order_relaxed);
+    stats->active_pools      = source.active_pools.load(std::memory_order_relaxed);
+    return true;
+#else
+    GGML_UNUSED(device);
+    GGML_UNUSED(stats);
+    return false;
+#endif
+}
+
+static bool ggml_backend_cuda_vmm_pool_stats_reset(int device) {
+#if defined(GGML_USE_VMM)
+    if (device < 0 || device >= ggml_cuda_info().device_count ||
+            !ggml_cuda_info().devices[device].vmm) {
+        return false;
+    }
+
+    auto & stats = g_cuda_vmm_pool_stats[device];
+    stats.enabled.store(true, std::memory_order_relaxed);
+    stats.live_peak_bytes.store(
+        stats.live_bytes.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    stats.mapped_peak_bytes.store(
+        stats.mapped_bytes.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    return true;
+#else
+    GGML_UNUSED(device);
+    return false;
+#endif
+}
 
 std::unique_ptr<ggml_cuda_pool> ggml_backend_cuda_context::new_pool_for_device(int                  device,
                                                                                [[maybe_unused]] int stream_no) {
@@ -5818,6 +5930,12 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     }
     if (strcmp(name, "ggml_backend_cuda_memory_checkpoint") == 0) {
         return (void *)ggml_backend_cuda_memory_checkpoint;
+    }
+    if (strcmp(name, "ggml_backend_cuda_vmm_pool_stats_get") == 0) {
+        return (void *)ggml_backend_cuda_vmm_pool_stats_get;
+    }
+    if (strcmp(name, "ggml_backend_cuda_vmm_pool_stats_reset") == 0) {
+        return (void *)ggml_backend_cuda_vmm_pool_stats_reset;
     }
     return nullptr;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,12 @@ if (Python3_Interpreter_FOUND)
     set_property(TEST test-std-kv-tail-static PROPERTY LABELS main)
 
     add_test(
+        NAME test-vmm-allocation-telemetry-static
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tests/test-vmm-allocation-telemetry-static.py)
+    set_property(TEST test-vmm-allocation-telemetry-static PROPERTY LABELS cuda)
+
+    add_test(
         NAME test-removed-cache-types-static
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tests/test-removed-cache-types-static.py)

--- a/tests/test-vmm-allocation-telemetry-static.py
+++ b/tests/test-vmm-allocation-telemetry-static.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(text: str, needle: str, message: str) -> None:
+    if needle not in text:
+        raise AssertionError(message)
+
+
+def main() -> None:
+    cuda = (ROOT / "ggml/src/ggml-cuda/ggml-cuda.cu").read_text(encoding="utf-8")
+    bench = (ROOT / "tools/llama-bench/llama-bench.cpp").read_text(encoding="utf-8")
+
+    for symbol in (
+        "ggml_backend_cuda_vmm_pool_stats_get",
+        "ggml_backend_cuda_vmm_pool_stats_reset",
+        "live_peak_bytes",
+        "mapped_peak_bytes",
+        "active_pools",
+    ):
+        require(cuda, symbol, f"CUDA VMM telemetry is missing {symbol}")
+
+    require(
+        cuda,
+        "if (telemetry_tracked || !stats.enabled.load(std::memory_order_relaxed))",
+        "CUDA VMM allocation accounting must stay dormant until explicitly enabled",
+    )
+    if "ggml_backend_cuda_trim_transient_pools" in cuda:
+        raise AssertionError("W02 must not import transient-pool trimming policy")
+
+    for field in (
+        '"cuda_vmm_live_peak_bytes"',
+        '"cuda_vmm_mapped_peak_bytes"',
+        '"cuda_device_context_buffer_bytes"',
+        '"cuda_device_compute_buffer_bytes"',
+        '"accelerator_host_context_buffer_bytes"',
+        '"accelerator_host_compute_buffer_bytes"',
+        '"host_context_buffer_bytes"',
+        '"host_compute_buffer_bytes"',
+    ):
+        require(bench, field, f"llama-bench output is missing {field}")
+
+    require(
+        bench,
+        "if (ggml_backend_buft_is_host(buft))",
+        "allocation classification must use buffer capability rather than backend names",
+    )
+    require(
+        bench,
+        "ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU",
+        "allocation classification must use the owning device type",
+    )
+    require(
+        bench,
+        "const bool kv_in_cuda_owner_total = !inst.no_kv_offload || inst.kv_cpu_pinned;",
+        "ordinary-host KV must not be subtracted from the historical CUDA-owner total",
+    )
+
+    enable_block = bench.split("if (params.kv_memory) {", 1)[1].split("llama_context * ctx", 1)[0]
+    require(
+        enable_block,
+        "cuda_vmm_pool_stats_reset(inst.main_gpu)",
+        "--kv-memory must be the opt-in telemetry client",
+    )
+    prefix = bench.split("if (params.kv_memory) {", 1)[0]
+    if "cuda_vmm_pool_stats_reset(" in prefix:
+        raise AssertionError("VMM telemetry must not be enabled on the default benchmark path")
+
+    for excluded in (
+        "phase_aware_workspace",
+        "live_context_workspace",
+        "flash_attn_native_quants",
+    ):
+        if excluded in bench:
+            raise AssertionError(f"W02 must not depend on later feature field {excluded}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1760,6 +1760,26 @@ struct test {
     uint64_t                 cuda_used_peak_bytes = 0;
     uint64_t                 cuda_used_after_context_bytes = 0;
     uint64_t                 cuda_total_bytes = 0;
+    uint64_t                 cuda_vmm_live_model_bytes = 0;
+    uint64_t                 cuda_vmm_mapped_model_bytes = 0;
+    uint64_t                 cuda_vmm_live_context_bytes = 0;
+    uint64_t                 cuda_vmm_mapped_context_bytes = 0;
+    uint64_t                 cuda_vmm_live_after_workload_bytes = 0;
+    uint64_t                 cuda_vmm_mapped_after_workload_bytes = 0;
+    uint64_t                 cuda_vmm_live_peak_bytes = 0;
+    uint64_t                 cuda_vmm_mapped_peak_bytes = 0;
+    uint64_t                 cuda_vmm_live_after_context_bytes = 0;
+    uint64_t                 cuda_vmm_mapped_after_context_bytes = 0;
+    uint64_t                 cuda_vmm_active_pools_model = 0;
+    uint64_t                 cuda_vmm_active_pools_context = 0;
+    uint64_t                 cuda_vmm_active_pools_after_workload = 0;
+    uint64_t                 cuda_vmm_active_pools_after_context = 0;
+    uint64_t                 cuda_device_context_buffer_bytes = 0;
+    uint64_t                 cuda_device_compute_buffer_bytes = 0;
+    uint64_t                 accelerator_host_context_buffer_bytes = 0;
+    uint64_t                 accelerator_host_compute_buffer_bytes = 0;
+    uint64_t                 host_context_buffer_bytes = 0;
+    uint64_t                 host_compute_buffer_bytes = 0;
     uint64_t                 cuda_context_buffer_bytes = 0;
     uint64_t                 cuda_non_kv_context_buffer_bytes = 0;
     uint64_t                 cuda_compute_buffer_bytes = 0;
@@ -1909,6 +1929,16 @@ struct test {
             "kv_tail_pack_bytes", "kv_tail_body_output_bytes", "kv_tail_exact_output_bytes", "kv_tail_plan_input_bytes",
             "kv_transient_bytes", "kv_peak_bytes", "cuda_used_model_bytes", "cuda_used_context_bytes",
             "cuda_used_prefill_bytes", "cuda_used_peak_bytes", "cuda_used_after_context_bytes", "cuda_total_bytes",
+            "cuda_vmm_live_model_bytes", "cuda_vmm_mapped_model_bytes",
+            "cuda_vmm_live_context_bytes", "cuda_vmm_mapped_context_bytes",
+            "cuda_vmm_live_after_workload_bytes", "cuda_vmm_mapped_after_workload_bytes",
+            "cuda_vmm_live_peak_bytes", "cuda_vmm_mapped_peak_bytes",
+            "cuda_vmm_live_after_context_bytes", "cuda_vmm_mapped_after_context_bytes",
+            "cuda_vmm_active_pools_model", "cuda_vmm_active_pools_context",
+            "cuda_vmm_active_pools_after_workload", "cuda_vmm_active_pools_after_context",
+            "cuda_device_context_buffer_bytes", "cuda_device_compute_buffer_bytes",
+            "accelerator_host_context_buffer_bytes", "accelerator_host_compute_buffer_bytes",
+            "host_context_buffer_bytes", "host_compute_buffer_bytes",
             "cuda_context_buffer_bytes", "cuda_non_kv_context_buffer_bytes", "cuda_compute_buffer_bytes",
             "cuda_context_delta_bytes", "cuda_peak_delta_bytes", "cuda_reconciliation_delta_bytes",
             "cuda_runtime_overhead_bytes", "cuda_teardown_delta_bytes",
@@ -2070,6 +2100,26 @@ struct test {
                                              std::to_string(cuda_used_peak_bytes),
                                              std::to_string(cuda_used_after_context_bytes),
                                              std::to_string(cuda_total_bytes),
+                                             std::to_string(cuda_vmm_live_model_bytes),
+                                             std::to_string(cuda_vmm_mapped_model_bytes),
+                                             std::to_string(cuda_vmm_live_context_bytes),
+                                             std::to_string(cuda_vmm_mapped_context_bytes),
+                                             std::to_string(cuda_vmm_live_after_workload_bytes),
+                                             std::to_string(cuda_vmm_mapped_after_workload_bytes),
+                                             std::to_string(cuda_vmm_live_peak_bytes),
+                                             std::to_string(cuda_vmm_mapped_peak_bytes),
+                                             std::to_string(cuda_vmm_live_after_context_bytes),
+                                             std::to_string(cuda_vmm_mapped_after_context_bytes),
+                                             std::to_string(cuda_vmm_active_pools_model),
+                                             std::to_string(cuda_vmm_active_pools_context),
+                                             std::to_string(cuda_vmm_active_pools_after_workload),
+                                             std::to_string(cuda_vmm_active_pools_after_context),
+                                             std::to_string(cuda_device_context_buffer_bytes),
+                                             std::to_string(cuda_device_compute_buffer_bytes),
+                                             std::to_string(accelerator_host_context_buffer_bytes),
+                                             std::to_string(accelerator_host_compute_buffer_bytes),
+                                             std::to_string(host_context_buffer_bytes),
+                                             std::to_string(host_compute_buffer_bytes),
                                              std::to_string(cuda_context_buffer_bytes),
                                              std::to_string(cuda_non_kv_context_buffer_bytes),
                                              std::to_string(cuda_compute_buffer_bytes),
@@ -2704,6 +2754,17 @@ using bench_kv_memory_transient_stats_reset_fn = void (*)();
 using bench_kv_memory_transient_stats_get_fn = void (*)(bench_kv_memory_transient_stats *);
 using bench_cuda_memory_checkpoint_fn = bool (*)(int, uint64_t *, uint64_t *, uint64_t *);
 
+struct bench_cuda_vmm_pool_stats {
+    uint64_t live_bytes;
+    uint64_t live_peak_bytes;
+    uint64_t mapped_bytes;
+    uint64_t mapped_peak_bytes;
+    uint64_t active_pools;
+};
+
+using bench_cuda_vmm_pool_stats_get_fn = bool (*)(int, bench_cuda_vmm_pool_stats *);
+using bench_cuda_vmm_pool_stats_reset_fn = bool (*)(int);
+
 static ggml_backend_dev_t bench_memory_device(const cmd_params_instance & inst) {
     if (inst.main_gpu >= 0 && size_t(inst.main_gpu) < inst.devices.size() &&
             inst.devices[inst.main_gpu] != nullptr) {
@@ -2876,6 +2937,7 @@ int llama_bench(int argc, char ** argv) {
         uint64_t cuda_used_model = 0;
         uint64_t cuda_free_model = 0;
         uint64_t cuda_total = 0;
+        bench_cuda_vmm_pool_stats cuda_vmm_model = {};
         ggml_backend_dev_t memory_dev = bench_memory_device(inst);
         const char * memory_device_name = memory_dev != nullptr ? ggml_backend_dev_name(memory_dev) : nullptr;
         const uint32_t route_stats_abi_version = memory_device_name != nullptr &&
@@ -2902,6 +2964,14 @@ int llama_bench(int argc, char ** argv) {
             reinterpret_cast<bench_cuda_memory_checkpoint_fn>(
                 ggml_backend_reg_get_proc_address(
                     memory_reg, "ggml_backend_cuda_memory_checkpoint")) : nullptr;
+        auto cuda_vmm_pool_stats_get = memory_reg != nullptr ?
+            reinterpret_cast<bench_cuda_vmm_pool_stats_get_fn>(
+                ggml_backend_reg_get_proc_address(
+                    memory_reg, "ggml_backend_cuda_vmm_pool_stats_get")) : nullptr;
+        auto cuda_vmm_pool_stats_reset = memory_reg != nullptr ?
+            reinterpret_cast<bench_cuda_vmm_pool_stats_reset_fn>(
+                ggml_backend_reg_get_proc_address(
+                    memory_reg, "ggml_backend_cuda_vmm_pool_stats_reset")) : nullptr;
         if (params.kv_memory) {
             if (kv_memory_transient_stats_reset == nullptr || kv_memory_transient_stats_get == nullptr ||
                     memory_dev == nullptr) {
@@ -2909,11 +2979,17 @@ int llama_bench(int argc, char ** argv) {
                 llama_model_free(lmodel);
                 return 1;
             }
+            if (cuda_vmm_pool_stats_reset != nullptr) {
+                cuda_vmm_pool_stats_reset(inst.main_gpu);
+            }
             if (!bench_device_memory_checkpoint(memory_dev, cuda_memory_checkpoint, inst.main_gpu, nullptr,
                     &cuda_used_model, &cuda_free_model, &cuda_total)) {
                 fprintf(stderr, "%s: error: failed to capture the synchronized model-only device checkpoint\n", __func__);
                 llama_model_free(lmodel);
                 return 1;
+            }
+            if (cuda_vmm_pool_stats_get != nullptr) {
+                cuda_vmm_pool_stats_get(inst.main_gpu, &cuda_vmm_model);
             }
         }
 
@@ -2949,23 +3025,44 @@ int llama_bench(int argc, char ** argv) {
             t.kv_tail_cpu_layers = kv_stats.tail_cpu_layers();
             t.cuda_used_model_bytes = cuda_used_model;
             t.cuda_total_bytes = cuda_total;
+            t.cuda_vmm_live_model_bytes = cuda_vmm_model.live_bytes;
+            t.cuda_vmm_mapped_model_bytes = cuda_vmm_model.mapped_bytes;
+            t.cuda_vmm_active_pools_model = cuda_vmm_model.active_pools;
 
             const llama_memory_breakdown breakdown = llama_get_memory_breakdown(ctx);
             for (const auto & [buft, memory] : breakdown) {
                 ggml_backend_dev_t dev = ggml_backend_buft_get_device(buft);
                 if (dev != nullptr && ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+                    // Preserve the historical accelerator-owner totals for result compatibility.
+                    // Accelerator host buffers consume host RAM, not physical device memory.
                     t.cuda_context_buffer_bytes += memory.context;
                     t.cuda_compute_buffer_bytes += memory.compute;
                 }
+                if (ggml_backend_buft_is_host(buft)) {
+                    if (dev != nullptr && ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+                        t.accelerator_host_context_buffer_bytes += memory.context;
+                        t.accelerator_host_compute_buffer_bytes += memory.compute;
+                    } else {
+                        t.host_context_buffer_bytes += memory.context;
+                        t.host_compute_buffer_bytes += memory.compute;
+                    }
+                } else if (dev != nullptr && ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+                    t.cuda_device_context_buffer_bytes += memory.context;
+                    t.cuda_device_compute_buffer_bytes += memory.compute;
+                }
             }
-            if (t.cuda_context_buffer_bytes < t.kv_resident_bytes) {
+            // The historical CUDA-owner total includes device KV and CUDA-pinned host KV,
+            // but deliberately excludes ordinary host buffers. Only subtract resident KV
+            // when its buffer type participates in that owner total.
+            const bool kv_in_cuda_owner_total = !inst.no_kv_offload || inst.kv_cpu_pinned;
+            if (kv_in_cuda_owner_total && t.cuda_context_buffer_bytes < t.kv_resident_bytes) {
                 fprintf(stderr, "%s: error: GPU context buffers are smaller than categorized resident KV storage\n", __func__);
                 llama_free(ctx);
                 llama_model_free(lmodel);
                 return 1;
             }
-            t.cuda_non_kv_context_buffer_bytes =
-                t.cuda_context_buffer_bytes - t.kv_resident_bytes;
+            t.cuda_non_kv_context_buffer_bytes = t.cuda_context_buffer_bytes -
+                (kv_in_cuda_owner_total ? t.kv_resident_bytes : 0);
 
             uint64_t cuda_free_context = 0;
             uint64_t cuda_total_context = 0;
@@ -2977,6 +3074,14 @@ int llama_bench(int argc, char ** argv) {
                 return 1;
             }
             t.cuda_context_delta_bytes = int64_t(t.cuda_used_context_bytes) - int64_t(t.cuda_used_model_bytes);
+            if (cuda_vmm_pool_stats_get != nullptr) {
+                bench_cuda_vmm_pool_stats stats = {};
+                if (cuda_vmm_pool_stats_get(inst.main_gpu, &stats)) {
+                    t.cuda_vmm_live_context_bytes = stats.live_bytes;
+                    t.cuda_vmm_mapped_context_bytes = stats.mapped_bytes;
+                    t.cuda_vmm_active_pools_context = stats.active_pools;
+                }
+            }
         }
 
         if (kvarn_route_stats_reset != nullptr) {
@@ -3042,6 +3147,9 @@ int llama_bench(int argc, char ** argv) {
 
         if (params.kv_memory) {
             kv_memory_transient_stats_reset();
+            if (cuda_vmm_pool_stats_reset != nullptr) {
+                cuda_vmm_pool_stats_reset(inst.main_gpu);
+            }
         }
 
         for (int i = 0; i < params.reps; i++) {
@@ -3183,11 +3291,22 @@ int llama_bench(int argc, char ** argv) {
             t.kv_peak_bytes = t.kv_resident_bytes + t.kv_transient_bytes;
             t.cuda_peak_delta_bytes = int64_t(t.cuda_used_peak_bytes) - int64_t(t.cuda_used_model_bytes);
             t.cuda_reconciliation_delta_bytes = t.cuda_peak_delta_bytes -
-                    int64_t(t.cuda_context_buffer_bytes + t.cuda_compute_buffer_bytes);
+                    int64_t(t.cuda_device_context_buffer_bytes + t.cuda_device_compute_buffer_bytes);
             // cudaMemGetInfo includes driver/runtime allocations and VMM pool
             // granularity that are not owned by a llama context buffer. Keep
             // that residual explicit instead of attributing it to KVarN.
             t.cuda_runtime_overhead_bytes = t.cuda_reconciliation_delta_bytes;
+
+            if (cuda_vmm_pool_stats_get != nullptr) {
+                bench_cuda_vmm_pool_stats vmm_stats = {};
+                if (cuda_vmm_pool_stats_get(inst.main_gpu, &vmm_stats)) {
+                    t.cuda_vmm_live_after_workload_bytes = vmm_stats.live_bytes;
+                    t.cuda_vmm_mapped_after_workload_bytes = vmm_stats.mapped_bytes;
+                    t.cuda_vmm_live_peak_bytes = vmm_stats.live_peak_bytes;
+                    t.cuda_vmm_mapped_peak_bytes = vmm_stats.mapped_peak_bytes;
+                    t.cuda_vmm_active_pools_after_workload = vmm_stats.active_pools;
+                }
+            }
 
             llama_perf_context_print(ctx);
             llama_free(ctx);
@@ -3203,6 +3322,14 @@ int llama_bench(int argc, char ** argv) {
             }
             t.cuda_teardown_delta_bytes = int64_t(t.cuda_used_after_context_bytes) -
                     int64_t(t.cuda_used_model_bytes);
+            if (cuda_vmm_pool_stats_get != nullptr) {
+                bench_cuda_vmm_pool_stats stats_after = {};
+                if (cuda_vmm_pool_stats_get(inst.main_gpu, &stats_after)) {
+                    t.cuda_vmm_live_after_context_bytes = stats_after.live_bytes;
+                    t.cuda_vmm_mapped_after_context_bytes = stats_after.mapped_bytes;
+                    t.cuda_vmm_active_pools_after_context = stats_after.active_pools;
+                }
+            }
         }
 
         if (p) {


### PR DESCRIPTION
## Summary

This migrates only the W02 allocation-classification and CUDA VMM/transient-pool telemetry support onto the pre-PR4 KV-offload base.

`llama-bench --kv-memory` now opts into:

- backend-generic physical allocation classification for GPU-device, accelerator-owned host (including CUDA-pinned), and ordinary-host context/compute buffers;
- CUDA VMM live bytes, mapped bytes, live/mapped high-water marks, and active-pool checkpoints; and
- model, context, workload, peak, and teardown allocation reporting while retaining the historical CUDA-owner totals for result compatibility.

The VMM counters remain dormant until the benchmark calls the reset proc. Fresh telemetry-off processes leave every new field at zero. This is support instrumentation only: it does not change allocation, mapping, reuse, release, or trimming policy.

## Base and comparison

- Repository: `GenerelSchwerz/llama.cpp`
- Base: `beellama-kv-cpu-offload` at `50ee5b2d765c91a0d9cd23728ac17a27ac510e3e`
- Head: `exp/vmm-allocation-telemetry-pre-pr4` at `3bd7a088199922b1e5e20973cd8cb6d970cde111`
- GitHub three-dot comparison: two commits, seven files, 562 insertions, 6 deletions, `ahead_by=2`, `behind_by=0`

PR 5 was merged into the published base as `50ee5b2d7` before this head refresh. Merge commit `3bd7a0881` preserves both ledger entries; relative to the current base, the feature diff remains the same seven W02 files. The two local KV-offload protocol/evidence commits remain outside the published base.

## Validation

### Dormant source A/B/A

Fresh pristine/candidate/pristine processes used identical Q8_0/Q8_0, depth-4096, three-repetition runs without `--kv-memory`:

| Order | Prefill | Decode | Telemetry fields |
|---|---:|---:|---|
| pristine A1 | 1570.49 +/- 130.64 t/s | 48.985 +/- 0.964 t/s | absent |
| candidate B | 1554.34 +/- 145.15 t/s | 49.089 +/- 1.150 t/s | all zero |
| pristine A2 | 1561.05 +/- 132.92 t/s | 48.943 +/- 0.887 t/s | absent |

The candidate differs by -0.73% prefill and +0.29% decode from the pristine mean, with overlapping dispersion. This is neutral and shows no dormant-path regression.

### Same-binary telemetry on/off/on

Fresh candidate processes produced:

| Order | Prefill | Decode | Prefill VMM live/mapped peak |
|---|---:|---:|---:|
| on A1 | 1557.55 t/s | 48.901 t/s | 9,619,456 / 10,485,760 B |
| off B | 1546.91 t/s | 48.777 t/s | 0 / 0 |
| on A2 | 1565.73 t/s | 48.857 t/s | 9,619,456 / 10,485,760 B |

Both on runs reproduced the decode VMM peaks exactly at 421,120 live and 2,097,152 mapped bytes. Off left all allocation/checkpoint/VMM fields zero. Live/mapped bytes and active pools returned to zero after context destruction.

### Allocation classes

Focused `-nkvo 1` probes demonstrated ordinary and pinned host placement in addition to the GPU-device row:

- GPU-device KV: 308,412,416 B device context and 267,281,536 B device compute.
- Ordinary CPU KV: 308,412,416 B ordinary-host context; accelerator-host context remained zero.
- Pinned CPU KV: 151,519,232 B accelerator-host context, reported separately from 156,893,184 B of ordinary-host context.

The migration also fixes the benchmark reconciliation guard so ordinary-host KV is not subtracted from the compatibility CUDA-owner total. Classification uses buffer capability and owning device type rather than architecture-name checks.

### PPL and focused tests

Matched pristine and candidate default-path `llama-perplexity` runs both reported exactly:

`PPL = 6.2739 +/- 0.66203`

Focused coverage passed:

```text
python3 tests/test-vmm-allocation-telemetry-static.py
ctest --test-dir build-cuda-vmm-telemetry-clean --output-on-failure \
  -R '^(test-vmm-allocation-telemetry-static|test-std-kv-tail-static|test-perplexity-plumbing)$'
# 3/3 passed after the PR 5 base refresh

git diff --check
```

After PR 5 advanced the base, the final composed source rebuilt `llama-bench`, `llama-perplexity`, and `test-perplexity-plumbing`; the three focused tests above passed. No prior GPU result was relabeled as a measurement of a different binary, and W02 production source is unchanged from the measured commit.

## Protocol

Every GPU-capable command ran as a fresh process wholly inside `flock /tmp/beellama-single-gpu.lock -c`, used native llama affinity (`-t 3 -C 0x7 --cpu-strict 1`), and exposed native `--progress` for benchmark runs. The core command was:

```bash
flock /tmp/beellama-single-gpu.lock -c \
  'BUILD/bin/llama-bench \
   -m /home/gencoolpc/llm_models/AtomicChat/Qwen3.8-27B-GGUF/Qwen3.8-27B-AD-IQ4_XS-IQ3_S.gguf \
   -p 128 -n 16 -d 4096 -r 3 -b 512 -ub 256 \
   -t 3 -C 0x7 --cpu-strict 1 --poll 100 \
   -ngl 999 -sm none -mg 0 -nkvo 0 -fa on -ctk q8_0 -ctv q8_0 \
   --no-warmup --progress [--kv-memory] -o jsonl'
```

Builds were Release CUDA/FlashAttention for SM 120 with `GGML_NATIVE=ON`, `GGML_CUDA_KVARN=OFF`, and at most six build jobs. Exact binary/model/log identities and command records are preserved in Experiment 020.

## Explicit exclusions

This PR does **not** import or depend on:

- native-Q8 reporting or PR 4 controls;
- live-context workspace changes;
- phase-aware behavior beyond the inherited KV-offload base;
- causal descriptors;
- VMM/transient-pool trimming policy;
- host staging changes; or
- changes to the inherited perplexity capacity fix from PR 5.

It makes no VRAM-saving claim and does not infer a trimming opportunity from the measured pool high-water marks.