### PR TITLE
tools: inherit feature-performance validation from KV base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,9 @@ Key binaries are `llama-server`, `llama-cli`, `llama-bench`, and
   post-composition gates for every KV-derived VRAM feature branch.
 - `docs/cpu-kv-offload-feature-delta.md` - source-backed capability delta from
   BeeLlama v0.4.3, including explicit features absent from the published KV base.
+- `docs/feature-performance-validation.md` - manifest-driven early A/B
+  screening, telemetry, statistics, resume, and optional Nsight diagnostics for
+  KV-derived feature work.
 
 ### Invariants
 
@@ -190,6 +193,12 @@ CPU-resident KV-cache investigation.
   a test, or interpreting a current result. It is the only documentation source
   for the runnable current protocol; the local source remains authoritative if
   documentation and behavior disagree.
+- For a new CPU-KV-derived performance or memory feature, preregister and run
+  the manifest workflow in `docs/feature-performance-validation.md` for early
+  exactness, short prefill/decode, representative weighted screens, and
+  resource telemetry. A clear early signal only permits deeper validation;
+  it never replaces the current long-context, perplexity, clean-process,
+  allocation-lifecycle, or feature-specific acceptance gates.
 - Read the relevant sections of `docs/cpu-kv-offload-development.md` and
   `docs/cpu-kv-offload-experiments.md` when historical rationale, prior
   protocol editions, rejected approaches, or old measurements are needed.

--- a/docs/cpu-kv-offload-current-testing.md
+++ b/docs/cpu-kv-offload-current-testing.md
@@ -183,6 +183,45 @@ Do not present an uncommitted or differently configured binary as evidence for
 the current commit. Documentation-only dirt does not change a binary; source
 or build changes do.
 
+## Manifest-driven early feature screen
+
+Every new CPU-KV-derived performance or memory feature starts with a
+preregistered manifest based on
+[`feature-performance-validation.md`](feature-performance-validation.md) and
+the checked-in schema/example. Select screens by workload, tensor layout, and
+backend capability; do not select by model or architecture name. Before a
+deeper campaign, run:
+
+```bash
+python3 scripts/feature-performance-validation.py validate MANIFEST.json
+python3 scripts/feature-performance-validation.py run \
+  MANIFEST.json --through early
+```
+
+The early ladder runs exactness first, then short prefill/decode and
+representative low/mid/high screens with real-ubatch weighting and fresh clean
+processes. A preregistered `single_pair_fail_fast` stage is a screening signal
+with no confidence interval or acceptance claim. Preserve all raw samples and
+stop on a regression signal.
+
+When the manifest preregisters `early_diagnostics`, an agent may opt into
+direct-target Nsight discovery and filtered capture after a regression:
+
+```bash
+python3 scripts/feature-performance-validation.py run \
+  MANIFEST.json --through early --diagnose-regressions
+```
+
+This diagnostic independently discovers baseline and candidate launches and
+remains explanatory evidence only. It must follow the profiler launch contract
+below and cannot convert an early result into acceptance. A clear early screen
+only authorizes proportional production confirmation. The canonical
+long-context comparison, matching-batch perplexity and output exactness oracle,
+whole-lifecycle clean-process evidence, pinned/ordinary-host and process-VRAM
+accounting, allocation-lifecycle checks, and every feature-specific gate in
+this document remain mandatory. Keep large raw runner and profiler artifacts
+outside Git; record only reproducible manifests and concise valid summaries.
+
 ## Canonical server lifecycle
 
 This is the current source-supported target-plus-MTP layout and matched short

--- a/docs/cpu-kv-offload-development.md
+++ b/docs/cpu-kv-offload-development.md
@@ -18,6 +18,29 @@ add the transition and rationale here. Do not rewrite valid old measurements to
 claim new flags or geometry. The companion experiment ledger records curated
 per-change evidence.
 
+## Manifest-driven early-screen transition: 2026-08-22
+
+The prior current protocol defined exact provenance, clean-process GPU
+serialization, matched performance/resource fields, correctness, long-context,
+and profiler rules, but left each derived feature agent to assemble its own
+early launcher and artifact layout. That made early decisions unnecessarily
+slow and made otherwise similar feature investigations harder to compare.
+
+The current-testing protocol now requires the generic manifest runner for a
+new CPU-KV-derived performance or memory feature's early exactness,
+prefill/decode smoke, representative weighted screens, and resource telemetry.
+Optional regression diagnostics use independent direct-target NSYS discovery
+and verified filtered NCU capture for each variant; they remain explanatory
+rather than benchmark or acceptance evidence. Selection is by workload,
+layout, and backend capability, never by architecture or model name.
+
+This supersedes ad hoc early-screen orchestration only. It does not relabel
+historical measurements and does not relax the canonical server lifecycle,
+final long-context comparison, matching-batch perplexity and output exactness,
+clean-process proof, allocation accounting, or any feature-specific acceptance
+gate. A single matched fail-fast pair has no confidence claim; a clear signal
+authorizes deeper validation and nothing more.
+
 ## Evidence-curation transition: 2026-08-20
 
 Earlier editions asked agents to preserve invalid attempts and every historical

--- a/docs/feature-performance-validation-validation.md
+++ b/docs/feature-performance-validation-validation.md
@@ -1,0 +1,127 @@
+# Feature/performance toolkit validation
+
+This record covers the tooling implementation based on
+`f6341a15779eb58fe6ad9e1b890e331c32b676c7` on
+`tools/feature-performance-validation`. It is a toolkit validation, not a
+feature-performance result and not long-context acceptance for CPU KV offload
+or any other feature.
+
+The current usage and evidence boundaries are in
+[feature-performance-validation.md](feature-performance-validation.md).
+
+## CPU-only validation
+
+Static compilation and whitespace validation:
+
+```bash
+git diff --check
+PYTHONWARNINGS=error::ResourceWarning python3 -m py_compile \
+  scripts/feature_validation/*.py \
+  scripts/feature-performance-validation.py \
+  scripts/test-feature-validation.py
+```
+
+Result: pass, with no output.
+
+Focused schema, provenance, quoting/arity, profiler, and telemetry layers:
+
+```bash
+python3 scripts/test-feature-validation.py -v \
+  ManifestAndScheduleTest ProvenanceTest QuotingAndArityTest \
+  ProfilerTest TelemetryTest
+```
+
+Result: 22 tests passed in 0.552 seconds at that checkpoint.
+
+Final warning-as-error suite:
+
+```bash
+PYTHONWARNINGS=error::ResourceWarning \
+  python3 scripts/test-feature-validation.py -v
+```
+
+Result after the implementation/test commits: 31 tests passed in 8.379 seconds.
+The tests use temporary Git
+repositories, fake direct binaries, fake NVIDIA XML streams, fake profiler
+JSONL, and fake NSYS SQLite. They cover safe quoting, zero/one option arity,
+`--no-kv-offload` misuse, fail-closed provenance, workload-only selectors,
+controlled A/B settings, balanced fresh processes, three-to-five adaptive
+repetition, all raw paired statistics, persistent telemetry cleanup and
+contamination, profiler discovery/filters, resume, preserved failed attempts,
+and taskset/wrapper rejection.
+
+CTest registration was checked without compiling a production target:
+
+```bash
+cmake -S . -B build-tools-validation \
+  -DGGML_CUDA=OFF -DLLAMA_BUILD_TESTS=ON -DLLAMA_CURL=OFF \
+  -DCMAKE_BUILD_TYPE=Release
+ctest --test-dir build-tools-validation \
+  -R '^test-feature-performance-validation$' --output-on-failure
+```
+
+Result after the implementation/test commits: 1/1 test passed in 8.50 seconds.
+No build was launched; therefore no
+parallel build wider than `-j6` occurred.
+
+## Small real-GPU integration smoke
+
+The assigned worktree had no configured BeeLlama build, model, or prebuilt CUDA
+sample. The host did have CUDA 13.3 `nvcc` and one NVIDIA GeForce RTX 5070 Ti,
+so a temporary, uncommitted CUDA program was compiled outside Git. It performed
+one 4 MiB allocation, `cudaMemset`, synchronization, and a three-second hold so
+the approximately 1 Hz sampler could observe the process. The compile was a
+single compiler process:
+
+```bash
+/opt/cuda/bin/nvcc -O2 -arch=sm_120 \
+  /tmp/beellama-feature-validation-gpu-smoke/smoke.cu \
+  -o /tmp/beellama-feature-validation-gpu-smoke/gpu-smoke
+```
+
+The final valid integration command was:
+
+```bash
+flock /tmp/beellama-single-gpu.lock -c \
+  '/usr/bin/python3 /home/gencoolpc/beellama-feature-performance-validation/scripts/feature-performance-validation.py _execute-run /tmp/beellama-feature-validation-gpu-smoke/artifacts/run-spec-attempt-05.json'
+```
+
+Result: exit 0 in 3.480 seconds. The target printed
+`gpu-smoke=ok bytes=4194304`. The owned sampler produced four GPU XML samples
+and was reaped; the proc reader produced 14 samples. The report observed no
+foreign compute process, retained the 4 MiB Xorg graphics-only context as
+ambient, and recorded:
+
+- target process VRAM peak: 226 MiB from `nvidia-smi`;
+- process-tree VmRSS/VmHWM peak: 116252 KiB;
+- GPU temperature: 32-33 C;
+- instantaneous/average power field used by this driver: 16.90-46.07 W;
+- SM clock: 180-2490 MHz;
+- pinned host memory: not directly measured, `null`, and not inferred from
+  VmLck, VmPin, process VRAM, or the ordinary host-memory samples.
+
+Raw smoke artifacts remain outside Git at
+`/tmp/beellama-feature-validation-gpu-smoke/artifacts`. Only attempt 05 is the
+current integration evidence. No throughput, latency, exactness, model-memory,
+NSYS/NCU, BeeLlama end-to-end, or long-context claim is made from this smoke.
+
+## Coverage and limitations
+
+Automated and manual responsibilities are inventoried in the current how-to.
+Important present limitations are:
+
+- the ~1 Hz GPU sampler can miss sub-second peaks;
+- direct per-process pinned allocation bytes are unavailable;
+- the NSYS parser and NCU-plan derivation have hermetic fake-log/SQLite tests,
+  but no production profiler capture was appropriate without a matched
+  BeeLlama build and model;
+- no in-process copied CUDA A/B harness was added; a future harness must compile
+  production source or pass exact source hashes and remain production-aligned;
+- a final long-context campaign remains a mandatory per-feature acceptance
+  activity and was intentionally not run merely to validate this toolkit.
+
+Integration recommendation: review and integrate this as a tooling-only commit
+series. Use a fresh manifest outside the source tree for the first real feature,
+validate a matched clean build/model identity, tune the early stages to the
+30-90 second target, then keep production confirmation and final long-context
+acceptance as separate recorded gates.

--- a/docs/feature-performance-validation-validation.md
+++ b/docs/feature-performance-validation-validation.md
@@ -40,15 +40,17 @@ PYTHONWARNINGS=error::ResourceWarning \
   python3 scripts/test-feature-validation.py -v
 ```
 
-Result after the implementation/test commits: 31 tests passed in 8.379 seconds.
-The tests use temporary Git
+Merge-readiness result: 44 tests passed in 8.334 seconds with
+`ResourceWarning` promoted to an error. The tests use temporary Git
 repositories, fake direct binaries, fake NVIDIA XML streams, fake profiler
 JSONL, and fake NSYS SQLite. They cover safe quoting, zero/one option arity,
-`--no-kv-offload` misuse, fail-closed provenance, workload-only selectors,
+common-versus-`llama-bench` `--no-kv-offload` arity, fail-closed provenance,
+same-size/mtime-restored identity changes, workload-only selectors,
 controlled A/B settings, balanced fresh processes, three-to-five adaptive
 repetition, all raw paired statistics, persistent telemetry cleanup and
-contamination, profiler discovery/filters, resume, preserved failed attempts,
-and taskset/wrapper rejection.
+contamination, executed-versus-passed acceptance states, explicit NSYS
+graph-node support/capture checks, post-NCU report/count/shape verification,
+resume, preserved failed attempts, and taskset/wrapper rejection.
 
 CTest registration was checked without compiling a production target:
 
@@ -60,9 +62,69 @@ ctest --test-dir build-tools-validation \
   -R '^test-feature-performance-validation$' --output-on-failure
 ```
 
-Result after the implementation/test commits: 1/1 test passed in 8.50 seconds.
+Final result: 1/1 test passed in 8.38 seconds with `ResourceWarning` promoted
+to an error.
 No build was launched; therefore no
 parallel build wider than `-j6` occurred.
+
+## Merge-readiness checkpoint
+
+The coordinator review points are resolved as follows:
+
+- every performance stage has an explicit acceptable-decision policy;
+  `execution_status=completed` is separate from
+  `status=passed|failed|unresolved`, and regression/inconclusive final-gate
+  tests prove neither can emit `acceptance_complete`;
+- graph-capable profiling explicitly requests NSYS graph-node tracing, checks
+  exact-tool help/version support, and requires nonzero graph-node IDs in the
+  export;
+- the separate NCU report is required, hashed, re-imported, and checked for
+  discovery-derived kernel, unique capture count, and available shapes;
+  missing fields are unverifiable and cross-process launch order is never
+  assumed stable;
+- the local source-backed arity schema treats common-tool
+  `-nkvo`/`--no-kv-offload` as bare and both `llama-bench` spellings as valued;
+- large identity files are hashed once per fresh/resumed provenance capture,
+  while every child checks size, mtime, ctime, device, and inode; a test changes
+  content at the same size and restores mtime and confirms ctime fails closed;
+- duplicate identity-spec and GPU-lock launcher implementations and the legacy
+  single-executable manifest form were removed. The remaining modules have
+  one contract each: CLI orchestration, manifest/provenance/statistics,
+  lifecycle/state, telemetry ownership, and profiler parsing/planning.
+
+Read-only host capability verification used:
+
+```bash
+nsys profile --help=cuda
+nsys --version
+ncu --help
+ncu --version
+```
+
+The installed NSYS 2026.1.3 advertised `--cuda-graph-trace` with node
+granularity, and the toolkit capability check returned `status=supported` for
+`node:host-only`. NCU 2026.2.1 advertised graph-node profiling, report import,
+raw-page CSV, demangled print names, and kernel-name filtering. No profiler
+capture was claimed from these read-only checks.
+
+### Early-screen overhead
+
+A temporary clean Git fixture ran the complete fresh early ladder with all
+early stages marked `resource=gpu`. The target itself was the tiny fake direct
+binary; GPU integration here means the real flock/telemetry/clean-process
+lifecycle, not a CUDA performance result. The invocation promoted
+`ResourceWarning` to an error and preserved visible output in
+`/tmp/beellama-fperf-overhead-review.log`.
+
+Result: 32/32 separately locked processes passed in 38.932 seconds, inside the
+30-90 second target. All 32 persistent samplers were reaped, all clean-process
+checks passed, and the run retained 32 GPU XML plus 64 proc samples. Aggregate
+target time was 1.221 seconds; sampler startup was 3.383 seconds (about 0.106
+seconds/run on this host); per-run identity checks were 0.198 seconds; initial
+full provenance preparation was 0.064 seconds; and honest wall-minus-target
+overhead was 37.711 seconds. The runner now records locked-wrapper timing too,
+so future studies can separate lock/interpreter launch from in-executor time.
+No unmeasured cause is assigned to the remaining orchestration time.
 
 ## Small real-GPU integration smoke
 

--- a/docs/feature-performance-validation-validation.md
+++ b/docs/feature-performance-validation-validation.md
@@ -187,3 +187,73 @@ series. Use a fresh manifest outside the source tree for the first real feature,
 validate a matched clean build/model identity, tune the early stages to the
 30-90 second target, then keep production confirmation and final long-context
 acceptance as separate recorded gates.
+
+## Fast early-screen follow-up
+
+The first compact-causal application showed that applying the full 3-to-5
+statistical policy to every smoke and every low/mid/high screen produced 32
+fresh model processes and a 292.91-second cold early ladder. The runner now
+supports an explicit `single_pair_fail_fast` policy only for smoke and kernel-
+screen stages. It emits a raw point observation, `confidence_interval=null`,
+and `confidence_claim=none`; it cannot be used on production confirmation or
+long-context acceptance and cannot coexist with a statistical decision policy.
+
+The revised causal manifest ran 12 clean locked processes in 76.27 seconds.
+Its target processes used 67.81 seconds, preparation 6.20 seconds, recorded
+runner overhead 1.65 seconds, and lock-wrapper handoff 0.46 seconds. A warm
+resume completed in 6.24 seconds. Exactness passed, all samplers were reaped,
+and the three preregistered one-pair signals cleared their 1% fail-fast
+threshold. These signals are screening workflow evidence, not new confidence
+intervals or acceptance results.
+
+Final validation after this addition:
+
+```bash
+PYTHONWARNINGS=error::ResourceWarning \
+  python3 scripts/test-feature-validation.py -v
+```
+
+Result: 54 tests passed in 8.757 seconds.
+
+## Regression-triggered Nsight diagnostics follow-up
+
+The optional agent-diagnostic path adds no work to a passing early screen. With
+`--diagnose-regressions`, only a preserved preregistered
+`regression_signal` starts profiling; the screening command still exits
+nonzero. The diagnostic independently performs NSYS discovery and one filtered,
+post-export-verified NCU capture for baseline and candidate. It writes a compact
+side-by-side report while retaining raw launches, shapes, graph IDs, requested
+NCU metrics, timing, commands, and artifact paths. The report is explicitly
+diagnostic-only.
+
+Focused validation used:
+
+```bash
+PYTHONWARNINGS=error::ResourceWarning \
+  python3 scripts/test-feature-validation.py -v \
+  ManifestAndScheduleTest ProfilerTest DiagnosticCliTest
+```
+
+Result: 34 tests passed in 0.512 seconds. This covers schema/runtime
+preregistration, graph-node requirements, deterministic largest-regression
+span selection, zero profiler calls after a clear result, independent
+baseline/candidate orchestration, raw NCU metric exposure, agent-facing
+inventory/comparison output, preservation of the failed screening exit status,
+and fail-closed unverifiable capture handling.
+
+The final warning-as-error suite used:
+
+```bash
+PYTHONWARNINGS=error::ResourceWarning \
+  python3 scripts/test-feature-validation.py -v
+```
+
+Result: 64 tests passed in 9.515 seconds. Static Python compilation, all three
+checked-in manifest examples, JSON schema parsing, and `git diff --check` also
+passed. The registered CTest invocation also passed 1/1 in 9.68 seconds. No new
+GPU or Nsight capture was run for this follow-up: doing so would
+require deliberately producing a real preregistered regression in exact
+matched builds. Existing real-GPU and profiler evidence is not relabeled as a
+test of this new trigger. All actual NSYS/NCU target executions still use the
+whole-command GPU lock and direct llama affinity path shared with the production
+profiler.

--- a/docs/feature-performance-validation.md
+++ b/docs/feature-performance-validation.md
@@ -1,0 +1,269 @@
+# Feature/performance validation toolkit
+
+This is the current how-to for `scripts/feature-performance-validation.py`.
+The toolkit is developer tooling only. It does not add a runtime option, a
+production kernel, a model-family special case, or a build dependency. Python,
+NCU, and NSYS are not required to build BeeLlama; the runner itself uses only
+the Python standard library, and the NVIDIA profilers are optional runtime
+tools.
+
+The checked-in [manifest example](../examples/feature-performance-validation/manifest.example.json)
+is a template, not current evidence. Replace every absolute path, hash, commit,
+workload geometry, regex, threshold, and capability before running it. The
+machine-readable shape is
+[`scripts/feature_validation/manifest.schema.json`](../scripts/feature_validation/manifest.schema.json);
+the runner's fail-closed checks are authoritative.
+
+## Evidence boundary
+
+The validation ladder deliberately has three boundaries:
+
+1. **Early screening** runs output exactness first, short prefill and decode
+   smoke, then low/mid/high direct-command prefill screens. It is designed so a
+   typical tuned manifest can make an early decision in about 30-90 seconds.
+2. **Production confirmation** adds the production binary at a preregistered
+   selected context depth. NSYS discovery and the one filtered production NCU
+   capture attach here, not to every repetition.
+3. **Final acceptance** separately runs the mandatory long-context stage.
+
+An early result or an Nsight capture is never reported as proof of end-to-end
+performance, resource use, output exactness, or long-context behavior. A
+production-confirmation result is likewise not final acceptance. `summary.json`
+states which boundary was actually completed.
+
+The selector schema accepts workload properties, tensor-layout properties,
+backend capabilities, and execution mode. It rejects architecture and model
+family/name selectors. This makes the same ladder usable for live workspaces,
+VMM telemetry, allocation strategies, native-quant attention, causal-mask
+work, CPU KV placement, and future features.
+
+## Prepare a manifest
+
+Keep the manifest small and preregister it before collecting measurements.
+Large outputs must go to the absolute `artifact_root`, which the runner rejects
+if it is inside either source repository.
+
+For each baseline and candidate, record:
+
+- the source root, exact commit, and either a clean-tree requirement or one
+  exact dirty-tree fingerprint;
+- one or more executable roles with an expected SHA-256;
+- a discoverable CMake cache plus expected important options, or an explicit
+  reason CMake does not apply;
+- every shared model, prompt file, library-like input, or other material input
+  as a hashed `inputs` entry.
+
+The runner hashes the executable and all ELF libraries reported by `ldd`, saves
+the entire discoverable CMake cache, verifies the source commit/tree before the
+study and before each process, and fingerprints the inputs. A resume fails if
+any stable identity changed. Host provenance records tool versions, CPU and OS
+identity, and starting load. Profiler executions additionally hash the `nsys`
+or `ncu` binary actually launched.
+
+Place all matched workload settings in `command.common_args`. If the feature
+requires different arguments or environment between variants, copy the exact
+differences into `controlled_delta`, explain why, and list the allowed option
+and environment names. The validator rejects variant deltas that change model,
+prompt, repetitions, depth, batch/ubatch, threads, affinity, GPU placement,
+flash-attention mode, cache layout, or seed. It also parses option arity; for
+example, both of these are invalid because `--no-kv-offload` is zero-arity:
+
+```text
+--no-kv-offload 1
+--no-kv-offload=1
+```
+
+Unknown options fail unless their zero/one arity is declared in `cli_schema`.
+`taskset` is rejected anywhere. Shells, `env`, `flock`, `timeout`, Python, and
+other opaque wrappers cannot be profiler targets.
+
+Every stage needs a finite timeout and a visible progress description. Use the
+target's native progress option where it has one. The runner also emits a
+five-second heartbeat for long or unexpectedly stalled processes. If preparing
+a build for a study, do not build wider than `-j6`.
+
+## Ladder requirements
+
+The schema requires this order:
+
+- one exactness stage using a stdout or named-file SHA-256 comparison;
+- a short prefill smoke and a short decode smoke;
+- one prefill `direct_command` screen with low, mid, and high token spans;
+- one selected-depth `production_binary` confirmation;
+- one final mandatory `long_context_acceptance` stage.
+
+Decode smoke must state whether CUDA-graph replay applies. When it does, its
+execution mode must be `cuda_graph_replay` and the capability list must contain
+`cuda_graphs`. When it does not, the manifest must say why.
+
+Each direct prefill screen records `span_tokens`, the number of times that span
+occurs in the real ubatch geometry, and the same number as `weight`. Use a
+weighted harmonic aggregate for throughput and a weighted arithmetic aggregate
+for latency-like quantities. Do not invent weights to favor a result; derive
+them from the preregistered production prompt/ubatch geometry.
+
+## Validate and run
+
+Validation includes live provenance, so the untouched example intentionally
+fails until its placeholder paths and hashes are replaced.
+
+```bash
+python3 scripts/feature-performance-validation.py validate /absolute/path/to/manifest.json
+
+# Exactness, both short smokes, and the weighted direct screen.
+python3 scripts/feature-performance-validation.py run \
+  /absolute/path/to/manifest.json --through early
+
+# Resume the same deterministic study and add selected-depth confirmation.
+python3 scripts/feature-performance-validation.py run \
+  /absolute/path/to/manifest.json --through production --resume
+
+# The separate, mandatory final gate. This includes any earlier missing stage.
+python3 scripts/feature-performance-validation.py run \
+  /absolute/path/to/manifest.json --through acceptance --resume
+```
+
+The artifact directory is deterministic:
+`ARTIFACT_ROOT/STUDY_ID-MANIFEST_SHA256_PREFIX`. Every target is a fresh direct
+process. GPU runs are launched in the safely quoted whole-lifecycle form
+`flock /tmp/beellama-single-gpu.lock -c <internal-executor-command>`; the
+internal executor owns telemetry preflight, the direct target, and telemetry
+cleanup. Both the exact argv/environment command and the exact flock command
+are saved in each attempt.
+
+A successful run is skipped on `--resume`. A failed, timed-out, contaminated,
+or incomplete attempt is retained and stops the study. It is never dropped or
+overwritten. After correcting an external prerequisite, an explicit
+`--retry-failed` creates the next numbered attempt:
+
+```bash
+python3 scripts/feature-performance-validation.py run \
+  /absolute/path/to/manifest.json --through early --resume --retry-failed
+```
+
+Do not delete a failed attempt to make a report look complete. If the manifest
+or any provenance identity changes, start a new deterministic study rather
+than combining unlike runs.
+
+## Statistics
+
+Performance stages start with three independent matched pairs in balanced
+order `AB, BA, AB`. Each observation is a new process. The runner calculates
+candidate/baseline paired log ratios, their geometric percent change, and a
+two-sided Student-t 95% interval. The report includes every raw per-screen and
+per-pair sample.
+
+The manifest preregisters improvement, regression, and equivalence effects. A
+three-pair result extends to pairs four and five, in `BA, AB` order, only when
+the confidence interval and effect thresholds classify it as inconclusive. A
+conclusive three-pair result records pairs four and five as
+`not_run_by_preregistered_conclusive_rule`. No subset selection, silent run
+dropping, threshold changes, or post-hoc extension is supported.
+
+## Telemetry and clean-process evidence
+
+Each locked GPU lifecycle starts exactly one persistent approximately 1 Hz
+`nvidia-smi -q -x -l 1` process. It is not a loop that spawns `nvidia-smi` and
+`awk` every 250 ms. The first XML sample is a clean-GPU preflight; an existing
+compute-capable (`C`/`C+G`, or unknown-type) process aborts the attempt. Ambient
+graphics-only contexts such as a display server are recorded separately and do
+not masquerade as benchmark processes. Subsequent samples retain GPU/driver
+identity, clocks, temperature, power, device memory, and per-process VRAM.
+
+A separate lightweight reader samples `/proc/PID/status` for the target process
+tree and relevant `/proc/meminfo` fields. Reports keep three concepts separate:
+
+- process VRAM comes from NVIDIA's per-process used-memory field;
+- ordinary host memory comes from process-tree VmRSS/VmHWM and related proc
+  status plus host meminfo;
+- pinned host memory is `null` unless a future direct allocation counter is
+  added.
+
+`VmLck`, `VmPin`, and process VRAM are retained only as observations and are
+never converted into a pinned-memory claim. The sampler is started in its own
+owned process group, terminated in every success/error/timeout path, joined,
+and reported as reaped. A foreign GPU process seen during the target makes the
+attempt invalid.
+
+The roughly 1 Hz GPU cadence can miss a sub-second peak; use a named manual
+allocation audit when exact transient or page-locked allocation accounting is
+an acceptance requirement.
+
+## NSYS discovery and NCU capture
+
+The optional profiler section must target the selected-depth production stage
+and sets `profile_repetitions` to one. For the established CPU 0-2
+`llama-bench` shape, the direct target must carry `-C 0x7 --cpu-strict 1`.
+Other direct llama tools must carry `--cpu-strict 1` plus both native
+`--cpu-range` and `--cpu-range-batch` controls. Never put `taskset` before or
+after a profiler.
+
+```bash
+# One locked direct-target NSYS discovery, SQLite export, parse, and NCU plan.
+python3 scripts/feature-performance-validation.py profile \
+  /absolute/path/to/manifest.json
+
+# Execute the one discovery-derived filtered production NCU capture later.
+python3 scripts/feature-performance-validation.py profile \
+  /absolute/path/to/manifest.json --resume --execute-ncu
+```
+
+The NSYS SQLite parser inventories kernel names, graph-node IDs, grid/block
+shapes, counts, chronological launch indices, and same-name occurrence indices.
+The selector is applied to that inventory. The runner emits one exact-name NCU
+command only when the selected occurrences form one contiguous range after the
+kernel filter; otherwise it fails closed and asks for a narrower discovery or
+selector. Thus `--launch-skip` and `--launch-count` are derived for the current
+binary, hardware, and capture rather than copied between builds. Re-run NSYS
+after any relevant identity changes.
+
+Profiler output is a kernel investigation, not a benchmark repetition. The
+intended pattern is one production NSYS discovery followed by one filtered
+production NCU capture for a preregistered question.
+
+## Direct harnesses
+
+A normal executable role is already a pluggable direct-command path. A small
+native harness may be used as a profiler target only when its executable role
+declares `direct_harness.kind=native_executable`, native llama affinity, and an
+expected SHA-256 for every production source file it depends on. Any mismatch
+fails before execution.
+
+This toolkit intentionally does **not** add a copied CUDA-event A/B harness.
+The causal-mask investigation showed that a small copy quickly acquires
+production launch, tail-padding, graph, and source-identity coupling. A bounded
+follow-up is appropriate only when it can compile production source directly,
+interleave A/B CUDA-event measurements, weight representative prefill spans by
+real ubatch geometry, and replay representative decode CUDA graphs without a
+parallel implementation. Until then, use the reusable direct-command path.
+
+## Automated versus manual
+
+Automated:
+
+- schema/arity/selector validation and controlled A/B deltas;
+- source, binary, ELF-library, CMake-cache, input, host, and profiler identity;
+- deterministic artifacts, balanced clean processes, progress, resume, and
+  preserved failures;
+- exactness ordering, short smokes, weighted screens, selected-depth and final
+  stage separation;
+- paired statistics and the preregistered 3-to-5 extension rule;
+- persistent GPU/proc telemetry and sampler cleanup;
+- NSYS SQLite discovery inventory and the derived one-command NCU plan.
+
+Manual and study-specific:
+
+- choosing representative workloads, layouts, capability declarations,
+  thresholds, context depths, and real ubatch weights;
+- preparing clean matched builds and models (with build parallelism no wider
+  than `-j6`);
+- deciding whether direct pinned-memory instrumentation or a VMM/allocation
+  trace is required;
+- reviewing raw logs, contamination flags, thermals/clocks, and host load;
+- running and interpreting the final long-context campaign for the feature,
+  rather than treating an early toolkit smoke as acceptance.
+
+Keep `.nsys-rep`, SQLite, NCU reports, stdout/stderr, and telemetry JSON outside
+Git. Check in only a schema/inventory or a concise truthful summary of valid
+evidence. Never promote a launcher failure, wrong identity, contaminated run,
+historical capture, or incomplete long-context run as current evidence.

--- a/docs/feature-performance-validation.md
+++ b/docs/feature-performance-validation.md
@@ -19,8 +19,9 @@ the runner's fail-closed checks are authoritative.
 The validation ladder deliberately has three boundaries:
 
 1. **Early screening** runs output exactness first, short prefill and decode
-   smoke, then low/mid/high direct-command prefill screens. It is designed so a
-   typical tuned manifest can make an early decision in about 30-90 seconds.
+   smoke, then low/mid/high direct-command prefill screens. Early-only stages
+   may preregister one matched fail-fast pair with no confidence claim; this is
+   the recommended way to keep a typical tuned manifest near 30-90 seconds.
 2. **Production confirmation** adds the production binary at a preregistered
    selected context depth. NSYS discovery and the one filtered production NCU
    capture attach here, not to every repetition.
@@ -114,6 +115,28 @@ weighted harmonic aggregate for throughput and a weighted arithmetic aggregate
 for latency-like quantities. Do not invent weights to favor a result; derive
 them from the preregistered production prompt/ubatch geometry.
 
+For a fast ladder, add `screening_policy` to the two smoke stages and the
+kernel screen:
+
+```json
+{
+  "kind": "single_pair_fail_fast",
+  "order": "AB",
+  "regression_threshold_percent": 2.0,
+  "confidence_claim": "none"
+}
+```
+
+This executes exactly one fresh base/candidate pair. Alternate `AB` and `BA`
+between adjacent early stages to limit systematic order bias. The result keeps
+the raw pair, weighted per-screen values, point change, and preregistered
+regression signal. It deliberately records `confidence_interval=null` and
+cannot claim improvement, equivalence, or acceptance. A regression signal
+stops the ladder; a clear signal only authorizes moving to the statistical
+production gate. `screening_policy` is rejected on production confirmation or
+long-context acceptance, and it is mutually exclusive with statistical
+`decision_policy`.
+
 ## Validate and run
 
 Validation includes live provenance, so the untouched example intentionally
@@ -165,8 +188,10 @@ than combining unlike runs.
 
 ## Statistics
 
-Performance stages start with three independent matched pairs in balanced
-order `AB, BA, AB`. Each observation is a new process. The runner calculates
+Statistical stages start with three independent matched pairs in balanced order
+`AB, BA, AB`. This includes production confirmation and final acceptance, and
+any early stage that intentionally omits `screening_policy`. Each observation
+is a new process. The runner calculates
 candidate/baseline paired log ratios, their geometric percent change, and a
 two-sided Student-t 95% interval. The report includes every raw per-screen and
 per-pair sample.
@@ -216,8 +241,15 @@ an acceptance requirement.
 
 ## NSYS discovery and NCU capture
 
-The optional profiler section must target the selected-depth production stage
-and sets `profile_repetitions` to one. For the established CPU 0-2
+Two profiler paths share the same fail-closed direct-target implementation:
+
+- `profiler` answers one preregistered production-stage investigation.
+- `early_diagnostics` is an opt-in response to a preserved early
+  `regression_signal`. It never runs after a clear screen and cannot change the
+  failed screening result.
+
+The optional production profiler must target the selected-depth production
+stage and sets `profile_repetitions` to one. For the established CPU 0-2
 `llama-bench` shape, the direct target must carry `-C 0x7 --cpu-strict 1`.
 Other direct llama tools must carry `--cpu-strict 1` plus both native
 `--cpu-range` and `--cpu-range-batch` controls. Never put `taskset` before or
@@ -262,6 +294,65 @@ Profiler output is a kernel investigation, not a benchmark repetition. The
 intended pattern is one production NSYS discovery followed by one filtered
 production NCU capture for a preregistered question.
 
+### Regression-triggered agent diagnostics
+
+An early diagnostic entry must name a smoke or direct-kernel stage that uses
+`single_pair_fail_fast`, declare `trigger=regression_signal_only`,
+`on_clear=skip`, `evidence_claim=diagnostic_only`, and target both variants in
+baseline/candidate order. It also preregisters the kernel-family selector,
+metrics, graph-trace applicability, and one of these screen policies:
+
+- `fixed` names the one screen to inspect.
+- `largest_observed_regression` deterministically selects the most negative
+  benefit among the preserved raw matched screen observations. The report
+  retains every span and the selection calculation; it does not select a
+  favorable subset.
+
+The checked-in manifest example contains the complete schema. To opt in while
+running the early ladder:
+
+```bash
+python3 scripts/feature-performance-validation.py run \
+  /absolute/path/to/manifest.json --through early --diagnose-regressions
+```
+
+A clear early result pays no profiler or extra provenance-hashing cost. If the
+stage reports a regression, the runner remains failed and launches a diagnostic
+phase. It performs an independent NSYS discovery and one discovery-derived,
+verified NCU capture for baseline, then repeats that sequence independently for
+candidate. Kernel spelling, shapes, graph-node IDs, occurrences, and launch
+indices are never transferred between binaries. This costs more than the fast
+screen by design and is reported separately from its 30-90 second budget.
+
+If the screen was run without the flag, or a partial diagnostic must be safely
+resumed, use:
+
+```bash
+python3 scripts/feature-performance-validation.py diagnose \
+  /absolute/path/to/manifest.json
+
+python3 scripts/feature-performance-validation.py diagnose \
+  /absolute/path/to/manifest.json --resume
+```
+
+The deterministic
+`early-diagnostics/agent-diagnostic-report.json` exposes, for each variant:
+
+- NSYS total/matching/selected launch counts, exact kernel, discovery indices,
+  same-name occurrences, shapes, and graph-node IDs;
+- verified NCU capture count, raw per-capture requested metric values, and any
+  verification issues;
+- NSYS/NCU target and locked-lifecycle timing plus paths to the raw reports,
+  inventory, plan, stdout/stderr, and verification record.
+
+Graph-replay diagnostics must request node tracing explicitly and verify
+nonzero graph-node IDs under the exact NSYS version. Missing tools, unsupported
+graph tracing, empty/mismatched exports, contamination, or cross-process
+launch-order drift fail the diagnostic and remain visible in its report. The
+compact report is intended to give an optimization agent an immediate lead; it
+does not convert Nsight counters into correctness, equivalence, end-to-end
+speed, memory, production, or long-context evidence.
+
 ## Direct harnesses
 
 A normal executable role is already a pluggable direct-command path. A small
@@ -293,6 +384,8 @@ Automated:
 - persistent GPU/proc telemetry and sampler cleanup;
 - explicit NSYS graph-node capability/capture verification, the derived
   one-command NCU plan, and post-NCU report verification.
+- opt-in early-regression diagnostics with deterministic span selection,
+  independent per-variant discovery/capture, and a compact agent-facing report.
 
 Manual and study-specific:
 

--- a/docs/feature-performance-validation.md
+++ b/docs/feature-performance-validation.md
@@ -29,7 +29,8 @@ The validation ladder deliberately has three boundaries:
 An early result or an Nsight capture is never reported as proof of end-to-end
 performance, resource use, output exactness, or long-context behavior. A
 production-confirmation result is likewise not final acceptance. `summary.json`
-states which boundary was actually completed.
+states which boundary was executed and which gate actually passed. Merely
+completing every process is not acceptance.
 
 The selector schema accepts workload properties, tensor-layout properties,
 backend capabilities, and execution mode. It rejects architecture and model
@@ -53,25 +54,36 @@ For each baseline and candidate, record:
 - every shared model, prompt file, library-like input, or other material input
   as a hashed `inputs` entry.
 
-The runner hashes the executable and all ELF libraries reported by `ldd`, saves
-the entire discoverable CMake cache, verifies the source commit/tree before the
-study and before each process, and fingerprints the inputs. A resume fails if
-any stable identity changed. Host provenance records tool versions, CPU and OS
-identity, and starting load. Profiler executions additionally hash the `nsys`
-or `ncu` binary actually launched.
+The runner hashes the executable, all ELF libraries reported by `ldd`, inputs,
+harness sources, the CMake cache, and `nvidia-smi` once at fresh-study or resume
+provenance capture. Each child then compares size, mtime, ctime, device, and inode to
+that cryptographic capture, while source commit/tree identity is rechecked for
+every process. This avoids repeatedly hashing a large model and shared-library
+set without allowing a changed file to pass silently; every new invocation or
+resume performs the full hashes again. Host provenance records tool versions,
+CPU and OS identity, and starting load. Profiler executions additionally hash
+the `nsys` or `ncu` binary actually launched.
 
 Place all matched workload settings in `command.common_args`. If the feature
 requires different arguments or environment between variants, copy the exact
 differences into `controlled_delta`, explain why, and list the allowed option
 and environment names. The validator rejects variant deltas that change model,
 prompt, repetitions, depth, batch/ubatch, threads, affinity, GPU placement,
-flash-attention mode, cache layout, or seed. It also parses option arity; for
-example, both of these are invalid because `--no-kv-offload` is zero-arity:
+flash-attention mode, cache layout, or seed. It also parses target-specific
+option arity. Common-argument binaries such as `llama-cli`, `llama-server`, and
+`llama-perplexity` use bare `-nkvo`/`--no-kv-offload`; both of these are invalid
+for those targets:
 
 ```text
 --no-kv-offload 1
 --no-kv-offload=1
 ```
+
+`llama-bench` has a separate parser: both `-nkvo` and
+`--no-kv-offload` require a `0` or `1` value. The built-in llama schema derives
+that distinction from the direct executable name, so the valid bench long
+alias is not mistaken for the common zero-arity flag. A local harness must use
+`builtin=none` and explicitly declare its option arities.
 
 Unknown options fail unless their zero/one arity is declared in `cli_schema`.
 `taskset` is rejected anywhere. Shells, `env`, `flock`, `timeout`, Python, and
@@ -131,6 +143,12 @@ internal executor owns telemetry preflight, the direct target, and telemetry
 cleanup. Both the exact argv/environment command and the exact flock command
 are saved in each attempt.
 
+Each attempt records identity-check, telemetry-startup, target, cleanup, and
+locked-wrapper timing. A fresh `summary.json` aggregates those fields and
+reports wall-minus-target overhead against the 30-90 second early target. Use
+the fresh-study numbers for overhead decisions; a resume summary reuses prior
+attempt artifacts and therefore labels its timing mode as `resume`.
+
 A successful run is skipped on `--resume`. A failed, timed-out, contaminated,
 or incomplete attempt is retained and stops the study. It is never dropped or
 overwritten. After correcting an external prerequisite, an explicit
@@ -159,6 +177,13 @@ the confidence interval and effect thresholds classify it as inconclusive. A
 conclusive three-pair result records pairs four and five as
 `not_run_by_preregistered_conclusive_rule`. No subset selection, silent run
 dropping, threshold changes, or post-hoc extension is supported.
+
+Every performance stage also preregisters `decision_policy`. Only
+`improvement` and/or `equivalent` may be acceptable; a regression always fails,
+and an inconclusive result after five pairs is explicitly unresolved and fails
+closed. Stage records keep `execution_status=completed` separate from
+`status=passed|failed|unresolved`. `acceptance_complete` is emitted only when
+the final mandatory long-context gate passed its policy.
 
 ## Telemetry and clean-process evidence
 
@@ -208,6 +233,14 @@ python3 scripts/feature-performance-validation.py profile \
   /absolute/path/to/manifest.json --resume --execute-ncu
 ```
 
+For a graph-capable or graph-only stage, `cuda_graph_trace` must preregister
+node tracing and its launch origin. Before launch, the runner inspects the exact
+NSYS binary's version/help for `--cuda-graph-trace` node support. It then passes
+the explicit option (normally `--cuda-graph-trace=node:host-only`) and rejects
+an export with no nonzero graph-node IDs. Unsupported tool versions therefore
+fail before or immediately after discovery instead of silently producing a
+non-graph inventory.
+
 The NSYS SQLite parser inventories kernel names, graph-node IDs, grid/block
 shapes, counts, chronological launch indices, and same-name occurrence indices.
 The selector is applied to that inventory. The runner emits one exact-name NCU
@@ -216,6 +249,14 @@ kernel filter; otherwise it fails closed and asks for a narrower discovery or
 selector. Thus `--launch-skip` and `--launch-count` are derived for the current
 binary, hardware, and capture rather than copied between builds. Re-run NSYS
 after any relevant identity changes.
+
+After the separate NCU process, the runner requires the expected nonempty
+`.ncu-rep`, hashes it, imports its raw CSV with the same NCU binary, and checks
+the observed demangled kernel, unique capture count, and available grid/block
+shapes against the NSYS-derived plan. Missing report fields are
+`unverifiable`; mismatches fail. This post-capture check accounts for
+cross-process launch-order drift rather than assuming the discovery skip/count
+still selected the intended work.
 
 Profiler output is a kernel investigation, not a benchmark repetition. The
 intended pattern is one production NSYS discovery followed by one filtered
@@ -248,8 +289,10 @@ Automated:
 - exactness ordering, short smokes, weighted screens, selected-depth and final
   stage separation;
 - paired statistics and the preregistered 3-to-5 extension rule;
+- executed-versus-passed gate state and fail-closed final acceptance;
 - persistent GPU/proc telemetry and sampler cleanup;
-- NSYS SQLite discovery inventory and the derived one-command NCU plan.
+- explicit NSYS graph-node capability/capture verification, the derived
+  one-command NCU plan, and post-NCU report verification.
 
 Manual and study-specific:
 
@@ -267,3 +310,16 @@ Keep `.nsys-rep`, SQLite, NCU reports, stdout/stderr, and telemetry JSON outside
 Git. Check in only a schema/inventory or a concise truthful summary of valid
 evidence. Never promote a launcher failure, wrong identity, contaminated run,
 historical capture, or incomplete long-context run as current evidence.
+
+## Maintenance boundary
+
+The implementation is intentionally split into a thin CLI, manifest/provenance
+and statistics core, clean-process runner, telemetry owner, and profiler
+parser/planner. The merge-readiness pass removed duplicate provenance-spec and
+GPU-lock launch implementations and removed the legacy single-executable
+manifest shape; the JSON schema and runtime now use the same executable-role
+contract. The remaining roughly 3.5k standard-library Python lines are mostly
+fail-closed validation, artifact inventory, lifecycle cleanup, and parsers with
+separate tests. There is no copied CUDA framework or project build dependency.
+Further code should enter a new module only when it has an independent
+lifecycle or artifact contract, rather than growing another parallel runner.

--- a/examples/feature-performance-validation/manifest.example.json
+++ b/examples/feature-performance-validation/manifest.example.json
@@ -1,0 +1,360 @@
+{
+  "schema_version": 1,
+  "study": {
+    "id": "feature-ab-screen",
+    "description": "Replace every absolute path, identity, workload geometry, and threshold before use.",
+    "early_decision_target_seconds": {
+      "minimum": 30,
+      "maximum": 90
+    }
+  },
+  "artifact_root": "/absolute/path/outside/source/feature-validation-artifacts",
+  "variants": {
+    "baseline": {
+      "source_root": "/absolute/path/to/clean/baseline/source",
+      "expected_commit": "f6341a15779eb58fe6ad9e1b890e331c32b676c7",
+      "tree_policy": "clean",
+      "executables": {
+        "correctness": {
+          "path": "/absolute/path/to/baseline/build/bin/llama-cli",
+          "expected_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+          "build": {
+            "mode": "cmake_required",
+            "cache": "/absolute/path/to/baseline/build/CMakeCache.txt",
+            "expected_options": {
+              "GGML_CUDA": "ON",
+              "GGML_CUDA_FA": "ON",
+              "CMAKE_BUILD_TYPE": "Release"
+            }
+          }
+        },
+        "benchmark": {
+          "path": "/absolute/path/to/baseline/build/bin/llama-bench",
+          "expected_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "build": {
+            "mode": "cmake_required",
+            "cache": "/absolute/path/to/baseline/build/CMakeCache.txt",
+            "expected_options": {
+              "GGML_CUDA": "ON",
+              "GGML_CUDA_FA": "ON",
+              "CMAKE_BUILD_TYPE": "Release"
+            }
+          }
+        }
+      }
+    },
+    "candidate": {
+      "source_root": "/absolute/path/to/clean/candidate/source",
+      "expected_commit": "2222222222222222222222222222222222222222",
+      "tree_policy": "clean",
+      "executables": {
+        "correctness": {
+          "path": "/absolute/path/to/candidate/build/bin/llama-cli",
+          "expected_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "build": {
+            "mode": "cmake_required",
+            "cache": "/absolute/path/to/candidate/build/CMakeCache.txt",
+            "expected_options": {
+              "GGML_CUDA": "ON",
+              "GGML_CUDA_FA": "ON",
+              "CMAKE_BUILD_TYPE": "Release"
+            }
+          }
+        },
+        "benchmark": {
+          "path": "/absolute/path/to/candidate/build/bin/llama-bench",
+          "expected_sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "build": {
+            "mode": "cmake_required",
+            "cache": "/absolute/path/to/candidate/build/CMakeCache.txt",
+            "expected_options": {
+              "GGML_CUDA": "ON",
+              "GGML_CUDA_FA": "ON",
+              "CMAKE_BUILD_TYPE": "Release"
+            }
+          }
+        }
+      }
+    }
+  },
+  "inputs": [
+    {
+      "role": "shared-model",
+      "path": "/absolute/path/to/model.gguf",
+      "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+    }
+  ],
+  "environment": {
+    "CUDA_VISIBLE_DEVICES": "0"
+  },
+  "repetition_policy": {
+    "minimum_pairs": 3,
+    "maximum_pairs": 5,
+    "order": ["AB", "BA", "AB", "BA", "AB"],
+    "confidence_level": 0.95,
+    "extension_rule": {
+      "kind": "extend_only_if_inconclusive",
+      "thresholds": {
+        "improvement_percent": 2.0,
+        "regression_percent": 2.0,
+        "equivalence_percent": 1.0
+      }
+    }
+  },
+  "stages": [
+    {
+      "id": "output-exactness",
+      "purpose": "exactness",
+      "resource": "gpu",
+      "timeout_seconds": 30,
+      "mandatory": true,
+      "progress": "short fixed generation writes tokens to stdout",
+      "selection": {
+        "workload": "exactness",
+        "tensor_layout": {"k": "q8_0", "v": "q8_0", "query_width": 1},
+        "backend_capabilities": ["direct_standard_quant_attention"],
+        "execution_mode": "direct_process"
+      },
+      "command": {
+        "executable_role": "correctness",
+        "common_args": [
+          "-m", "/absolute/path/to/model.gguf", "-p", "Fixed exactness prompt", "-n", "16",
+          "--seed", "1234", "-C", "0x7", "--cpu-strict", "1", "--no-warmup"
+        ],
+        "baseline_args": [],
+        "candidate_args": ["--no-kv-offload"],
+        "cli_schema": {"builtin": "llama", "allow_positionals": false},
+        "controlled_delta": {
+          "reason": "the preregistered feature toggle is the only runtime difference",
+          "baseline_args": [],
+          "candidate_args": ["--no-kv-offload"],
+          "baseline_environment": {},
+          "candidate_environment": {},
+          "allowed_options": ["--no-kv-offload"],
+          "allowed_environment": []
+        }
+      },
+      "comparison": {"mode": "stdout_sha256"}
+    },
+    {
+      "id": "short-prefill-smoke",
+      "purpose": "smoke",
+      "resource": "gpu",
+      "timeout_seconds": 20,
+      "mandatory": true,
+      "progress": "llama-bench --progress",
+      "selection": {
+        "workload": "prefill",
+        "tensor_layout": {"k": "q8_0", "v": "q8_0", "query_width": 128},
+        "backend_capabilities": ["direct_standard_quant_attention"],
+        "execution_mode": "direct_process",
+        "duration_class": "short"
+      },
+      "command": {
+        "executable_role": "benchmark",
+        "common_args": [
+          "-m", "/absolute/path/to/model.gguf", "-p", "128", "-n", "0", "-r", "1",
+          "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
+        ],
+        "baseline_args": [],
+        "candidate_args": ["--no-kv-offload"],
+        "cli_schema": {"builtin": "llama", "allow_positionals": false},
+        "controlled_delta": {
+          "reason": "the preregistered feature toggle is the only runtime difference",
+          "baseline_args": [],
+          "candidate_args": ["--no-kv-offload"],
+          "baseline_environment": {},
+          "candidate_environment": {},
+          "allowed_options": ["--no-kv-offload"],
+          "allowed_environment": []
+        }
+      },
+      "metric": {
+        "stream": "combined",
+        "regex": "\\|[^|]*\\|\\s*([0-9]+(?:\\.[0-9]+)?)\\s*±",
+        "match": "last",
+        "direction": "higher"
+      }
+    },
+    {
+      "id": "short-graph-decode-smoke",
+      "purpose": "smoke",
+      "resource": "gpu",
+      "timeout_seconds": 20,
+      "mandatory": true,
+      "progress": "llama-bench --progress",
+      "selection": {
+        "workload": "decode",
+        "tensor_layout": {"k": "q8_0", "v": "q8_0", "query_width": 1},
+        "backend_capabilities": ["direct_standard_quant_attention", "cuda_graphs"],
+        "execution_mode": "cuda_graph_replay",
+        "duration_class": "short",
+        "cuda_graph_replay": {"applicability": "required"}
+      },
+      "command": {
+        "executable_role": "benchmark",
+        "common_args": [
+          "-m", "/absolute/path/to/model.gguf", "-p", "0", "-n", "16", "-r", "1",
+          "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
+        ],
+        "baseline_args": [],
+        "candidate_args": ["--no-kv-offload"],
+        "cli_schema": {"builtin": "llama", "allow_positionals": false},
+        "controlled_delta": {
+          "reason": "the preregistered feature toggle is the only runtime difference",
+          "baseline_args": [],
+          "candidate_args": ["--no-kv-offload"],
+          "baseline_environment": {},
+          "candidate_environment": {},
+          "allowed_options": ["--no-kv-offload"],
+          "allowed_environment": []
+        }
+      },
+      "metric": {
+        "stream": "combined",
+        "regex": "\\|[^|]*\\|\\s*([0-9]+(?:\\.[0-9]+)?)\\s*±",
+        "match": "last",
+        "direction": "higher"
+      }
+    },
+    {
+      "id": "weighted-prefill-screen",
+      "purpose": "kernel_screen",
+      "resource": "gpu",
+      "timeout_seconds": 20,
+      "mandatory": true,
+      "progress": "llama-bench --progress and one runner line per low/mid/high screen",
+      "selection": {
+        "workload": "prefill",
+        "tensor_layout": {"k": "q8_0", "v": "q8_0", "ubatch_tokens": 256},
+        "backend_capabilities": ["direct_standard_quant_attention"],
+        "execution_mode": "direct_command"
+      },
+      "command": {
+        "executable_role": "benchmark",
+        "common_args": [
+          "-m", "/absolute/path/to/model.gguf", "-n", "0", "-r", "1", "-b", "512", "-ub", "256",
+          "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
+        ],
+        "baseline_args": [],
+        "candidate_args": ["--no-kv-offload"],
+        "cli_schema": {"builtin": "llama", "allow_positionals": false},
+        "controlled_delta": {
+          "reason": "the preregistered feature toggle is the only runtime difference",
+          "baseline_args": [],
+          "candidate_args": ["--no-kv-offload"],
+          "baseline_environment": {},
+          "candidate_environment": {},
+          "allowed_options": ["--no-kv-offload"],
+          "allowed_environment": []
+        }
+      },
+      "screens": [
+        {"id": "low", "span_class": "low", "span_tokens": 64, "ubatch_occurrences": 4, "args": ["-p", "64"], "weight": 4},
+        {"id": "mid", "span_class": "mid", "span_tokens": 256, "ubatch_occurrences": 8, "args": ["-p", "256"], "weight": 8},
+        {"id": "high", "span_class": "high", "span_tokens": 1024, "ubatch_occurrences": 4, "args": ["-p", "1024"], "weight": 4}
+      ],
+      "aggregation": {"mode": "weighted_harmonic", "weight_source": "real_ubatch_geometry"},
+      "metric": {
+        "stream": "combined",
+        "regex": "\\|[^|]*\\|\\s*([0-9]+(?:\\.[0-9]+)?)\\s*±",
+        "match": "last",
+        "direction": "higher"
+      }
+    },
+    {
+      "id": "selected-depth-production",
+      "purpose": "production_confirmation",
+      "resource": "gpu",
+      "timeout_seconds": 45,
+      "mandatory": true,
+      "progress": "llama-bench --progress",
+      "selection": {
+        "workload": "decode",
+        "tensor_layout": {"k": "q8_0", "v": "q8_0", "query_width": 1},
+        "backend_capabilities": ["direct_standard_quant_attention", "cuda_graphs"],
+        "execution_mode": "production_binary",
+        "context_depth_tokens": 4096
+      },
+      "command": {
+        "executable_role": "benchmark",
+        "common_args": [
+          "-m", "/absolute/path/to/model.gguf", "-p", "0", "-n", "32", "-d", "4096", "-r", "1",
+          "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
+        ],
+        "baseline_args": [],
+        "candidate_args": ["--no-kv-offload"],
+        "cli_schema": {"builtin": "llama", "allow_positionals": false},
+        "controlled_delta": {
+          "reason": "the preregistered feature toggle is the only runtime difference",
+          "baseline_args": [],
+          "candidate_args": ["--no-kv-offload"],
+          "baseline_environment": {},
+          "candidate_environment": {},
+          "allowed_options": ["--no-kv-offload"],
+          "allowed_environment": []
+        }
+      },
+      "metric": {
+        "stream": "combined",
+        "regex": "\\|[^|]*\\|\\s*([0-9]+(?:\\.[0-9]+)?)\\s*±",
+        "match": "last",
+        "direction": "higher"
+      }
+    },
+    {
+      "id": "final-long-context-acceptance",
+      "purpose": "long_context_acceptance",
+      "resource": "gpu",
+      "timeout_seconds": 1800,
+      "mandatory": true,
+      "progress": "llama-bench --progress",
+      "selection": {
+        "workload": "decode",
+        "tensor_layout": {"k": "q8_0", "v": "q8_0", "query_width": 1},
+        "backend_capabilities": ["direct_standard_quant_attention", "cuda_graphs"],
+        "execution_mode": "production_binary",
+        "context_depth_tokens": 32768,
+        "acceptance_class": "long_context"
+      },
+      "command": {
+        "executable_role": "benchmark",
+        "common_args": [
+          "-m", "/absolute/path/to/model.gguf", "-p", "0", "-n", "32", "-d", "32768", "-r", "1",
+          "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
+        ],
+        "baseline_args": [],
+        "candidate_args": ["--no-kv-offload"],
+        "cli_schema": {"builtin": "llama", "allow_positionals": false},
+        "controlled_delta": {
+          "reason": "the preregistered feature toggle is the only runtime difference",
+          "baseline_args": [],
+          "candidate_args": ["--no-kv-offload"],
+          "baseline_environment": {},
+          "candidate_environment": {},
+          "allowed_options": ["--no-kv-offload"],
+          "allowed_environment": []
+        }
+      },
+      "metric": {
+        "stream": "combined",
+        "regex": "\\|[^|]*\\|\\s*([0-9]+(?:\\.[0-9]+)?)\\s*±",
+        "match": "last",
+        "direction": "higher"
+      }
+    }
+  ],
+  "profiler": {
+    "pattern": "one_nsys_discovery_then_one_filtered_ncu",
+    "profile_repetitions": 1,
+    "stage": "selected-depth-production",
+    "variant": "candidate",
+    "screen": "default",
+    "timeout_seconds": 300,
+    "selector": {
+      "kernel_regex": "replace-with-discovered-production-kernel-regex",
+      "graph_only": true
+    },
+    "metrics": ["gpu__time_duration.sum"]
+  }
+}

--- a/examples/feature-performance-validation/manifest.example.json
+++ b/examples/feature-performance-validation/manifest.example.json
@@ -142,10 +142,11 @@
       "resource": "gpu",
       "timeout_seconds": 20,
       "mandatory": true,
-      "decision_policy": {
-        "acceptable_decisions": ["improvement", "equivalent"],
-        "regression": "fail",
-        "inconclusive_after_maximum": "unresolved_fail"
+      "screening_policy": {
+        "kind": "single_pair_fail_fast",
+        "order": "AB",
+        "regression_threshold_percent": 5.0,
+        "confidence_claim": "none"
       },
       "progress": "llama-bench --progress",
       "selection": {
@@ -187,10 +188,11 @@
       "resource": "gpu",
       "timeout_seconds": 20,
       "mandatory": true,
-      "decision_policy": {
-        "acceptable_decisions": ["improvement", "equivalent"],
-        "regression": "fail",
-        "inconclusive_after_maximum": "unresolved_fail"
+      "screening_policy": {
+        "kind": "single_pair_fail_fast",
+        "order": "BA",
+        "regression_threshold_percent": 5.0,
+        "confidence_claim": "none"
       },
       "progress": "llama-bench --progress",
       "selection": {
@@ -233,10 +235,11 @@
       "resource": "gpu",
       "timeout_seconds": 20,
       "mandatory": true,
-      "decision_policy": {
-        "acceptable_decisions": ["improvement", "equivalent"],
-        "regression": "fail",
-        "inconclusive_after_maximum": "unresolved_fail"
+      "screening_policy": {
+        "kind": "single_pair_fail_fast",
+        "order": "AB",
+        "regression_threshold_percent": 5.0,
+        "confidence_claim": "none"
       },
       "progress": "llama-bench --progress and one runner line per low/mid/high screen",
       "selection": {
@@ -367,6 +370,38 @@
         "match": "last",
         "direction": "higher"
       }
+    }
+  ],
+  "early_diagnostics": [
+    {
+      "id": "prefill-regression-kernel",
+      "trigger": "regression_signal_only",
+      "on_clear": "skip",
+      "evidence_claim": "diagnostic_only",
+      "pattern": "independent_nsys_then_filtered_ncu_per_variant",
+      "profile_repetitions": 1,
+      "stage": "weighted-prefill-screen",
+      "variants": ["baseline", "candidate"],
+      "screen_selection": {
+        "kind": "largest_observed_regression"
+      },
+      "timeout_seconds": 300,
+      "cuda_graph_trace": {
+        "applicability": "not_applicable",
+        "reason": "this prefill screen uses direct kernel launches rather than CUDA graph replay"
+      },
+      "selector": {
+        "kernel_regex": "replace-with-preregistered-kernel-family-regex",
+        "graph_only": false,
+        "occurrence_policy": {
+          "kind": "last"
+        }
+      },
+      "metrics": [
+        "gpu__time_duration.sum",
+        "sm__throughput.avg.pct_of_peak_sustained_elapsed",
+        "dram__throughput.avg.pct_of_peak_sustained_elapsed"
+      ]
     }
   ],
   "profiler": {

--- a/examples/feature-performance-validation/manifest.example.json
+++ b/examples/feature-performance-validation/manifest.example.json
@@ -142,6 +142,11 @@
       "resource": "gpu",
       "timeout_seconds": 20,
       "mandatory": true,
+      "decision_policy": {
+        "acceptable_decisions": ["improvement", "equivalent"],
+        "regression": "fail",
+        "inconclusive_after_maximum": "unresolved_fail"
+      },
       "progress": "llama-bench --progress",
       "selection": {
         "workload": "prefill",
@@ -157,12 +162,12 @@
           "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
         ],
         "baseline_args": [],
-        "candidate_args": ["--no-kv-offload"],
+        "candidate_args": ["--no-kv-offload", "1"],
         "cli_schema": {"builtin": "llama", "allow_positionals": false},
         "controlled_delta": {
           "reason": "the preregistered feature toggle is the only runtime difference",
           "baseline_args": [],
-          "candidate_args": ["--no-kv-offload"],
+          "candidate_args": ["--no-kv-offload", "1"],
           "baseline_environment": {},
           "candidate_environment": {},
           "allowed_options": ["--no-kv-offload"],
@@ -182,6 +187,11 @@
       "resource": "gpu",
       "timeout_seconds": 20,
       "mandatory": true,
+      "decision_policy": {
+        "acceptable_decisions": ["improvement", "equivalent"],
+        "regression": "fail",
+        "inconclusive_after_maximum": "unresolved_fail"
+      },
       "progress": "llama-bench --progress",
       "selection": {
         "workload": "decode",
@@ -198,12 +208,12 @@
           "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
         ],
         "baseline_args": [],
-        "candidate_args": ["--no-kv-offload"],
+        "candidate_args": ["--no-kv-offload", "1"],
         "cli_schema": {"builtin": "llama", "allow_positionals": false},
         "controlled_delta": {
           "reason": "the preregistered feature toggle is the only runtime difference",
           "baseline_args": [],
-          "candidate_args": ["--no-kv-offload"],
+          "candidate_args": ["--no-kv-offload", "1"],
           "baseline_environment": {},
           "candidate_environment": {},
           "allowed_options": ["--no-kv-offload"],
@@ -223,6 +233,11 @@
       "resource": "gpu",
       "timeout_seconds": 20,
       "mandatory": true,
+      "decision_policy": {
+        "acceptable_decisions": ["improvement", "equivalent"],
+        "regression": "fail",
+        "inconclusive_after_maximum": "unresolved_fail"
+      },
       "progress": "llama-bench --progress and one runner line per low/mid/high screen",
       "selection": {
         "workload": "prefill",
@@ -237,12 +252,12 @@
           "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
         ],
         "baseline_args": [],
-        "candidate_args": ["--no-kv-offload"],
+        "candidate_args": ["--no-kv-offload", "1"],
         "cli_schema": {"builtin": "llama", "allow_positionals": false},
         "controlled_delta": {
           "reason": "the preregistered feature toggle is the only runtime difference",
           "baseline_args": [],
-          "candidate_args": ["--no-kv-offload"],
+          "candidate_args": ["--no-kv-offload", "1"],
           "baseline_environment": {},
           "candidate_environment": {},
           "allowed_options": ["--no-kv-offload"],
@@ -268,6 +283,11 @@
       "resource": "gpu",
       "timeout_seconds": 45,
       "mandatory": true,
+      "decision_policy": {
+        "acceptable_decisions": ["improvement", "equivalent"],
+        "regression": "fail",
+        "inconclusive_after_maximum": "unresolved_fail"
+      },
       "progress": "llama-bench --progress",
       "selection": {
         "workload": "decode",
@@ -283,12 +303,12 @@
           "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
         ],
         "baseline_args": [],
-        "candidate_args": ["--no-kv-offload"],
+        "candidate_args": ["--no-kv-offload", "1"],
         "cli_schema": {"builtin": "llama", "allow_positionals": false},
         "controlled_delta": {
           "reason": "the preregistered feature toggle is the only runtime difference",
           "baseline_args": [],
-          "candidate_args": ["--no-kv-offload"],
+          "candidate_args": ["--no-kv-offload", "1"],
           "baseline_environment": {},
           "candidate_environment": {},
           "allowed_options": ["--no-kv-offload"],
@@ -308,6 +328,11 @@
       "resource": "gpu",
       "timeout_seconds": 1800,
       "mandatory": true,
+      "decision_policy": {
+        "acceptable_decisions": ["improvement", "equivalent"],
+        "regression": "fail",
+        "inconclusive_after_maximum": "unresolved_fail"
+      },
       "progress": "llama-bench --progress",
       "selection": {
         "workload": "decode",
@@ -324,12 +349,12 @@
           "-b", "512", "-ub", "256", "-t", "1", "-C", "0x7", "--cpu-strict", "1", "--progress"
         ],
         "baseline_args": [],
-        "candidate_args": ["--no-kv-offload"],
+        "candidate_args": ["--no-kv-offload", "1"],
         "cli_schema": {"builtin": "llama", "allow_positionals": false},
         "controlled_delta": {
           "reason": "the preregistered feature toggle is the only runtime difference",
           "baseline_args": [],
-          "candidate_args": ["--no-kv-offload"],
+          "candidate_args": ["--no-kv-offload", "1"],
           "baseline_environment": {},
           "candidate_environment": {},
           "allowed_options": ["--no-kv-offload"],
@@ -351,6 +376,11 @@
     "variant": "candidate",
     "screen": "default",
     "timeout_seconds": 300,
+    "cuda_graph_trace": {
+      "applicability": "required",
+      "granularity": "node",
+      "launch_origin": "host-only"
+    },
     "selector": {
       "kernel_regex": "replace-with-discovered-production-kernel-regex",
       "graph_only": true

--- a/scripts/feature-performance-validation.py
+++ b/scripts/feature-performance-validation.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+
+"""Manifest-driven feature/performance validation command line interface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+from feature_validation import core, profiler
+from feature_validation.runner import StudyRunner, execute_run_spec
+
+
+TOOL_SCRIPT = pathlib.Path(__file__).resolve()
+
+
+def _load_spec(path: pathlib.Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or value.get("schema_version") != 1:
+        raise core.ValidationError("run spec must be a schema_version 1 object")
+    return value
+
+
+def _identity_files(provenance: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    files: dict[str, dict[str, Any]] = {}
+    sources: list[dict[str, str]] = []
+    for variant in provenance["variants"].values():
+        for executable in variant["executables"].values():
+            binary = executable["binary"]
+            files[binary["resolved_path"]] = {
+                "path": binary["resolved_path"],
+                **{key: binary[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
+                "rehash": True,
+            }
+            for library in binary.get("libraries", []):
+                files[library["path"]] = {"path": library["path"], **library}
+            if executable["build"].get("cache"):
+                build = executable["build"]
+                files[build["cache"]] = {
+                    "path": build["cache"],
+                    "sha256": build["cache_sha256"],
+                    **build["cache_stat"],
+                }
+        source = variant["source"]
+        sources.append(
+            {
+                "root": source["root"],
+                "head": source["head"],
+                "dirty_fingerprint": source["dirty_fingerprint"],
+            }
+        )
+    for item in provenance["inputs"]:
+        files[item["path"]] = {
+            "path": item["path"],
+            **{key: item[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
+        }
+    return ([files[key] for key in sorted(files)], sources)
+
+
+def _tool_identity(name: str) -> dict[str, Any]:
+    found = shutil.which(name)
+    if found is None:
+        raise core.ValidationError(f"required optional profiler tool is unavailable: {name}")
+    path = pathlib.Path(found).resolve()
+    return {
+        "path": str(path),
+        "sha256": core.sha256_file(path),
+        **core.stat_identity(path),
+        "rehash": True,
+    }
+
+
+def _launch_locked(spec: dict[str, Any], spec_path: pathlib.Path) -> dict[str, Any]:
+    result_path = pathlib.Path(spec["result_path"])
+    if spec_path.exists() or result_path.exists():
+        raise core.ValidationError(
+            f"refusing to overwrite an existing profiler attempt: {spec_path} / {result_path}"
+        )
+    inner = [sys.executable, str(TOOL_SCRIPT), "_execute-run", str(spec_path)]
+    wrapper = core.flock_argv(inner)
+    spec["gpu_lock"] = {
+        "path": core.GPU_LOCK,
+        "whole_command_argv": wrapper,
+        "whole_command": core.quote_argv(wrapper),
+        "inner_lifecycle": "telemetry preflight, direct profiler lifecycle, telemetry cleanup",
+    }
+    core.write_json_atomic(spec_path, spec)
+    print(f"[feature-validation] launch {core.quote_argv(wrapper)}", flush=True)
+    completed = subprocess.run(wrapper, check=False)
+    if not result_path.is_file():
+        raise core.ValidationError(
+            f"locked profiler command returned {completed.returncode} without result artifact"
+        )
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    if result.get("status") != "success":
+        raise core.ValidationError(f"profiler command failed: {result.get('error')}")
+    return result
+
+
+def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) -> dict[str, Any]:
+    manifest, manifest_sha = core.load_and_validate_manifest(manifest_path)
+    config = manifest.get("profiler")
+    if not isinstance(config, dict):
+        raise core.ManifestError("manifest has no profiler section")
+    provenance = core.capture_provenance(manifest, manifest_sha)
+    stage = core.stage_by_id(manifest, config["stage"])
+    if stage["resource"] != "gpu":
+        raise core.ManifestError("profiler stage must use resource=gpu")
+    variant_name = config["variant"]
+    screens = stage.get("screens", [{"id": "default", "args": [], "weight": 1.0}])
+    screen_id = config.get("screen", screens[0]["id"])
+    if screen_id not in {item["id"] for item in screens}:
+        raise core.ManifestError(f"profiler screen {screen_id!r} is not in stage {stage['id']!r}")
+    study_root = pathlib.Path(manifest["artifact_root"]) / (
+        f"{core.safe_slug(manifest['study']['id'])}-{manifest_sha[:12]}"
+    )
+    profile_root = study_root / "profiles" / f"{stage['id']}-{variant_name}-{screen_id}"
+    state_path = profile_root / "profile-state.json"
+    plan_path = profile_root / "ncu-plan.json"
+    if state_path.exists():
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        if not resume:
+            raise core.ValidationError(f"profile artifacts already exist; use --resume: {profile_root}")
+        if state.get("manifest_sha256") != manifest_sha:
+            raise core.ProvenanceError("profile resume manifest identity mismatch")
+        if state.get("provenance_identity_fingerprint") != provenance["identity_fingerprint"]:
+            raise core.ProvenanceError("profile resume provenance identity mismatch")
+        if state.get("ncu_executed") or not execute_ncu:
+            return json.loads(plan_path.read_text(encoding="utf-8"))
+    else:
+        if resume:
+            raise core.ValidationError(f"no resumable profile exists at {profile_root}")
+        profile_root.mkdir(parents=True, exist_ok=False)
+        state = {
+            "schema_version": 1,
+            "manifest_sha256": manifest_sha,
+            "provenance_identity_fingerprint": provenance["identity_fingerprint"],
+            "stage": stage["id"],
+            "variant": variant_name,
+            "screen": screen_id,
+            "nsys_discovery_completed": False,
+            "ncu_plan_completed": False,
+            "ncu_executed": False,
+        }
+        core.write_json_atomic(profile_root / "provenance.json", provenance)
+        core.write_json_atomic(state_path, state)
+
+    scheduled = next(
+        item
+        for item in core.build_schedule(manifest, stage)
+        if item["variant"] == variant_name and item["screen"] == screen_id
+    )
+    target_argv, environment = core.command_for_run(manifest, stage, scheduled)
+    context = {
+        "artifact_dir": profile_root,
+        "variant": variant_name,
+        "pair": 1,
+        "screen": screen_id,
+        "run_id": "profile-discovery",
+    }
+    target_argv = [value.format_map(context) for value in target_argv]
+    executable_role = str(stage["command"].get("executable_role", "default"))
+    direct_harness = core.variant_executables(manifest["variants"][variant_name])[
+        executable_role
+    ].get("direct_harness")
+    profiler.validate_native_affinity(target_argv, direct_harness)
+    identity_files, source_identities = _identity_files(provenance)
+
+    sqlite_path = profile_root / "discovery.sqlite"
+    if not state["nsys_discovery_completed"]:
+        nsys_identity = _tool_identity("nsys")
+        identity_files_with_nsys = [*identity_files, nsys_identity]
+        prefix = profile_root / "discovery"
+        nsys_argv = profiler.nsys_discovery_argv(target_argv, prefix, direct_harness)
+        spec_path = profile_root / "nsys-run-spec.json"
+        spec = {
+            "schema_version": 1,
+            "run_id": f"profile--{stage['id']}--nsys-discovery",
+            "attempt": 1,
+            "resource": "gpu",
+            "argv": nsys_argv,
+            "environment": environment,
+            "cwd": str(profile_root),
+            "timeout_seconds": float(config.get("timeout_seconds", stage["timeout_seconds"])),
+            "progress": "NSYS target output plus five-second runner heartbeat",
+            "result_path": str(profile_root / "nsys-result.json"),
+            "stdout_path": str(profile_root / "nsys-stdout.log"),
+            "stderr_path": str(profile_root / "nsys-stderr.log"),
+            "identity_files": identity_files_with_nsys,
+            "source_identities": source_identities,
+            "host_load_before": core.host_load_snapshot(),
+        }
+        _launch_locked(spec, spec_path)
+        report_path = prefix.with_suffix(".nsys-rep")
+        if not report_path.is_file():
+            raise core.ValidationError(f"NSYS report is missing: {report_path}")
+        export_argv = [
+            "nsys",
+            "export",
+            "--type",
+            "sqlite",
+            "--force-overwrite",
+            "true",
+            "--output",
+            str(sqlite_path),
+            str(report_path),
+        ]
+        print(f"[feature-validation] NSYS export {core.quote_argv(export_argv)}", flush=True)
+        exported = subprocess.run(export_argv, check=False, capture_output=True, text=True)
+        core.write_json_atomic(
+            profile_root / "nsys-export.json",
+            {
+                "argv": export_argv,
+                "command": core.quote_argv(export_argv),
+                "returncode": exported.returncode,
+                "stdout": exported.stdout,
+                "stderr": exported.stderr,
+            },
+        )
+        if exported.returncode != 0 or not sqlite_path.is_file():
+            raise core.ValidationError(f"NSYS SQLite export failed: {exported.stderr.strip()}")
+        state["nsys_discovery_completed"] = True
+        core.write_json_atomic(state_path, state)
+
+    discovery = profiler.parse_discovery(sqlite_path)
+    core.write_json_atomic(profile_root / "discovery-inventory.json", discovery)
+    plan = profiler.build_ncu_plan(
+        discovery,
+        config["selector"],
+        target_argv,
+        profile_root / "ncu",
+        metrics=[str(value) for value in config.get("metrics", [])],
+        direct_harness=direct_harness,
+    )
+    plan["stage"] = stage["id"]
+    plan["variant"] = variant_name
+    plan["screen"] = screen_id
+    plan["profile_repetitions"] = 1
+    core.write_json_atomic(plan_path, plan)
+    state["ncu_plan_completed"] = True
+    core.write_json_atomic(state_path, state)
+
+    if execute_ncu and not state["ncu_executed"]:
+        ncu_identity = _tool_identity("ncu")
+        command = plan["command"]["direct_argv"]
+        spec_path = profile_root / "ncu-run-spec.json"
+        spec = {
+            "schema_version": 1,
+            "run_id": f"profile--{stage['id']}--filtered-ncu",
+            "attempt": 1,
+            "resource": "gpu",
+            "argv": command,
+            "environment": environment,
+            "cwd": str(profile_root),
+            "timeout_seconds": float(config.get("timeout_seconds", stage["timeout_seconds"])),
+            "progress": "filtered NCU target output plus five-second runner heartbeat",
+            "result_path": str(profile_root / "ncu-result.json"),
+            "stdout_path": str(profile_root / "ncu-stdout.log"),
+            "stderr_path": str(profile_root / "ncu-stderr.log"),
+            "identity_files": [*identity_files, ncu_identity],
+            "source_identities": source_identities,
+            "host_load_before": core.host_load_snapshot(),
+        }
+        _launch_locked(spec, spec_path)
+        state["ncu_executed"] = True
+        core.write_json_atomic(state_path, state)
+    return plan
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate = subparsers.add_parser("validate", help="validate schema and fail-closed provenance")
+    validate.add_argument("manifest", type=pathlib.Path)
+    run = subparsers.add_parser("run", help="run validation stages")
+    run.add_argument("manifest", type=pathlib.Path)
+    run.add_argument("--through", choices=("early", "production", "acceptance"), default="early")
+    run.add_argument("--resume", action="store_true")
+    run.add_argument("--retry-failed", action="store_true")
+    profile = subparsers.add_parser("profile", help="one NSYS discovery and one filtered NCU plan/capture")
+    profile.add_argument("manifest", type=pathlib.Path)
+    profile.add_argument("--resume", action="store_true")
+    profile.add_argument("--execute-ncu", action="store_true")
+    internal = subparsers.add_parser("_execute-run", help=argparse.SUPPRESS)
+    internal.add_argument("spec", type=pathlib.Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.command == "validate":
+            manifest, manifest_sha = core.load_and_validate_manifest(args.manifest)
+            provenance = core.capture_provenance(manifest, manifest_sha)
+            print(
+                json.dumps(
+                    {
+                        "status": "valid",
+                        "manifest_sha256": manifest_sha,
+                        "provenance_identity_fingerprint": provenance["identity_fingerprint"],
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        elif args.command == "run":
+            runner = StudyRunner(args.manifest, TOOL_SCRIPT)
+            summary = runner.run(
+                through=args.through,
+                resume=args.resume,
+                retry_failed=args.retry_failed,
+            )
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        elif args.command == "profile":
+            plan = _profile(args.manifest, resume=args.resume, execute_ncu=args.execute_ncu)
+            print(json.dumps(plan, indent=2, sort_keys=True))
+        else:
+            result = execute_run_spec(_load_spec(args.spec))
+            return 0 if result["status"] == "success" else 1
+    except (ValueError, KeyError, TypeError, OSError, json.JSONDecodeError) as error:
+        print(f"feature-validation: {type(error).__name__}: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/feature-performance-validation.py
+++ b/scripts/feature-performance-validation.py
@@ -13,7 +13,7 @@ import sys
 from typing import Any
 
 from feature_validation import core, profiler
-from feature_validation.runner import StudyRunner, execute_run_spec
+from feature_validation.runner import StudyRunner, execute_run_spec, launch_locked_spec
 
 
 TOOL_SCRIPT = pathlib.Path(__file__).resolve()
@@ -24,42 +24,6 @@ def _load_spec(path: pathlib.Path) -> dict[str, Any]:
     if not isinstance(value, dict) or value.get("schema_version") != 1:
         raise core.ValidationError("run spec must be a schema_version 1 object")
     return value
-
-
-def _identity_files(provenance: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
-    files: dict[str, dict[str, Any]] = {}
-    sources: list[dict[str, str]] = []
-    for variant in provenance["variants"].values():
-        for executable in variant["executables"].values():
-            binary = executable["binary"]
-            files[binary["resolved_path"]] = {
-                "path": binary["resolved_path"],
-                **{key: binary[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
-                "rehash": True,
-            }
-            for library in binary.get("libraries", []):
-                files[library["path"]] = {"path": library["path"], **library}
-            if executable["build"].get("cache"):
-                build = executable["build"]
-                files[build["cache"]] = {
-                    "path": build["cache"],
-                    "sha256": build["cache_sha256"],
-                    **build["cache_stat"],
-                }
-        source = variant["source"]
-        sources.append(
-            {
-                "root": source["root"],
-                "head": source["head"],
-                "dirty_fingerprint": source["dirty_fingerprint"],
-            }
-        )
-    for item in provenance["inputs"]:
-        files[item["path"]] = {
-            "path": item["path"],
-            **{key: item[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
-        }
-    return ([files[key] for key in sorted(files)], sources)
 
 
 def _tool_identity(name: str) -> dict[str, Any]:
@@ -73,33 +37,6 @@ def _tool_identity(name: str) -> dict[str, Any]:
         **core.stat_identity(path),
         "rehash": True,
     }
-
-
-def _launch_locked(spec: dict[str, Any], spec_path: pathlib.Path) -> dict[str, Any]:
-    result_path = pathlib.Path(spec["result_path"])
-    if spec_path.exists() or result_path.exists():
-        raise core.ValidationError(
-            f"refusing to overwrite an existing profiler attempt: {spec_path} / {result_path}"
-        )
-    inner = [sys.executable, str(TOOL_SCRIPT), "_execute-run", str(spec_path)]
-    wrapper = core.flock_argv(inner)
-    spec["gpu_lock"] = {
-        "path": core.GPU_LOCK,
-        "whole_command_argv": wrapper,
-        "whole_command": core.quote_argv(wrapper),
-        "inner_lifecycle": "telemetry preflight, direct profiler lifecycle, telemetry cleanup",
-    }
-    core.write_json_atomic(spec_path, spec)
-    print(f"[feature-validation] launch {core.quote_argv(wrapper)}", flush=True)
-    completed = subprocess.run(wrapper, check=False)
-    if not result_path.is_file():
-        raise core.ValidationError(
-            f"locked profiler command returned {completed.returncode} without result artifact"
-        )
-    result = json.loads(result_path.read_text(encoding="utf-8"))
-    if result.get("status") != "success":
-        raise core.ValidationError(f"profiler command failed: {result.get('error')}")
-    return result
 
 
 def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) -> dict[str, Any]:
@@ -130,7 +67,13 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
             raise core.ProvenanceError("profile resume manifest identity mismatch")
         if state.get("provenance_identity_fingerprint") != provenance["identity_fingerprint"]:
             raise core.ProvenanceError("profile resume provenance identity mismatch")
-        if state.get("ncu_executed") or not execute_ncu:
+        if state.get("ncu_executed"):
+            if state.get("ncu_verification_status") != "verified":
+                raise core.ValidationError(
+                    "the preserved NCU capture is failed or unverifiable; start a new profile identity"
+                )
+            return json.loads(plan_path.read_text(encoding="utf-8"))
+        if not execute_ncu and state.get("ncu_plan_completed"):
             return json.loads(plan_path.read_text(encoding="utf-8"))
     else:
         if resume:
@@ -146,6 +89,7 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
             "nsys_discovery_completed": False,
             "ncu_plan_completed": False,
             "ncu_executed": False,
+            "ncu_verification_status": "not_executed",
         }
         core.write_json_atomic(profile_root / "provenance.json", provenance)
         core.write_json_atomic(state_path, state)
@@ -169,14 +113,46 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
         executable_role
     ].get("direct_harness")
     profiler.validate_native_affinity(target_argv, direct_harness)
-    identity_files, source_identities = _identity_files(provenance)
+    identity_files, source_identities = core.provenance_identity_spec(provenance)
+    nvidia_smi_identity = provenance.get("runtime_tools", {}).get("nvidia-smi")
+    nvidia_smi = nvidia_smi_identity["path"] if nvidia_smi_identity else "nvidia-smi"
 
     sqlite_path = profile_root / "discovery.sqlite"
     if not state["nsys_discovery_completed"]:
         nsys_identity = _tool_identity("nsys")
+        nsys_help = core.command_capture(
+            [nsys_identity["path"], "profile", "--help=cuda"]
+        )
+        nsys_version = core.command_capture([nsys_identity["path"], "--version"])
+        if (
+            nsys_help.get("returncode") != 0
+            and config["cuda_graph_trace"]["applicability"] == "required"
+        ):
+            raise core.ValidationError(
+                f"cannot inspect NSYS CUDA tracing support: {nsys_help.get('stderr', nsys_help.get('error'))}"
+            )
+        graph_capability = profiler.verify_nsys_graph_trace_capability(
+            config["cuda_graph_trace"],
+            help_text=str(nsys_help.get("stdout", "")) + str(nsys_help.get("stderr", "")),
+            version_text=str(nsys_version.get("stdout", "")) + str(nsys_version.get("stderr", "")),
+        )
+        core.write_json_atomic(
+            profile_root / "nsys-graph-trace-capability.json",
+            {
+                **graph_capability,
+                "help_command": nsys_help,
+                "version_command": nsys_version,
+            },
+        )
         identity_files_with_nsys = [*identity_files, nsys_identity]
         prefix = profile_root / "discovery"
-        nsys_argv = profiler.nsys_discovery_argv(target_argv, prefix, direct_harness)
+        nsys_argv = profiler.nsys_discovery_argv(
+            target_argv,
+            prefix,
+            direct_harness,
+            cuda_graph_trace=config["cuda_graph_trace"],
+            nsys_executable=nsys_identity["path"],
+        )
         spec_path = profile_root / "nsys-run-spec.json"
         spec = {
             "schema_version": 1,
@@ -193,14 +169,18 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
             "stderr_path": str(profile_root / "nsys-stderr.log"),
             "identity_files": identity_files_with_nsys,
             "source_identities": source_identities,
+            "nvidia_smi_identity": nvidia_smi_identity,
+            "nvidia_smi": nvidia_smi,
             "host_load_before": core.host_load_snapshot(),
         }
-        _launch_locked(spec, spec_path)
+        result = launch_locked_spec(spec, spec_path, TOOL_SCRIPT)
+        if result.get("status") != "success":
+            raise core.ValidationError(f"NSYS command failed: {result.get('error')}")
         report_path = prefix.with_suffix(".nsys-rep")
         if not report_path.is_file():
             raise core.ValidationError(f"NSYS report is missing: {report_path}")
         export_argv = [
-            "nsys",
+            nsys_identity["path"],
             "export",
             "--type",
             "sqlite",
@@ -228,6 +208,9 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
         core.write_json_atomic(state_path, state)
 
     discovery = profiler.parse_discovery(sqlite_path)
+    discovery["graph_node_verification"] = profiler.verify_graph_node_discovery(
+        discovery, config["cuda_graph_trace"]
+    )
     core.write_json_atomic(profile_root / "discovery-inventory.json", discovery)
     plan = profiler.build_ncu_plan(
         discovery,
@@ -247,7 +230,7 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
 
     if execute_ncu and not state["ncu_executed"]:
         ncu_identity = _tool_identity("ncu")
-        command = plan["command"]["direct_argv"]
+        command = [ncu_identity["path"], *plan["command"]["direct_argv"][1:]]
         spec_path = profile_root / "ncu-run-spec.json"
         spec = {
             "schema_version": 1,
@@ -264,11 +247,60 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
             "stderr_path": str(profile_root / "ncu-stderr.log"),
             "identity_files": [*identity_files, ncu_identity],
             "source_identities": source_identities,
+            "nvidia_smi_identity": nvidia_smi_identity,
+            "nvidia_smi": nvidia_smi,
             "host_load_before": core.host_load_snapshot(),
         }
-        _launch_locked(spec, spec_path)
+        result = launch_locked_spec(spec, spec_path, TOOL_SCRIPT)
+        if result.get("status") != "success":
+            raise core.ValidationError(f"NCU command failed: {result.get('error')}")
         state["ncu_executed"] = True
+        report_path = pathlib.Path(plan["command"]["report_path"])
+        verification: dict[str, Any]
+        if not report_path.is_file() or report_path.stat().st_size == 0:
+            verification = {
+                "status": "unverifiable",
+                "issues": [f"NCU report is missing or empty: {report_path}"],
+                "report_path": str(report_path),
+            }
+        else:
+            import_argv = [
+                ncu_identity["path"],
+                "--import",
+                str(report_path),
+                "--csv",
+                "--page",
+                "raw",
+                "--print-kernel-base",
+                "demangled",
+            ]
+            imported = core.command_capture(import_argv, cwd=profile_root, timeout=120.0)
+            if imported.get("returncode") != 0:
+                verification = {
+                    "status": "unverifiable",
+                    "issues": ["NCU report import failed"],
+                }
+            else:
+                parsed = profiler.parse_ncu_raw_csv(
+                    str(imported.get("stdout", "")) + "\n" + str(imported.get("stderr", ""))
+                )
+                verification = profiler.verify_ncu_capture(plan, parsed)
+                verification["parsed_export"] = parsed
+            verification.update(
+                {
+                    "report_path": str(report_path),
+                    "report_sha256": core.sha256_file(report_path),
+                    "report_size": report_path.stat().st_size,
+                    "import_command": imported,
+                }
+            )
+        core.write_json_atomic(profile_root / "ncu-verification.json", verification)
+        state["ncu_verification_status"] = verification["status"]
         core.write_json_atomic(state_path, state)
+        if verification["status"] != "verified":
+            raise core.ValidationError(
+                f"NCU capture is {verification['status']}: {verification.get('issues')}"
+            )
     return plan
 
 

--- a/scripts/feature-performance-validation.py
+++ b/scripts/feature-performance-validation.py
@@ -39,24 +39,25 @@ def _tool_identity(name: str) -> dict[str, Any]:
     }
 
 
-def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) -> dict[str, Any]:
-    manifest, manifest_sha = core.load_and_validate_manifest(manifest_path)
-    config = manifest.get("profiler")
-    if not isinstance(config, dict):
-        raise core.ManifestError("manifest has no profiler section")
-    provenance = core.capture_provenance(manifest, manifest_sha)
+def _profile_one(
+    manifest: dict[str, Any],
+    manifest_sha: str,
+    provenance: dict[str, Any],
+    config: dict[str, Any],
+    *,
+    variant_name: str,
+    screen_id: str,
+    profile_base: pathlib.Path,
+    resume: bool,
+    execute_ncu: bool,
+) -> dict[str, Any]:
     stage = core.stage_by_id(manifest, config["stage"])
     if stage["resource"] != "gpu":
         raise core.ManifestError("profiler stage must use resource=gpu")
-    variant_name = config["variant"]
     screens = stage.get("screens", [{"id": "default", "args": [], "weight": 1.0}])
-    screen_id = config.get("screen", screens[0]["id"])
     if screen_id not in {item["id"] for item in screens}:
         raise core.ManifestError(f"profiler screen {screen_id!r} is not in stage {stage['id']!r}")
-    study_root = pathlib.Path(manifest["artifact_root"]) / (
-        f"{core.safe_slug(manifest['study']['id'])}-{manifest_sha[:12]}"
-    )
-    profile_root = study_root / "profiles" / f"{stage['id']}-{variant_name}-{screen_id}"
+    profile_root = profile_base / f"{stage['id']}-{variant_name}-{screen_id}"
     state_path = profile_root / "profile-state.json"
     plan_path = profile_root / "ncu-plan.json"
     if state_path.exists():
@@ -86,6 +87,7 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
             "stage": stage["id"],
             "variant": variant_name,
             "screen": screen_id,
+            "evidence_claim": config.get("evidence_claim", "kernel_investigation_only"),
             "nsys_discovery_completed": False,
             "ncu_plan_completed": False,
             "ncu_executed": False,
@@ -113,7 +115,9 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
         executable_role
     ].get("direct_harness")
     profiler.validate_native_affinity(target_argv, direct_harness)
-    identity_files, source_identities = core.provenance_identity_spec(provenance)
+    identity_files, source_identities = core.provenance_identity_spec(
+        provenance, [(variant_name, executable_role)]
+    )
     nvidia_smi_identity = provenance.get("runtime_tools", {}).get("nvidia-smi")
     nvidia_smi = nvidia_smi_identity["path"] if nvidia_smi_identity else "nvidia-smi"
 
@@ -224,6 +228,7 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
     plan["variant"] = variant_name
     plan["screen"] = screen_id
     plan["profile_repetitions"] = 1
+    plan["evidence_claim"] = config.get("evidence_claim", "kernel_investigation_only")
     core.write_json_atomic(plan_path, plan)
     state["ncu_plan_completed"] = True
     core.write_json_atomic(state_path, state)
@@ -304,6 +309,133 @@ def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) ->
     return plan
 
 
+def _study_root(manifest: dict[str, Any], manifest_sha: str) -> pathlib.Path:
+    return pathlib.Path(manifest["artifact_root"]) / (
+        f"{core.safe_slug(manifest['study']['id'])}-{manifest_sha[:12]}"
+    )
+
+
+def _profile(manifest_path: pathlib.Path, *, resume: bool, execute_ncu: bool) -> dict[str, Any]:
+    manifest, manifest_sha = core.load_and_validate_manifest(manifest_path)
+    config = manifest.get("profiler")
+    if not isinstance(config, dict):
+        raise core.ManifestError("manifest has no profiler section")
+    provenance = core.capture_provenance(manifest, manifest_sha)
+    stage = core.stage_by_id(manifest, config["stage"])
+    screens = stage.get("screens", [{"id": "default"}])
+    return _profile_one(
+        manifest,
+        manifest_sha,
+        provenance,
+        config,
+        variant_name=str(config["variant"]),
+        screen_id=str(config.get("screen", screens[0]["id"])),
+        profile_base=_study_root(manifest, manifest_sha) / "profiles",
+        resume=resume,
+        execute_ncu=execute_ncu,
+    )
+
+
+def _diagnose(manifest_path: pathlib.Path, *, resume: bool) -> dict[str, Any]:
+    manifest, manifest_sha = core.load_and_validate_manifest(manifest_path)
+    configs = manifest.get("early_diagnostics")
+    if not isinstance(configs, list) or not configs:
+        raise core.ManifestError("manifest has no early_diagnostics section")
+    provenance = core.capture_provenance(manifest, manifest_sha)
+    study_root = _study_root(manifest, manifest_sha)
+    state_path = study_root / "state.json"
+    if not state_path.is_file():
+        raise core.ValidationError("early diagnostics require a preserved screening study state")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    if state.get("manifest_sha256") != manifest_sha:
+        raise core.ProvenanceError("diagnostic study manifest identity mismatch")
+    if state.get("provenance_identity_fingerprint") != provenance["identity_fingerprint"]:
+        raise core.ProvenanceError("diagnostic study provenance identity mismatch")
+
+    diagnostic_root = study_root / "early-diagnostics"
+    report_path = diagnostic_root / "agent-diagnostic-report.json"
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "status": "not_triggered",
+        "generated_utc": core.utc_now(),
+        "manifest_sha256": manifest_sha,
+        "provenance_identity_fingerprint": provenance["identity_fingerprint"],
+        "trigger_policy": "regression_signal_only",
+        "profiles": [],
+        "investigations": [],
+        "normal_early_screen_profiler_cost": "zero when no regression signal is emitted",
+        "evidence_boundary": (
+            "These profiles are diagnostic-only and cannot pass correctness, statistical "
+            "performance, resource, production, or long-context acceptance gates."
+        ),
+    }
+    diagnostic_root.mkdir(parents=True, exist_ok=True)
+    core.write_json_atomic(report_path, report)
+    for config in configs:
+        stage = core.stage_by_id(manifest, str(config["stage"]))
+        trigger = profiler.select_regression_diagnostic(
+            stage,
+            state.get("stages", {}).get(stage["id"]),
+            config["screen_selection"],
+        )
+        investigation = {
+            "id": config["id"],
+            "stage": stage["id"],
+            "trigger": trigger,
+            "status": "not_triggered",
+            "variant_profiles": {},
+        }
+        report["investigations"].append(investigation)
+        core.write_json_atomic(report_path, report)
+        if not trigger["triggered"]:
+            continue
+        report["status"] = "running"
+        investigation["status"] = "running"
+        screen_id = str(trigger["selected_screen"]["screen"])
+        profile_base = diagnostic_root / str(config["id"])
+        for variant_name in config["variants"]:
+            profile_root = profile_base / f"{stage['id']}-{variant_name}-{screen_id}"
+            try:
+                _profile_one(
+                    manifest,
+                    manifest_sha,
+                    provenance,
+                    config,
+                    variant_name=str(variant_name),
+                    screen_id=screen_id,
+                    profile_base=profile_base,
+                    resume=resume and profile_root.exists(),
+                    execute_ncu=True,
+                )
+                compact = profiler.agent_profile_summary(profile_root)
+                if compact["status"] != "verified":
+                    raise core.ValidationError(
+                        f"{variant_name} diagnostic profile is {compact['status']}"
+                    )
+                investigation["variant_profiles"][variant_name] = compact
+                report["profiles"].append(compact)
+                core.write_json_atomic(report_path, report)
+            except Exception as error:
+                investigation["status"] = "failed"
+                investigation["error"] = f"{type(error).__name__}: {error}"
+                report["status"] = "failed"
+                core.write_json_atomic(report_path, report)
+                raise
+        investigation["status"] = "verified"
+        investigation["cross_variant_discovery"] = (
+            "independent; no launch index, kernel spelling, or shape was reused across variants"
+        )
+        investigation["agent_comparison"] = profiler.compare_agent_profiles(
+            investigation["variant_profiles"]["baseline"],
+            investigation["variant_profiles"]["candidate"],
+        )
+        report["status"] = "verified"
+        core.write_json_atomic(report_path, report)
+    report["generated_utc"] = core.utc_now()
+    core.write_json_atomic(report_path, report)
+    return report
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -314,10 +446,25 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--through", choices=("early", "production", "acceptance"), default="early")
     run.add_argument("--resume", action="store_true")
     run.add_argument("--retry-failed", action="store_true")
-    profile = subparsers.add_parser("profile", help="one NSYS discovery and one filtered NCU plan/capture")
+    run.add_argument(
+        "--diagnose-regressions",
+        action="store_true",
+        help=(
+            "after a preregistered early regression, run independent "
+            "baseline/candidate NSYS+NCU diagnostics"
+        ),
+    )
+    profile = subparsers.add_parser(
+        "profile", help="one NSYS discovery and one filtered NCU plan/capture"
+    )
     profile.add_argument("manifest", type=pathlib.Path)
     profile.add_argument("--resume", action="store_true")
     profile.add_argument("--execute-ncu", action="store_true")
+    diagnose = subparsers.add_parser(
+        "diagnose", help="run preregistered NSYS+NCU diagnostics for a preserved early regression"
+    )
+    diagnose.add_argument("manifest", type=pathlib.Path)
+    diagnose.add_argument("--resume", action="store_true")
     internal = subparsers.add_parser("_execute-run", help=argparse.SUPPRESS)
     internal.add_argument("spec", type=pathlib.Path)
     return parser
@@ -342,15 +489,30 @@ def main() -> int:
             )
         elif args.command == "run":
             runner = StudyRunner(args.manifest, TOOL_SCRIPT)
-            summary = runner.run(
-                through=args.through,
-                resume=args.resume,
-                retry_failed=args.retry_failed,
-            )
+            try:
+                summary = runner.run(
+                    through=args.through,
+                    resume=args.resume,
+                    retry_failed=args.retry_failed,
+                )
+            except core.ValidationError as run_error:
+                if args.diagnose_regressions:
+                    try:
+                        diagnostic = _diagnose(args.manifest, resume=args.resume)
+                        print(json.dumps(diagnostic, indent=2, sort_keys=True))
+                    except Exception as diagnostic_error:
+                        raise core.ValidationError(
+                            f"{run_error}; regression diagnostic failed: "
+                            f"{type(diagnostic_error).__name__}: {diagnostic_error}"
+                        ) from diagnostic_error
+                raise
             print(json.dumps(summary, indent=2, sort_keys=True))
         elif args.command == "profile":
             plan = _profile(args.manifest, resume=args.resume, execute_ncu=args.execute_ncu)
             print(json.dumps(plan, indent=2, sort_keys=True))
+        elif args.command == "diagnose":
+            report = _diagnose(args.manifest, resume=args.resume)
+            print(json.dumps(report, indent=2, sort_keys=True))
         else:
             result = execute_run_spec(_load_spec(args.spec))
             return 0 if result["status"] == "success" else 1

--- a/scripts/feature_validation/__init__.py
+++ b/scripts/feature_validation/__init__.py
@@ -1,0 +1,12 @@
+"""Manifest-driven feature/performance validation helpers."""
+
+from .core import (  # noqa: F401
+    ManifestError,
+    ProvenanceError,
+    ValidationError,
+    build_schedule,
+    load_and_validate_manifest,
+    paired_log_report,
+    quote_argv,
+    validate_argv,
+)

--- a/scripts/feature_validation/core.py
+++ b/scripts/feature_validation/core.py
@@ -485,6 +485,128 @@ def _validate_repetitions(manifest: dict[str, Any]) -> None:
             raise ManifestError(f"extension threshold {key} must be non-negative")
 
 
+def _validate_screening_policy(stage: dict[str, Any]) -> None:
+    policy = stage.get("screening_policy")
+    if policy is None:
+        return
+    if stage.get("purpose") not in {"smoke", "kernel_screen"}:
+        raise ManifestError("screening_policy is limited to smoke and kernel_screen stages")
+    if not isinstance(policy, dict) or policy.get("kind") != "single_pair_fail_fast":
+        raise ManifestError("screening_policy.kind must be single_pair_fail_fast")
+    required = {
+        "kind",
+        "order",
+        "regression_threshold_percent",
+        "confidence_claim",
+    }
+    if set(policy) != required:
+        raise ManifestError(f"screening_policy requires exactly {sorted(required)}")
+    if policy.get("order") not in {"AB", "BA"}:
+        raise ManifestError("single-pair screening order must be AB or BA")
+    threshold = policy.get("regression_threshold_percent")
+    if not isinstance(threshold, (int, float)) or isinstance(threshold, bool) or threshold <= 0:
+        raise ManifestError("single-pair screening requires a positive regression_threshold_percent")
+    if policy.get("confidence_claim") != "none":
+        raise ManifestError("single-pair screening must declare confidence_claim=none")
+    if "decision_policy" in stage:
+        raise ManifestError(
+            "single-pair screening cannot declare a statistical decision_policy"
+        )
+
+
+def _validate_profiler_details(
+    config: dict[str, Any], stage: dict[str, Any], *, label: str
+) -> None:
+    if stage.get("resource") != "gpu":
+        raise ManifestError(f"{label} must target a GPU stage")
+    selector = config.get("selector")
+    if not isinstance(selector, dict) or not selector.get("kernel_regex"):
+        raise ManifestError(f"{label} requires a discovery selector with kernel_regex")
+    selector_keys = {"kernel_regex", "graph_only", "grid", "block", "occurrence_policy"}
+    if set(selector) - selector_keys:
+        unknown = sorted(set(selector) - selector_keys)
+        raise ManifestError(f"{label} selector has unknown keys {unknown}")
+    try:
+        re.compile(str(selector["kernel_regex"]))
+    except re.error as error:
+        raise ManifestError(f"{label} kernel_regex is invalid: {error}") from error
+    if "graph_only" in selector and not isinstance(selector["graph_only"], bool):
+        raise ManifestError(f"{label} selector.graph_only must be boolean")
+    for shape_name in ("grid", "block"):
+        shape = selector.get(shape_name)
+        if shape is not None and (
+            not isinstance(shape, list)
+            or len(shape) != 3
+            or any(
+                not isinstance(value, int) or isinstance(value, bool) or value <= 0
+                for value in shape
+            )
+        ):
+            raise ManifestError(f"{label} selector.{shape_name} must have three positive integers")
+    occurrence_policy = selector.get("occurrence_policy", {"kind": "all"})
+    if (
+        not isinstance(occurrence_policy, dict)
+        or set(occurrence_policy) != {"kind"}
+        or occurrence_policy.get("kind") not in {"all", "first", "middle", "last"}
+    ):
+        raise ManifestError(
+            f"{label} selector occurrence_policy.kind must be all, first, middle, or last"
+        )
+    graph_trace = config.get("cuda_graph_trace")
+    if not isinstance(graph_trace, dict) or graph_trace.get("applicability") not in {
+        "required",
+        "not_applicable",
+    }:
+        raise ManifestError(
+            f"{label}.cuda_graph_trace must preregister required or not_applicable"
+        )
+    selection = stage["selection"]
+    graph_replay = selection.get("cuda_graph_replay", {})
+    graph_applicable = (
+        selection.get("execution_mode") == "cuda_graph_replay"
+        or (
+            isinstance(graph_replay, dict)
+            and graph_replay.get("applicability") == "required"
+        )
+        or selector.get("graph_only")
+    )
+    if graph_applicable and graph_trace["applicability"] != "required":
+        raise ManifestError(
+            "CUDA-graph-replay or graph-only profiling requires graph-node tracing"
+        )
+    if graph_trace["applicability"] == "required":
+        if set(graph_trace) != {"applicability", "granularity", "launch_origin"}:
+            raise ManifestError("required CUDA graph tracing has unknown or missing fields")
+        if graph_trace.get("granularity") != "node":
+            raise ManifestError("required CUDA graph tracing must use granularity=node")
+        if graph_trace.get("launch_origin") not in {"host-only", "host-and-device"}:
+            raise ManifestError(
+                "required CUDA graph tracing needs host-only or host-and-device launch_origin"
+            )
+    else:
+        if set(graph_trace) != {"applicability", "reason"} or not graph_trace.get("reason"):
+            raise ManifestError("not-applicable CUDA graph tracing requires exactly a reason")
+    metrics = config.get("metrics", [])
+    if not isinstance(metrics, list) or any(
+        not isinstance(value, str) or not value for value in metrics
+    ):
+        raise ManifestError(f"{label} metrics must be non-empty strings")
+    timeout = config.get("timeout_seconds")
+    if timeout is not None and (
+        not isinstance(timeout, (int, float))
+        or isinstance(timeout, bool)
+        or not (0 < float(timeout) <= 86400)
+    ):
+        raise ManifestError(f"{label} timeout_seconds must be in (0, 86400]")
+
+
+def _stage_screen_ids(stage: dict[str, Any]) -> set[str]:
+    return {
+        str(item["id"])
+        for item in stage.get("screens", [{"id": "default"}])
+    }
+
+
 def variant_executables(variant: dict[str, Any]) -> dict[str, dict[str, Any]]:
     executables = variant.get("executables")
     if not isinstance(executables, dict) or not executables:
@@ -568,6 +690,7 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
     seen: set[str] = set()
     purpose_counts = {purpose: 0 for purpose in PURPOSE_ORDER}
     smoke_workloads: set[str] = set()
+    screening_orders: list[str] = []
     last_order = -1
     for index, stage in enumerate(stages):
         if not isinstance(stage, dict):
@@ -579,6 +702,9 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
         purpose = stage.get("purpose")
         if purpose not in PURPOSE_ORDER:
             raise ManifestError(f"stage {stage_id!r} has unknown purpose {purpose!r}")
+        _validate_screening_policy(stage)
+        if stage.get("screening_policy") is not None:
+            screening_orders.append(stage["screening_policy"]["order"])
         purpose_counts[purpose] += 1
         order = PURPOSE_ORDER[purpose]
         if order < last_order:
@@ -740,27 +866,28 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
         if purpose != "exactness":
             if not isinstance(stage.get("metric"), dict):
                 raise ManifestError(f"performance stage {stage_id!r} requires a metric extractor")
-            policy = stage.get("decision_policy")
-            if not isinstance(policy, dict):
-                raise ManifestError(
-                    f"performance stage {stage_id!r} requires an explicit decision_policy"
-                )
-            acceptable = policy.get("acceptable_decisions")
-            if (
-                not isinstance(acceptable, list)
-                or not acceptable
-                or not set(acceptable).issubset({"improvement", "equivalent"})
-            ):
-                raise ManifestError(
-                    "decision_policy.acceptable_decisions must be a non-empty subset of "
-                    "improvement/equivalent"
-                )
-            if policy.get("regression") != "fail":
-                raise ManifestError("decision_policy.regression must be fail")
-            if policy.get("inconclusive_after_maximum") != "unresolved_fail":
-                raise ManifestError(
-                    "decision_policy.inconclusive_after_maximum must be unresolved_fail"
-                )
+            if stage.get("screening_policy") is None:
+                policy = stage.get("decision_policy")
+                if not isinstance(policy, dict):
+                    raise ManifestError(
+                        f"performance stage {stage_id!r} requires an explicit decision_policy"
+                    )
+                acceptable = policy.get("acceptable_decisions")
+                if (
+                    not isinstance(acceptable, list)
+                    or not acceptable
+                    or not set(acceptable).issubset({"improvement", "equivalent"})
+                ):
+                    raise ManifestError(
+                        "decision_policy.acceptable_decisions must be a non-empty subset of "
+                        "improvement/equivalent"
+                    )
+                if policy.get("regression") != "fail":
+                    raise ManifestError("decision_policy.regression must be fail")
+                if policy.get("inconclusive_after_maximum") != "unresolved_fail":
+                    raise ManifestError(
+                        "decision_policy.inconclusive_after_maximum must be unresolved_fail"
+                    )
         if purpose == "exactness" and stage.get("comparison", {}).get("mode") not in (
             "stdout_sha256",
             "file_sha256",
@@ -773,11 +900,34 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             raise ManifestError(f"the ladder requires exactly one {purpose} stage")
     if smoke_workloads != {"prefill", "decode"}:
         raise ManifestError("the ladder requires short prefill and short decode smoke stages")
+    if any(first == second for first, second in zip(screening_orders, screening_orders[1:])):
+        raise ManifestError("adjacent single-pair screening stages must alternate AB/BA order")
 
     profiler = manifest.get("profiler")
     if profiler is not None:
         if not isinstance(profiler, dict):
             raise ManifestError("profiler must be an object")
+        profiler_keys = {
+            "pattern",
+            "profile_repetitions",
+            "stage",
+            "variant",
+            "screen",
+            "timeout_seconds",
+            "selector",
+            "cuda_graph_trace",
+            "metrics",
+        }
+        profiler_required = {
+            "pattern",
+            "profile_repetitions",
+            "stage",
+            "variant",
+            "selector",
+            "cuda_graph_trace",
+        }
+        if profiler_required - set(profiler) or set(profiler) - profiler_keys:
+            raise ManifestError("profiler has unknown or missing fields")
         if profiler.get("pattern") != "one_nsys_discovery_then_one_filtered_ncu":
             raise ManifestError("profiler pattern must preregister one NSYS discovery then one filtered NCU")
         if profiler.get("profile_repetitions") != 1:
@@ -785,37 +935,92 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
         stage_id = profiler.get("stage")
         if stage_id not in seen:
             raise ManifestError(f"profiler references unknown stage {stage_id!r}")
-        if stage_by_id(manifest, str(stage_id))["purpose"] != "production_confirmation":
+        profiled_stage = stage_by_id(manifest, str(stage_id))
+        if profiled_stage["purpose"] != "production_confirmation":
             raise ManifestError("profiler discovery/capture must target production_confirmation")
         target_variant = profiler.get("variant")
         if target_variant not in variants:
             raise ManifestError("profiler variant must be baseline or candidate")
-        if not isinstance(profiler.get("selector"), dict) or not profiler["selector"].get("kernel_regex"):
-            raise ManifestError("profiler requires a discovery selector with kernel_regex")
-        graph_trace = profiler.get("cuda_graph_trace")
-        if not isinstance(graph_trace, dict) or graph_trace.get("applicability") not in {
-            "required",
-            "not_applicable",
+        if profiler.get("screen", "default") not in _stage_screen_ids(profiled_stage):
+            raise ManifestError("profiler screen is absent from its target stage")
+        _validate_profiler_details(profiler, profiled_stage, label="profiler")
+
+    diagnostics = manifest.get("early_diagnostics", [])
+    if not isinstance(diagnostics, list):
+        raise ManifestError("early_diagnostics must be an array")
+    diagnostic_ids: set[str] = set()
+    diagnostic_stages: set[str] = set()
+    for config in diagnostics:
+        if not isinstance(config, dict):
+            raise ManifestError("each early diagnostic must be an object")
+        diagnostic_required = {
+            "id",
+            "trigger",
+            "on_clear",
+            "evidence_claim",
+            "pattern",
+            "profile_repetitions",
+            "stage",
+            "variants",
+            "screen_selection",
+            "selector",
+            "cuda_graph_trace",
+        }
+        diagnostic_keys = diagnostic_required | {"timeout_seconds", "metrics"}
+        if diagnostic_required - set(config) or set(config) - diagnostic_keys:
+            raise ManifestError("early diagnostic has unknown or missing fields")
+        diagnostic_id = safe_slug(str(config.get("id", "")))
+        if diagnostic_id in diagnostic_ids:
+            raise ManifestError(f"duplicate early diagnostic id {diagnostic_id!r}")
+        diagnostic_ids.add(diagnostic_id)
+        if config.get("trigger") != "regression_signal_only":
+            raise ManifestError("early diagnostic trigger must be regression_signal_only")
+        if config.get("on_clear") != "skip":
+            raise ManifestError("early diagnostic on_clear policy must be skip")
+        if config.get("evidence_claim") != "diagnostic_only":
+            raise ManifestError("early diagnostic evidence_claim must be diagnostic_only")
+        if config.get("pattern") != "independent_nsys_then_filtered_ncu_per_variant":
+            raise ManifestError(
+                "early diagnostic must independently discover and capture each variant"
+            )
+        if config.get("profile_repetitions") != 1:
+            raise ManifestError("early diagnostic profiling must run once per variant")
+        if config.get("variants") != ["baseline", "candidate"]:
+            raise ManifestError("early diagnostic variants must be baseline then candidate")
+        stage_id = config.get("stage")
+        if stage_id not in seen:
+            raise ManifestError(f"early diagnostic references unknown stage {stage_id!r}")
+        if stage_id in diagnostic_stages:
+            raise ManifestError("only one early diagnostic is allowed per screening stage")
+        diagnostic_stages.add(str(stage_id))
+        profiled_stage = stage_by_id(manifest, str(stage_id))
+        if profiled_stage.get("purpose") not in {"smoke", "kernel_screen"}:
+            raise ManifestError("early diagnostics are limited to smoke and kernel_screen stages")
+        if profiled_stage.get("screening_policy") is None:
+            raise ManifestError("early diagnostics require a single-pair screening_policy")
+        screen_selection = config.get("screen_selection")
+        if not isinstance(screen_selection, dict) or screen_selection.get("kind") not in {
+            "fixed",
+            "largest_observed_regression",
         }:
             raise ManifestError(
-                "profiler.cuda_graph_trace must preregister required or not_applicable"
+                "early diagnostic screen_selection.kind must be fixed or "
+                "largest_observed_regression"
             )
-        profiled_stage = stage_by_id(manifest, str(stage_id))
-        graph_capable = "cuda_graphs" in profiled_stage["selection"]["backend_capabilities"]
-        if graph_capable or profiler["selector"].get("graph_only"):
-            if graph_trace["applicability"] != "required":
+        if screen_selection["kind"] == "fixed":
+            if set(screen_selection) != {"kind", "screen"}:
                 raise ManifestError(
-                    "CUDA-graph-capable or graph-only profiling requires graph-node tracing"
+                    "fixed diagnostic screen selection requires exactly kind and screen"
                 )
-        if graph_trace["applicability"] == "required":
-            if graph_trace.get("granularity") != "node":
-                raise ManifestError("required CUDA graph tracing must use granularity=node")
-            if graph_trace.get("launch_origin") not in {"host-only", "host-and-device"}:
-                raise ManifestError(
-                    "required CUDA graph tracing needs host-only or host-and-device launch_origin"
-                )
-        elif not graph_trace.get("reason"):
-            raise ManifestError("not-applicable CUDA graph tracing requires a reason")
+            if screen_selection.get("screen") not in _stage_screen_ids(profiled_stage):
+                raise ManifestError("fixed diagnostic screen is absent from its target stage")
+        elif set(screen_selection) != {"kind"}:
+            raise ManifestError(
+                "largest-observed-regression screen selection requires exactly kind"
+            )
+        _validate_profiler_details(
+            config, profiled_stage, label=f"early_diagnostics[{diagnostic_id}]"
+        )
 
 
 def load_and_validate_manifest(path: pathlib.Path) -> tuple[dict[str, Any], str]:
@@ -951,7 +1156,15 @@ def binary_snapshot(executable: pathlib.Path) -> dict[str, Any]:
                 {"path": str(library), **stat_identity(library), "sha256": sha256_file(library)}
             )
         record["format"] = "elf"
-        record["ldd"] = ldd
+        # Raw ldd output contains ASLR load addresses, so retaining it in the
+        # provenance identity would make every resume differ despite identical
+        # binaries and libraries.  Preserve the stable invocation/result and
+        # the fully hashed resolved library inventory instead.
+        record["ldd"] = {
+            "argv": ldd["argv"],
+            "returncode": ldd["returncode"],
+            "resolved_library_count": len(libraries),
+        }
         record["libraries"] = libraries
     else:
         with resolved.open("rb") as source:
@@ -1148,6 +1361,8 @@ def build_schedule(manifest: dict[str, Any], stage: dict[str, Any]) -> list[dict
     policy = manifest["repetition_policy"]
     if stage["purpose"] == "exactness":
         orientations = ["AB"]
+    elif stage.get("screening_policy") is not None:
+        orientations = [stage["screening_policy"]["order"]]
     else:
         orientations = list(policy["order"])
     screens = stage.get("screens", [{"id": "default", "args": [], "weight": 1.0}])
@@ -1281,6 +1496,49 @@ def paired_log_report(
     }
 
 
+def single_pair_screen_report(
+    pair: dict[str, Any], *, direction: str, regression_threshold_percent: float
+) -> dict[str, Any]:
+    """Report one fail-fast screening pair without claiming statistical confidence."""
+    if direction not in ("higher", "lower"):
+        raise ValidationError("metric direction must be 'higher' or 'lower'")
+    baseline = float(pair["baseline"])
+    candidate = float(pair["candidate"])
+    if baseline <= 0 or candidate <= 0:
+        raise ValidationError("single-pair screening ratios require positive observations")
+    log_ratio = math.log(candidate / baseline)
+    percent = 100.0 * math.expm1(log_ratio)
+    benefit_percent = percent if direction == "higher" else -percent
+    signal = (
+        "regression_signal"
+        if benefit_percent <= -float(regression_threshold_percent)
+        else "clear_to_continue"
+    )
+    return {
+        "pair_count": 1,
+        "method": "single matched-pair fail-fast screen",
+        "direction": direction,
+        "geometric_ratio": math.exp(log_ratio),
+        "percent_change": percent,
+        "benefit_percent": benefit_percent,
+        "confidence_interval": None,
+        "confidence_claim": "none",
+        "signal": signal,
+        "regression_threshold_percent": float(regression_threshold_percent),
+        "raw_pairs": [
+            {
+                **pair,
+                "log_ratio": log_ratio,
+                "percent_change": percent,
+            }
+        ],
+        "evidence_boundary": (
+            "A single-pair screen is a preregistered fail-fast signal only; it is not "
+            "a confidence interval, equivalence result, or performance acceptance claim."
+        ),
+    }
+
+
 def performance_outcome(decision: str, policy: dict[str, Any]) -> str:
     """Map an executed statistical decision to a fail-closed gate outcome."""
     if decision in policy["acceptable_decisions"]:
@@ -1326,7 +1584,7 @@ def command_for_run(
     ]
     reject_forbidden_tokens(argv)
     validate_direct_target(pathlib.Path(argv[0]), direct_harness=executable.get("direct_harness"))
-    validate_argv(argv[1:], command.get("cli_schema"))
+    validate_argv(argv[1:], command.get("cli_schema"), argv[0])
     environment = sterile_environment(
         manifest.get("environment", {}),
         variant.get("environment", {}),

--- a/scripts/feature_validation/core.py
+++ b/scripts/feature_validation/core.py
@@ -1,0 +1,1149 @@
+"""Core schema, provenance, scheduling, and statistics for feature validation.
+
+This module intentionally uses only the Python standard library.  Commands are
+represented as argv lists until the one place where flock's ``-c`` interface
+requires a safely quoted shell command.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import pathlib
+import platform
+import re
+import shlex
+import statistics
+import subprocess
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+GPU_LOCK = "/tmp/beellama-single-gpu.lock"
+PURPOSE_ORDER = {
+    "exactness": 0,
+    "smoke": 1,
+    "kernel_screen": 2,
+    "production_confirmation": 3,
+    "long_context_acceptance": 4,
+}
+PROFILE_TOOLS = {"nsys", "ncu"}
+FORBIDDEN_TOKENS = {"taskset"}
+OPAQUE_WRAPPERS = {
+    "bash",
+    "dash",
+    "env",
+    "flock",
+    "nice",
+    "nohup",
+    "python",
+    "python3",
+    "sh",
+    "sudo",
+    "timeout",
+    "xargs",
+    "zsh",
+}
+IMMUTABLE_AB_OPTIONS = {
+    "-m",
+    "--model",
+    "-p",
+    "--prompt",
+    "-n",
+    "--n-predict",
+    "-d",
+    "--depth",
+    "-r",
+    "--repetitions",
+    "-b",
+    "--batch-size",
+    "-ub",
+    "--ubatch-size",
+    "-t",
+    "--threads",
+    "-tb",
+    "--threads-batch",
+    "-C",
+    "--cpu-mask",
+    "--cpu-range",
+    "--cpu-range-batch",
+    "--cpu-strict",
+    "-ngl",
+    "--n-gpu-layers",
+    "-fa",
+    "--flash-attn",
+    "-ctk",
+    "--cache-type-k",
+    "-ctv",
+    "--cache-type-v",
+    "--seed",
+}
+
+# This is deliberately a validation schema, not an invocation generator.  A
+# manifest may extend it with explicit option arities for a local harness.
+LLAMA_OPTION_ARITY: dict[str, int] = {
+    "-m": 1,
+    "--model": 1,
+    "-p": 1,
+    "--prompt": 1,
+    "-n": 1,
+    "--n-predict": 1,
+    "-d": 1,
+    "--depth": 1,
+    "-r": 1,
+    "--repetitions": 1,
+    "-b": 1,
+    "--batch-size": 1,
+    "-ub": 1,
+    "--ubatch-size": 1,
+    "-t": 1,
+    "--threads": 1,
+    "-tb": 1,
+    "--threads-batch": 1,
+    "-C": 1,
+    "--cpu-mask": 1,
+    "--cpu-range": 1,
+    "--cpu-range-batch": 1,
+    "--cpu-strict": 1,
+    "--poll": 1,
+    "-ngl": 1,
+    "--n-gpu-layers": 1,
+    "--n-gpu-layers-draft": 1,
+    "-sm": 1,
+    "--split-mode": 1,
+    "-mg": 1,
+    "--main-gpu": 1,
+    "-fa": 1,
+    "--flash-attn": 1,
+    "-ctk": 1,
+    "--cache-type-k": 1,
+    "-ctv": 1,
+    "--cache-type-v": 1,
+    "-nkvo": 1,
+    "--kv-offload": 0,
+    "--no-kv-offload": 0,
+    "--kv-cpu-pinned": 0,
+    "--no-kv-cpu-pinned": 0,
+    "--recurrent-state-offload": 0,
+    "--no-recurrent-state-offload": 0,
+    "--kv-gpu-layers": 1,
+    "--spec-draft-kv-gpu-layers": 1,
+    "--spec-draft-ubatch-size": 1,
+    "--spec-mtp-rs-planes": 1,
+    "--phase-aware-workspace": 0,
+    "--no-phase-aware-workspace": 0,
+    "--live-context-workspace": 0,
+    "--no-live-context-workspace": 0,
+    "--flash-attn-native-quants": 0,
+    "--no-flash-attn-native-quants": 0,
+    "--no-warmup": 0,
+    "--progress": 0,
+    "--kv-memory": 0,
+    "-o": 1,
+    "--output": 1,
+    "--ctx-size": 1,
+    "--parallel": 1,
+    "--cont-batching": 0,
+    "--kv-unified": 0,
+    "--fit": 1,
+    "--seed": 1,
+    "--cache-ram": 1,
+    "--verbosity": 1,
+    "--spec-type": 1,
+    "--spec-draft-model": 1,
+    "--spec-draft-n-max": 1,
+    "--spec-draft-p-min": 1,
+    "--spec-draft-type-k": 1,
+    "--spec-draft-type-v": 1,
+    "--host": 1,
+    "--port": 1,
+    "--alias": 1,
+}
+
+
+class ValidationError(ValueError):
+    """Base class for fail-closed validation errors."""
+
+
+class ManifestError(ValidationError):
+    """The preregistered manifest is incomplete or inconsistent."""
+
+
+class ProvenanceError(ValidationError):
+    """Observed source/build/input identity does not match the manifest."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def stat_identity(path: pathlib.Path) -> dict[str, int]:
+    observed = path.stat()
+    return {
+        "size": observed.st_size,
+        "mtime_ns": observed.st_mtime_ns,
+        "device": observed.st_dev,
+        "inode": observed.st_ino,
+    }
+
+
+def write_json_atomic(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def command_capture(
+    argv: list[str], cwd: pathlib.Path | None = None, timeout: float = 30.0
+) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            argv,
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {"argv": argv, "error": f"{type(error).__name__}: {error}"}
+    return {
+        "argv": argv,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def quote_argv(argv: Iterable[str]) -> str:
+    values = [str(value) for value in argv]
+    if not values:
+        raise ValidationError("cannot quote an empty argv")
+    if any("\x00" in value for value in values):
+        raise ValidationError("argv contains a NUL byte")
+    return shlex.join(values)
+
+
+def flock_argv(inner_argv: list[str]) -> list[str]:
+    """Return the required whole-command lock representation."""
+    return ["flock", GPU_LOCK, "-c", quote_argv(inner_argv)]
+
+
+def safe_slug(value: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value):
+        raise ManifestError(
+            f"{value!r} is not a safe identifier; use letters, digits, dot, underscore, or dash"
+        )
+    return value
+
+
+def validate_sha256(value: Any, label: str) -> str:
+    text = str(value)
+    if not re.fullmatch(r"[0-9a-fA-F]{64}", text):
+        raise ManifestError(f"{label} must be a 64-digit SHA-256")
+    return text.lower()
+
+
+def _basename(token: str) -> str:
+    return pathlib.PurePath(token).name
+
+
+def reject_forbidden_tokens(argv: Iterable[str]) -> None:
+    for token in argv:
+        if _basename(str(token)) in FORBIDDEN_TOKENS:
+            raise ValidationError("taskset is forbidden; use llama-native affinity controls")
+
+
+def validate_direct_target(
+    executable: pathlib.Path,
+    *,
+    profiler: bool = False,
+    direct_harness: dict[str, Any] | None = None,
+) -> None:
+    name = executable.name
+    if name in OPAQUE_WRAPPERS:
+        raise ValidationError(f"opaque/wrapper target {name!r} is not allowed")
+    if not profiler:
+        return
+    if re.fullmatch(r"llama-(bench|server|cli|perplexity)", name):
+        return
+    if direct_harness is None:
+        raise ValidationError(
+            "profiler target must be a direct llama binary or a declared direct local harness"
+        )
+    if direct_harness.get("kind") != "native_executable":
+        raise ValidationError("a profiler direct harness must be a native executable")
+    source_files = direct_harness.get("source_files")
+    if not isinstance(source_files, list) or not source_files:
+        raise ValidationError("a direct harness requires source_files with expected SHA-256 values")
+    for item in source_files:
+        if not isinstance(item, dict) or not item.get("path") or not item.get("sha256"):
+            raise ValidationError("each direct-harness source file needs path and sha256")
+        validate_sha256(item["sha256"], "direct-harness source sha256")
+        if not pathlib.Path(item["path"]).is_absolute():
+            raise ManifestError("direct-harness source paths must be absolute")
+
+
+def option_arities(schema: dict[str, Any] | None) -> tuple[dict[str, int], bool, int | None]:
+    schema = schema or {"builtin": "llama", "allow_positionals": False}
+    builtin = schema.get("builtin", "llama")
+    if builtin not in ("llama", "none"):
+        raise ManifestError(f"unknown CLI schema builtin {builtin!r}")
+    options = dict(LLAMA_OPTION_ARITY if builtin == "llama" else {})
+    for option, raw_arity in schema.get("options", {}).items():
+        arity = int(raw_arity)
+        if arity not in (0, 1):
+            raise ManifestError(f"option {option!r} arity must be 0 or 1")
+        options[str(option)] = arity
+    allow_unknown = bool(schema.get("allow_unknown_options", False))
+    if schema.get("allow_positionals", False):
+        positional_limit = schema.get("max_positionals")
+        return options, allow_unknown, None if positional_limit is None else int(positional_limit)
+    return options, allow_unknown, 0
+
+
+def validate_argv(argv: list[str], schema: dict[str, Any] | None = None) -> None:
+    reject_forbidden_tokens(argv)
+    options, allow_unknown, positional_limit = option_arities(schema)
+    positionals = 0
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--":
+            raise ValidationError("'--' positional passthrough is not allowed in validated commands")
+        if token.startswith("-") and token != "-":
+            option, separator, inline_value = token.partition("=")
+            if option not in options:
+                if allow_unknown:
+                    index += 1
+                    continue
+                raise ValidationError(f"unknown option {option!r}; declare its arity in cli_schema")
+            arity = options[option]
+            if arity == 0 and separator:
+                raise ValidationError(f"zero-arity option {option} cannot take a value")
+            if arity == 1:
+                if separator:
+                    if not inline_value:
+                        raise ValidationError(f"option {option} requires a non-empty value")
+                else:
+                    if index + 1 >= len(argv):
+                        raise ValidationError(f"option {option} requires one value")
+                    index += 1
+            index += 1
+            continue
+        positionals += 1
+        if positional_limit is not None and positionals > positional_limit:
+            raise ValidationError(
+                f"unexpected positional argument {token!r}; this often means a value was given to a zero-arity option"
+            )
+        index += 1
+
+
+def option_names(argv: list[str], schema: dict[str, Any] | None = None) -> list[str]:
+    """Return option names while respecting arity, so negative values are values."""
+    options, allow_unknown, _ = option_arities(schema)
+    names: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token.startswith("-") and token != "-":
+            option, separator, _ = token.partition("=")
+            if option in options:
+                names.append(option)
+                if options[option] == 1 and not separator:
+                    index += 1
+            elif allow_unknown:
+                names.append(option)
+        index += 1
+    return names
+
+
+def _forbidden_selection_key(value: Any, path: str = "selection") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = str(key).lower().replace("-", "_")
+            if normalized in {"architecture", "architecture_name", "model_family", "model_name"}:
+                raise ManifestError(
+                    f"{path}.{key} is forbidden; select by workload, tensor layout, and backend capability"
+                )
+            _forbidden_selection_key(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _forbidden_selection_key(child, f"{path}[{index}]")
+
+
+def _validate_selection(stage: dict[str, Any]) -> None:
+    selection = stage.get("selection")
+    if not isinstance(selection, dict):
+        raise ManifestError(f"stage {stage.get('id')!r} requires a selection object")
+    required = {"workload", "tensor_layout", "backend_capabilities", "execution_mode"}
+    missing = sorted(required - selection.keys())
+    if missing:
+        raise ManifestError(f"stage {stage['id']!r} selection is missing {missing}")
+    if selection["workload"] not in {"exactness", "prefill", "decode", "mixed"}:
+        raise ManifestError("workload must be exactness, prefill, decode, or mixed")
+    if not isinstance(selection["tensor_layout"], dict) or not selection["tensor_layout"]:
+        raise ManifestError("tensor_layout must be a non-empty property object")
+    if not isinstance(selection["backend_capabilities"], list):
+        raise ManifestError("backend_capabilities must be an array")
+    if not all(isinstance(value, str) and value for value in selection["backend_capabilities"]):
+        raise ManifestError("backend_capabilities entries must be non-empty strings")
+    if selection["execution_mode"] not in {
+        "direct_process",
+        "direct_command",
+        "cuda_graph_replay",
+        "production_binary",
+    }:
+        raise ManifestError("unknown execution_mode")
+    _forbidden_selection_key(selection)
+    if selection["execution_mode"] == "cuda_graph_replay":
+        capabilities = {str(value) for value in selection["backend_capabilities"]}
+        if "cuda_graphs" not in capabilities:
+            raise ManifestError("cuda_graph_replay requires the cuda_graphs capability")
+
+
+def _validate_repetitions(manifest: dict[str, Any]) -> None:
+    policy = manifest.get("repetition_policy")
+    if not isinstance(policy, dict):
+        raise ManifestError("repetition_policy is required")
+    if policy.get("minimum_pairs") != 3 or policy.get("maximum_pairs") != 5:
+        raise ManifestError("repetition policy must preregister exactly 3 initial and 5 maximum pairs")
+    order = policy.get("order")
+    if order != ["AB", "BA", "AB", "BA", "AB"]:
+        raise ManifestError("repetition order must be the preregistered AB/BA/AB/BA/AB sequence")
+    if policy.get("confidence_level") != 0.95:
+        raise ManifestError("the current honest paired interval supports confidence_level 0.95")
+    rule = policy.get("extension_rule")
+    if not isinstance(rule, dict) or rule.get("kind") != "extend_only_if_inconclusive":
+        raise ManifestError("extension_rule.kind must be extend_only_if_inconclusive")
+    thresholds = rule.get("thresholds")
+    required = {"improvement_percent", "regression_percent", "equivalence_percent"}
+    if not isinstance(thresholds, dict) or required - thresholds.keys():
+        raise ManifestError(f"extension thresholds must include {sorted(required)}")
+    for key in required:
+        if float(thresholds[key]) < 0:
+            raise ManifestError(f"extension threshold {key} must be non-negative")
+
+
+def variant_executables(variant: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Normalize a variant's executable roles (legacy single role is useful in tests)."""
+    if "executables" in variant:
+        executables = variant["executables"]
+        if not isinstance(executables, dict) or not executables:
+            raise ManifestError("variant executables must be a non-empty role object")
+        return executables
+    if variant.get("executable"):
+        return {
+            "default": {
+                "path": variant["executable"],
+                "expected_sha256": variant.get("expected_sha256"),
+                "build": variant.get("build"),
+                "direct_harness": variant.get("direct_harness"),
+            }
+        }
+    raise ManifestError("variant requires executable roles")
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ManifestError(f"schema_version must be {SCHEMA_VERSION}")
+    study = manifest.get("study")
+    if not isinstance(study, dict):
+        raise ManifestError("study object is required")
+    safe_slug(str(study.get("id", "")))
+    budget = study.get("early_decision_target_seconds")
+    if budget != {"minimum": 30, "maximum": 90}:
+        raise ManifestError("study must state the 30-90 second early-decision target")
+    artifact_root = manifest.get("artifact_root")
+    if not isinstance(artifact_root, str) or not pathlib.Path(artifact_root).is_absolute():
+        raise ManifestError("artifact_root must be an absolute path outside the repository")
+
+    variants = manifest.get("variants")
+    if not isinstance(variants, dict) or set(variants) != {"baseline", "candidate"}:
+        raise ManifestError("variants must contain exactly baseline and candidate")
+    for name, variant in variants.items():
+        if not isinstance(variant, dict):
+            raise ManifestError(f"variant {name} must be an object")
+        for key in ("source_root", "expected_commit", "tree_policy"):
+            if not variant.get(key):
+                raise ManifestError(f"variant {name} requires {key}")
+        if not pathlib.Path(variant["source_root"]).is_absolute():
+            raise ManifestError(f"variant {name} source_root must be absolute")
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", str(variant["expected_commit"])):
+            raise ManifestError(f"variant {name} expected_commit must be a full 40-digit commit")
+        if variant["tree_policy"] not in ("clean", "expected_dirty"):
+            raise ManifestError(f"variant {name} tree_policy must be clean or expected_dirty")
+        if variant["tree_policy"] == "expected_dirty" and not variant.get("expected_dirty_fingerprint"):
+            raise ManifestError(f"variant {name} expected_dirty requires expected_dirty_fingerprint")
+        if variant["tree_policy"] == "expected_dirty":
+            validate_sha256(
+                variant["expected_dirty_fingerprint"],
+                f"variant {name} expected_dirty_fingerprint",
+            )
+        for role, executable in variant_executables(variant).items():
+            safe_slug(str(role))
+            if not isinstance(executable, dict):
+                raise ManifestError(f"variant {name} executable role {role} must be an object")
+            if not executable.get("path") or not executable.get("expected_sha256"):
+                raise ManifestError(f"variant {name} executable role {role} requires path and expected_sha256")
+            if not pathlib.Path(executable["path"]).is_absolute():
+                raise ManifestError(f"variant {name} executable role {role} path must be absolute")
+            validate_sha256(executable["expected_sha256"], f"variant {name}/{role} expected_sha256")
+            build = executable.get("build")
+            if not isinstance(build, dict) or build.get("mode") not in ("cmake_required", "not_applicable"):
+                raise ManifestError(
+                    f"variant {name} executable role {role} build.mode must be cmake_required or not_applicable"
+                )
+            if build["mode"] == "not_applicable" and not build.get("reason"):
+                raise ManifestError(f"variant {name} executable role {role} non-CMake build requires a reason")
+        try:
+            pathlib.Path(artifact_root).resolve().relative_to(pathlib.Path(variant["source_root"]).resolve())
+        except ValueError:
+            pass
+        else:
+            raise ManifestError("artifact_root must be outside every variant source repository")
+
+    inputs = manifest.get("inputs", [])
+    if not isinstance(inputs, list):
+        raise ManifestError("inputs must be an array")
+    for item in inputs:
+        if not isinstance(item, dict) or not item.get("path") or not item.get("sha256"):
+            raise ManifestError("every input requires path and sha256")
+        if not pathlib.Path(item["path"]).is_absolute():
+            raise ManifestError("every input path must be absolute")
+        validate_sha256(item["sha256"], f"input {item['path']} sha256")
+
+    _validate_repetitions(manifest)
+    stages = manifest.get("stages")
+    if not isinstance(stages, list) or not stages:
+        raise ManifestError("stages must be a non-empty array")
+    seen: set[str] = set()
+    purpose_counts = {purpose: 0 for purpose in PURPOSE_ORDER}
+    smoke_workloads: set[str] = set()
+    last_order = -1
+    for index, stage in enumerate(stages):
+        if not isinstance(stage, dict):
+            raise ManifestError("every stage must be an object")
+        stage_id = safe_slug(str(stage.get("id", "")))
+        if stage_id in seen:
+            raise ManifestError(f"duplicate stage id {stage_id!r}")
+        seen.add(stage_id)
+        purpose = stage.get("purpose")
+        if purpose not in PURPOSE_ORDER:
+            raise ManifestError(f"stage {stage_id!r} has unknown purpose {purpose!r}")
+        purpose_counts[purpose] += 1
+        order = PURPOSE_ORDER[purpose]
+        if order < last_order:
+            raise ManifestError("validation stages must follow the declared ladder order")
+        last_order = order
+        if index == 0 and purpose != "exactness":
+            raise ManifestError("the first stage must be exactness")
+        if stage.get("resource") not in ("cpu", "gpu"):
+            raise ManifestError(f"stage {stage_id!r} resource must be cpu or gpu")
+        timeout = stage.get("timeout_seconds")
+        if not isinstance(timeout, (int, float)) or not (0 < float(timeout) <= 86400):
+            raise ManifestError(f"stage {stage_id!r} requires timeout_seconds in (0, 86400]")
+        if not stage.get("progress"):
+            raise ManifestError(f"stage {stage_id!r} must declare a visible progress mechanism")
+        _validate_selection(stage)
+        selection = stage["selection"]
+        if purpose == "exactness" and selection["workload"] != "exactness":
+            raise ManifestError("the exactness gate selection.workload must be exactness")
+        if purpose == "smoke":
+            if selection["workload"] not in {"prefill", "decode"}:
+                raise ManifestError("smoke stages must select prefill or decode")
+            if selection.get("duration_class") != "short":
+                raise ManifestError("smoke stages must declare duration_class=short")
+            smoke_workloads.add(selection["workload"])
+            if selection["workload"] == "decode":
+                graph = selection.get("cuda_graph_replay")
+                if not isinstance(graph, dict) or graph.get("applicability") not in {
+                    "required",
+                    "not_applicable",
+                }:
+                    raise ManifestError(
+                        "decode smoke must preregister CUDA-graph applicability as required or not_applicable"
+                    )
+                if graph["applicability"] == "required" and selection["execution_mode"] != "cuda_graph_replay":
+                    raise ManifestError("applicable decode CUDA graphs must be screened by replay")
+                if graph["applicability"] == "not_applicable" and not graph.get("reason"):
+                    raise ManifestError("not-applicable decode CUDA graphs require a reason")
+        if purpose == "production_confirmation":
+            if selection["execution_mode"] != "production_binary":
+                raise ManifestError("production confirmation must execute a production binary")
+            if not isinstance(selection.get("context_depth_tokens"), int) or selection["context_depth_tokens"] <= 0:
+                raise ManifestError("production confirmation requires a positive selected context depth")
+        if purpose == "long_context_acceptance":
+            if selection.get("acceptance_class") != "long_context":
+                raise ManifestError("final acceptance must declare acceptance_class=long_context")
+            if not isinstance(selection.get("context_depth_tokens"), int) or selection["context_depth_tokens"] <= 0:
+                raise ManifestError("long-context acceptance requires a positive context depth")
+        command = stage.get("command")
+        if not isinstance(command, dict):
+            raise ManifestError(f"stage {stage_id!r} requires command")
+        if command.get("cli_schema", {}).get("allow_unknown_options", False):
+            raise ManifestError("allow_unknown_options is not fail-closed; declare every option arity")
+        executable_role = str(command.get("executable_role", "default"))
+        for variant_name, variant in variants.items():
+            if executable_role not in variant_executables(variant):
+                raise ManifestError(
+                    f"stage {stage_id!r} executable role {executable_role!r} is absent from {variant_name}"
+                )
+        common_args = [str(value) for value in command.get("common_args", [])]
+        baseline_args = [str(value) for value in command.get("baseline_args", [])]
+        candidate_args = [str(value) for value in command.get("candidate_args", [])]
+        for variant_name in ("baseline", "candidate"):
+            delta = baseline_args if variant_name == "baseline" else candidate_args
+            validate_argv(common_args + delta, command.get("cli_schema"))
+        baseline_environment = {
+            str(key): str(value) for key, value in command.get("baseline_environment", {}).items()
+        }
+        candidate_environment = {
+            str(key): str(value) for key, value in command.get("candidate_environment", {}).items()
+        }
+        if baseline_args != candidate_args or baseline_environment != candidate_environment:
+            controlled = command.get("controlled_delta")
+            if not isinstance(controlled, dict) or not controlled.get("reason"):
+                raise ManifestError(f"stage {stage_id!r} A/B differences require a controlled_delta reason")
+            if controlled.get("baseline_args", []) != baseline_args or controlled.get(
+                "candidate_args", []
+            ) != candidate_args:
+                raise ManifestError("controlled_delta must reproduce the exact baseline/candidate args")
+            if controlled.get("baseline_environment", {}) != baseline_environment or controlled.get(
+                "candidate_environment", {}
+            ) != candidate_environment:
+                raise ManifestError("controlled_delta must reproduce exact baseline/candidate environments")
+            observed_options = sorted(
+                set(option_names(baseline_args, command.get("cli_schema")))
+                | set(option_names(candidate_args, command.get("cli_schema")))
+            )
+            if sorted(controlled.get("allowed_options", [])) != observed_options:
+                raise ManifestError("controlled_delta.allowed_options must exactly name every delta option")
+            forbidden = sorted(set(observed_options) & IMMUTABLE_AB_OPTIONS)
+            if forbidden:
+                raise ManifestError(
+                    f"stage {stage_id!r} changes immutable A/B workload settings in variant args: {forbidden}"
+                )
+            observed_environment = sorted(set(baseline_environment) | set(candidate_environment))
+            if sorted(controlled.get("allowed_environment", [])) != observed_environment:
+                raise ManifestError(
+                    "controlled_delta.allowed_environment must exactly name every delta environment variable"
+                )
+        screens = stage.get("screens", [{"id": "default", "args": [], "weight": 1.0}])
+        if not isinstance(screens, list) or not screens:
+            raise ManifestError(f"stage {stage_id!r} screens must be non-empty")
+        for screen in screens:
+            safe_slug(str(screen.get("id", "")))
+            if float(screen.get("weight", 0)) <= 0:
+                raise ManifestError("every screen weight must be positive")
+            screen_args = [str(value) for value in screen.get("args", [])]
+            validate_argv(common_args + screen_args + baseline_args, command.get("cli_schema"))
+            validate_argv(common_args + screen_args + candidate_args, command.get("cli_schema"))
+        if purpose == "kernel_screen":
+            if selection["workload"] != "prefill" or selection["execution_mode"] != "direct_command":
+                raise ManifestError("kernel screens must use a direct-command prefill workload")
+            spans = {screen.get("span_class") for screen in screens}
+            if spans != {"low", "mid", "high"}:
+                raise ManifestError("kernel_screen must preregister low, mid, and high spans")
+            aggregation = stage.get("aggregation")
+            if not isinstance(aggregation, dict) or aggregation.get("mode") not in (
+                "weighted_mean",
+                "weighted_harmonic",
+            ):
+                raise ManifestError("kernel_screen requires weighted_mean or weighted_harmonic aggregation")
+            if aggregation.get("weight_source") != "real_ubatch_geometry":
+                raise ManifestError("kernel_screen weights must come from real_ubatch_geometry")
+            for screen in screens:
+                if not isinstance(screen.get("span_tokens"), int) or screen["span_tokens"] <= 0:
+                    raise ManifestError("kernel screens require a positive span_tokens")
+                occurrences = screen.get("ubatch_occurrences")
+                if not isinstance(occurrences, int) or occurrences <= 0:
+                    raise ManifestError("kernel screens require positive ubatch_occurrences")
+                if float(screen["weight"]) != float(occurrences):
+                    raise ManifestError("kernel screen weight must equal its real ubatch_occurrences")
+        if purpose != "exactness" and not isinstance(stage.get("metric"), dict):
+            raise ManifestError(f"performance stage {stage_id!r} requires a metric extractor")
+        if purpose == "exactness" and stage.get("comparison", {}).get("mode") not in (
+            "stdout_sha256",
+            "file_sha256",
+        ):
+            raise ManifestError("exactness stage requires stdout_sha256 or file_sha256 comparison")
+    if stages[-1].get("purpose") != "long_context_acceptance" or not stages[-1].get("mandatory"):
+        raise ManifestError("the final stage must be a mandatory long_context_acceptance gate")
+    for purpose in ("exactness", "kernel_screen", "production_confirmation", "long_context_acceptance"):
+        if purpose_counts[purpose] != 1:
+            raise ManifestError(f"the ladder requires exactly one {purpose} stage")
+    if smoke_workloads != {"prefill", "decode"}:
+        raise ManifestError("the ladder requires short prefill and short decode smoke stages")
+
+    profiler = manifest.get("profiler")
+    if profiler is not None:
+        if not isinstance(profiler, dict):
+            raise ManifestError("profiler must be an object")
+        if profiler.get("pattern") != "one_nsys_discovery_then_one_filtered_ncu":
+            raise ManifestError("profiler pattern must preregister one NSYS discovery then one filtered NCU")
+        if profiler.get("profile_repetitions") != 1:
+            raise ManifestError("profiler capture must run once per preregistered stage")
+        stage_id = profiler.get("stage")
+        if stage_id not in seen:
+            raise ManifestError(f"profiler references unknown stage {stage_id!r}")
+        if stage_by_id(manifest, str(stage_id))["purpose"] != "production_confirmation":
+            raise ManifestError("profiler discovery/capture must target production_confirmation")
+        target_variant = profiler.get("variant")
+        if target_variant not in variants:
+            raise ManifestError("profiler variant must be baseline or candidate")
+        if not isinstance(profiler.get("selector"), dict) or not profiler["selector"].get("kernel_regex"):
+            raise ManifestError("profiler requires a discovery selector with kernel_regex")
+
+
+def load_and_validate_manifest(path: pathlib.Path) -> tuple[dict[str, Any], str]:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ManifestError("manifest root must be an object")
+    validate_manifest(manifest)
+    return manifest, sha256_file(path)
+
+
+def _git_text(root: pathlib.Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ProvenanceError(f"git {' '.join(args)} failed for {root}: {result.stderr.strip()}")
+    return result.stdout
+
+
+def git_snapshot(root: pathlib.Path) -> dict[str, Any]:
+    resolved = pathlib.Path(_git_text(root, "rev-parse", "--show-toplevel").strip()).resolve()
+    status = _git_text(resolved, "status", "--porcelain=v1", "--untracked-files=all")
+    unstaged = subprocess.run(
+        ["git", "-C", str(resolved), "diff", "--binary", "HEAD", "--"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    staged = subprocess.run(
+        ["git", "-C", str(resolved), "diff", "--binary", "--cached", "HEAD", "--"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    untracked_raw = subprocess.run(
+        ["git", "-C", str(resolved), "ls-files", "--others", "--exclude-standard", "-z"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    untracked: list[dict[str, Any]] = []
+    for raw in untracked_raw.split(b"\0"):
+        if not raw:
+            continue
+        relative = pathlib.Path(os.fsdecode(raw))
+        source = resolved / relative
+        if source.is_file():
+            untracked.append({"path": str(relative), "sha256": sha256_file(source)})
+    fingerprint_body = {
+        "status": status,
+        "unstaged_sha256": sha256_bytes(unstaged),
+        "staged_sha256": sha256_bytes(staged),
+        "untracked": untracked,
+    }
+    return {
+        "root": str(resolved),
+        "head": _git_text(resolved, "rev-parse", "HEAD").strip(),
+        "head_tree": _git_text(resolved, "rev-parse", "HEAD^{tree}").strip(),
+        "branch": _git_text(resolved, "branch", "--show-current").strip(),
+        **fingerprint_body,
+        "dirty_fingerprint": canonical_sha256(fingerprint_body),
+    }
+
+
+def _find_cmake_cache(executable: pathlib.Path, build: dict[str, Any]) -> pathlib.Path | None:
+    if build.get("cache"):
+        candidate = pathlib.Path(build["cache"]).expanduser().resolve()
+        return candidate if candidate.is_file() else None
+    for parent in executable.parents:
+        candidate = parent / "CMakeCache.txt"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def cmake_snapshot(executable: pathlib.Path, build: dict[str, Any]) -> dict[str, Any]:
+    if build["mode"] == "not_applicable":
+        return {"mode": "not_applicable", "reason": build["reason"]}
+    cache = _find_cmake_cache(executable, build)
+    if cache is None:
+        raise ProvenanceError(f"no discoverable CMakeCache.txt for {executable}")
+    entries: dict[str, str] = {}
+    for line in cache.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line or line.startswith(("#", "//")) or "=" not in line:
+            continue
+        key_type, value = line.split("=", 1)
+        entries[key_type.split(":", 1)[0]] = value
+    expected = {str(key): str(value) for key, value in build.get("expected_options", {}).items()}
+    mismatches = {
+        key: {"expected": value, "observed": entries.get(key)}
+        for key, value in expected.items()
+        if entries.get(key) != value
+    }
+    if mismatches:
+        raise ProvenanceError(f"CMake option mismatch for {executable}: {mismatches}")
+    return {
+        "mode": "cmake",
+        "cache": str(cache),
+        "cache_sha256": sha256_file(cache),
+        "cache_stat": stat_identity(cache),
+        "entries": entries,
+    }
+
+
+def binary_snapshot(executable: pathlib.Path) -> dict[str, Any]:
+    resolved = executable.expanduser().resolve()
+    if not resolved.is_file():
+        raise ProvenanceError(f"executable is missing: {resolved}")
+    if not os.access(resolved, os.X_OK):
+        raise ProvenanceError(f"executable is not executable: {resolved}")
+    record: dict[str, Any] = {
+        "path": str(executable),
+        "resolved_path": str(resolved),
+        **stat_identity(resolved),
+        "sha256": sha256_file(resolved),
+    }
+    prefix = resolved.read_bytes()[:4]
+    if prefix == b"\x7fELF":
+        ldd = command_capture(["ldd", str(resolved)])
+        if ldd.get("returncode") != 0:
+            raise ProvenanceError(f"ldd failed for {resolved}")
+        libraries: list[dict[str, Any]] = []
+        seen: set[pathlib.Path] = set()
+        for line in str(ldd.get("stdout", "")).splitlines():
+            match = re.search(r"(?:=>\s+)?(/[^\s]+)\s+\(0x", line)
+            if match is None:
+                continue
+            library = pathlib.Path(match.group(1)).resolve()
+            if library in seen or not library.is_file():
+                continue
+            seen.add(library)
+            libraries.append(
+                {"path": str(library), **stat_identity(library), "sha256": sha256_file(library)}
+            )
+        record["format"] = "elf"
+        record["ldd"] = ldd
+        record["libraries"] = libraries
+    else:
+        with resolved.open("rb") as source:
+            first_line = source.readline(4096).decode("utf-8", errors="replace").rstrip()
+        record["format"] = "script_or_other"
+        record["shebang"] = first_line if first_line.startswith("#!") else None
+    return record
+
+
+def verify_variant(name: str, variant: dict[str, Any]) -> dict[str, Any]:
+    source = git_snapshot(pathlib.Path(variant["source_root"]))
+    if source["head"] != variant["expected_commit"]:
+        raise ProvenanceError(
+            f"{name} source commit mismatch: expected {variant['expected_commit']}, observed {source['head']}"
+        )
+    if variant["tree_policy"] == "clean" and source["status"]:
+        raise ProvenanceError(f"{name} source tree is dirty but the manifest requires clean")
+    if variant["tree_policy"] == "expected_dirty":
+        expected = variant["expected_dirty_fingerprint"]
+        if source["dirty_fingerprint"] != expected:
+            raise ProvenanceError(
+                f"{name} dirty-tree fingerprint mismatch: expected {expected}, observed {source['dirty_fingerprint']}"
+            )
+    executables: dict[str, Any] = {}
+    for role, executable in variant_executables(variant).items():
+        binary = binary_snapshot(pathlib.Path(executable["path"]))
+        if binary["sha256"] != executable["expected_sha256"]:
+            raise ProvenanceError(
+                f"{name}/{role} binary SHA-256 mismatch: expected {executable['expected_sha256']}, "
+                f"observed {binary['sha256']}"
+            )
+        harness = executable.get("direct_harness")
+        if harness:
+            validate_direct_target(pathlib.Path(binary["resolved_path"]), direct_harness=harness)
+            for item in harness["source_files"]:
+                source_path = pathlib.Path(item["path"]).expanduser().resolve()
+                if not source_path.is_file() or sha256_file(source_path) != item["sha256"]:
+                    raise ProvenanceError(f"direct-harness source identity mismatch: {source_path}")
+        executables[role] = {
+            "binary": binary,
+            "build": cmake_snapshot(pathlib.Path(binary["resolved_path"]), executable["build"]),
+            "direct_harness": harness,
+        }
+    return {"source": source, "executables": executables}
+
+
+def capture_provenance(manifest: dict[str, Any], manifest_sha256: str) -> dict[str, Any]:
+    variants = {
+        name: verify_variant(name, variant) for name, variant in manifest["variants"].items()
+    }
+    inputs: list[dict[str, Any]] = []
+    for item in manifest.get("inputs", []):
+        path = pathlib.Path(item["path"]).expanduser().resolve()
+        if not path.is_file():
+            raise ProvenanceError(f"input is missing: {path}")
+        observed = sha256_file(path)
+        if observed != item["sha256"]:
+            raise ProvenanceError(
+                f"input SHA-256 mismatch for {path}: expected {item['sha256']}, observed {observed}"
+            )
+        inputs.append(
+            {
+                "role": item.get("role", "input"),
+                "path": str(path),
+                **stat_identity(path),
+                "sha256": observed,
+            }
+        )
+    host = {
+        "captured_utc": utc_now(),
+        "platform": platform.platform(),
+        "uname": list(platform.uname()),
+        "python": platform.python_version(),
+        "load_average": list(os.getloadavg()),
+        "proc_loadavg": pathlib.Path("/proc/loadavg").read_text(encoding="utf-8").strip()
+        if pathlib.Path("/proc/loadavg").is_file()
+        else None,
+        "lscpu": command_capture(["lscpu", "--json"]),
+        "nvidia_smi_version": command_capture(["nvidia-smi", "--version"]),
+        "nsys_version": command_capture(["nsys", "--version"]),
+        "ncu_version": command_capture(["ncu", "--version"]),
+    }
+    identity = {
+        "manifest_sha256": manifest_sha256,
+        "runner_schema_version": SCHEMA_VERSION,
+        "variants": variants,
+        "inputs": inputs,
+    }
+    body = {
+        **identity,
+        "host": host,
+    }
+    body["identity_fingerprint"] = canonical_sha256(identity)
+    body["fingerprint"] = canonical_sha256(body)
+    return body
+
+
+def build_schedule(manifest: dict[str, Any], stage: dict[str, Any]) -> list[dict[str, Any]]:
+    policy = manifest["repetition_policy"]
+    if stage["purpose"] == "exactness":
+        orientations = ["AB"]
+    else:
+        orientations = list(policy["order"])
+    screens = stage.get("screens", [{"id": "default", "args": [], "weight": 1.0}])
+    schedule: list[dict[str, Any]] = []
+    for pair_index, orientation in enumerate(orientations, start=1):
+        variant_order = ["baseline", "candidate"] if orientation == "AB" else ["candidate", "baseline"]
+        for screen in screens:
+            for order_index, variant in enumerate(variant_order, start=1):
+                schedule.append(
+                    {
+                        "run_id": f"pair-{pair_index:02d}-{safe_slug(str(screen['id']))}-{order_index:02d}-{variant}",
+                        "pair": pair_index,
+                        "orientation": orientation,
+                        "order": order_index,
+                        "variant": variant,
+                        "screen": str(screen["id"]),
+                        "weight": float(screen.get("weight", 1.0)),
+                    }
+                )
+    return schedule
+
+
+def extract_metric(metric: dict[str, Any], stdout: str, stderr: str) -> float:
+    stream_name = metric.get("stream", "stdout")
+    if stream_name == "stdout":
+        text = stdout
+    elif stream_name == "stderr":
+        text = stderr
+    elif stream_name == "combined":
+        text = stdout + "\n" + stderr
+    else:
+        raise ValidationError(f"unsupported metric stream {stream_name!r}")
+    pattern = metric.get("regex")
+    if not isinstance(pattern, str):
+        raise ValidationError("metric regex is required")
+    matches = list(re.finditer(pattern, text, flags=re.MULTILINE))
+    if not matches:
+        raise ValidationError(f"metric regex did not match: {pattern!r}")
+    policy = metric.get("match", "last")
+    if policy == "only" and len(matches) != 1:
+        raise ValidationError(f"metric regex matched {len(matches)} times; exactly one was required")
+    match = matches[0] if policy == "first" else matches[-1]
+    group = metric.get("group", 1)
+    try:
+        value = float(match.group(group))
+    except (IndexError, ValueError) as error:
+        raise ValidationError(f"metric match cannot be converted to float: {error}") from error
+    if not math.isfinite(value) or value <= 0:
+        raise ValidationError(f"metric must be finite and positive, observed {value}")
+    return value
+
+
+def aggregate_screen_values(values: list[tuple[float, float]], mode: str) -> float:
+    if not values:
+        raise ValidationError("cannot aggregate an empty screen set")
+    total_weight = sum(weight for _, weight in values)
+    if total_weight <= 0:
+        raise ValidationError("screen weights must sum to a positive value")
+    if mode == "weighted_mean":
+        return sum(value * weight for value, weight in values) / total_weight
+    if mode == "weighted_harmonic":
+        return total_weight / sum(weight / value for value, weight in values)
+    raise ValidationError(f"unknown aggregation mode {mode!r}")
+
+
+T_CRITICAL_95 = {
+    1: 12.7062047364,
+    2: 4.3026527297,
+    3: 3.1824463053,
+    4: 2.7764451052,
+}
+
+
+def paired_log_report(
+    pairs: list[dict[str, Any]],
+    *,
+    direction: str,
+    thresholds: dict[str, Any],
+) -> dict[str, Any]:
+    if len(pairs) not in (3, 5):
+        raise ValidationError("paired statistics require exactly 3 or 5 independent matched pairs")
+    if direction not in ("higher", "lower"):
+        raise ValidationError("metric direction must be 'higher' or 'lower'")
+    logs: list[float] = []
+    raw: list[dict[str, Any]] = []
+    for pair in pairs:
+        baseline = float(pair["baseline"])
+        candidate = float(pair["candidate"])
+        if baseline <= 0 or candidate <= 0:
+            raise ValidationError("paired log ratios require positive observations")
+        log_ratio = math.log(candidate / baseline)
+        logs.append(log_ratio)
+        raw.append({**pair, "log_ratio": log_ratio, "percent_change": 100.0 * math.expm1(log_ratio)})
+    mean_log = statistics.fmean(logs)
+    standard_error = statistics.stdev(logs) / math.sqrt(len(logs))
+    margin = T_CRITICAL_95[len(logs) - 1] * standard_error
+    lower_log = mean_log - margin
+    upper_log = mean_log + margin
+    percent = 100.0 * math.expm1(mean_log)
+    interval = [100.0 * math.expm1(lower_log), 100.0 * math.expm1(upper_log)]
+
+    if direction == "higher":
+        benefit_interval = interval
+        benefit_percent = percent
+    else:
+        benefit_interval = [-interval[1], -interval[0]]
+        benefit_percent = -percent
+    improvement = float(thresholds["improvement_percent"])
+    regression = float(thresholds["regression_percent"])
+    equivalence = float(thresholds["equivalence_percent"])
+    if benefit_interval[0] >= improvement:
+        decision = "improvement"
+    elif benefit_interval[1] <= -regression:
+        decision = "regression"
+    elif benefit_interval[0] >= -equivalence and benefit_interval[1] <= equivalence:
+        decision = "equivalent"
+    else:
+        decision = "inconclusive"
+    return {
+        "pair_count": len(pairs),
+        "method": "paired log ratio with two-sided Student-t 95% interval",
+        "direction": direction,
+        "geometric_ratio": math.exp(mean_log),
+        "percent_change": percent,
+        "percent_interval_95": interval,
+        "benefit_percent": benefit_percent,
+        "benefit_interval_95": benefit_interval,
+        "decision": decision,
+        "thresholds": {key: float(value) for key, value in thresholds.items()},
+        "raw_pairs": raw,
+    }
+
+
+def sterile_environment(*parts: dict[str, Any]) -> dict[str, str]:
+    environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "LC_ALL": "C",
+    }
+    for part in parts:
+        for key, value in part.items():
+            environment[str(key)] = str(value)
+    return environment
+
+
+def stage_by_id(manifest: dict[str, Any], stage_id: str) -> dict[str, Any]:
+    for stage in manifest["stages"]:
+        if stage["id"] == stage_id:
+            return stage
+    raise ManifestError(f"unknown stage {stage_id!r}")
+
+
+def command_for_run(
+    manifest: dict[str, Any], stage: dict[str, Any], run: dict[str, Any]
+) -> tuple[list[str], dict[str, str]]:
+    variant_name = run["variant"]
+    variant = manifest["variants"][variant_name]
+    command = stage["command"]
+    executable = variant_executables(variant)[str(command.get("executable_role", "default"))]
+    screen = next(item for item in stage.get("screens", [{"id": "default", "args": []}]) if item["id"] == run["screen"])
+    argv = [
+        str(pathlib.Path(executable["path"]).expanduser().resolve()),
+        *[str(value) for value in command.get("common_args", [])],
+        *[str(value) for value in screen.get("args", [])],
+        *[str(value) for value in command.get(f"{variant_name}_args", [])],
+    ]
+    reject_forbidden_tokens(argv)
+    validate_direct_target(pathlib.Path(argv[0]), direct_harness=executable.get("direct_harness"))
+    validate_argv(argv[1:], command.get("cli_schema"))
+    environment = sterile_environment(
+        manifest.get("environment", {}),
+        variant.get("environment", {}),
+        command.get("environment", {}),
+        command.get(f"{variant_name}_environment", {}),
+    )
+    return argv, environment
+
+
+def host_load_snapshot() -> dict[str, Any]:
+    meminfo: dict[str, int] = {}
+    path = pathlib.Path("/proc/meminfo")
+    if path.is_file():
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            key, separator, remainder = line.partition(":")
+            if separator and key in {"MemAvailable", "MemFree", "SwapFree", "Mlocked", "PageTables"}:
+                match = re.search(r"([0-9]+)", remainder)
+                if match:
+                    meminfo[f"{key}_kib"] = int(match.group(1))
+    return {
+        "captured_utc": utc_now(),
+        "load_average": list(os.getloadavg()),
+        "meminfo": meminfo,
+    }

--- a/scripts/feature_validation/core.py
+++ b/scripts/feature_validation/core.py
@@ -16,6 +16,7 @@ import pathlib
 import platform
 import re
 import shlex
+import shutil
 import statistics
 import subprocess
 from typing import Any, Iterable
@@ -84,7 +85,7 @@ IMMUTABLE_AB_OPTIONS = {
 
 # This is deliberately a validation schema, not an invocation generator.  A
 # manifest may extend it with explicit option arities for a local harness.
-LLAMA_OPTION_ARITY: dict[str, int] = {
+LLAMA_COMMON_OPTION_ARITY: dict[str, int] = {
     "-m": 1,
     "--model": 1,
     "-p": 1,
@@ -122,7 +123,7 @@ LLAMA_OPTION_ARITY: dict[str, int] = {
     "--cache-type-k": 1,
     "-ctv": 1,
     "--cache-type-v": 1,
-    "-nkvo": 1,
+    "-nkvo": 0,
     "--kv-offload": 0,
     "--no-kv-offload": 0,
     "--kv-cpu-pinned": 0,
@@ -161,6 +162,14 @@ LLAMA_OPTION_ARITY: dict[str, int] = {
     "--host": 1,
     "--port": 1,
     "--alias": 1,
+}
+
+# llama-bench has its own argument parser.  Unlike common_arg, both of its
+# no-KV-offload spellings consume an explicit 0/1 value.
+LLAMA_BENCH_OPTION_ARITY = {
+    **LLAMA_COMMON_OPTION_ARITY,
+    "-nkvo": 1,
+    "--no-kv-offload": 1,
 }
 
 
@@ -205,6 +214,7 @@ def stat_identity(path: pathlib.Path) -> dict[str, int]:
     return {
         "size": observed.st_size,
         "mtime_ns": observed.st_mtime_ns,
+        "ctime_ns": observed.st_ctime_ns,
         "device": observed.st_dev,
         "inode": observed.st_ino,
     }
@@ -308,12 +318,30 @@ def validate_direct_target(
             raise ManifestError("direct-harness source paths must be absolute")
 
 
-def option_arities(schema: dict[str, Any] | None) -> tuple[dict[str, int], bool, int | None]:
+def option_arities(
+    schema: dict[str, Any] | None,
+    target_executable: str | pathlib.Path | None = None,
+) -> tuple[dict[str, int], bool, int | None]:
     schema = schema or {"builtin": "llama", "allow_positionals": False}
     builtin = schema.get("builtin", "llama")
     if builtin not in ("llama", "none"):
         raise ManifestError(f"unknown CLI schema builtin {builtin!r}")
-    options = dict(LLAMA_OPTION_ARITY if builtin == "llama" else {})
+    if builtin == "llama":
+        if target_executable is None:
+            options = dict(LLAMA_COMMON_OPTION_ARITY)
+        else:
+            target_name = pathlib.Path(str(target_executable)).name
+            if target_name == "llama-bench":
+                options = dict(LLAMA_BENCH_OPTION_ARITY)
+            elif re.fullmatch(r"llama-(server|cli|perplexity)", target_name):
+                options = dict(LLAMA_COMMON_OPTION_ARITY)
+            else:
+                raise ManifestError(
+                    f"builtin llama CLI schema cannot identify target {target_name!r}; "
+                    "use builtin=none with explicit option arities for a harness"
+                )
+    else:
+        options = {}
     for option, raw_arity in schema.get("options", {}).items():
         arity = int(raw_arity)
         if arity not in (0, 1):
@@ -326,9 +354,13 @@ def option_arities(schema: dict[str, Any] | None) -> tuple[dict[str, int], bool,
     return options, allow_unknown, 0
 
 
-def validate_argv(argv: list[str], schema: dict[str, Any] | None = None) -> None:
+def validate_argv(
+    argv: list[str],
+    schema: dict[str, Any] | None = None,
+    target_executable: str | pathlib.Path | None = None,
+) -> None:
     reject_forbidden_tokens(argv)
-    options, allow_unknown, positional_limit = option_arities(schema)
+    options, allow_unknown, positional_limit = option_arities(schema, target_executable)
     positionals = 0
     index = 0
     while index < len(argv):
@@ -363,9 +395,13 @@ def validate_argv(argv: list[str], schema: dict[str, Any] | None = None) -> None
         index += 1
 
 
-def option_names(argv: list[str], schema: dict[str, Any] | None = None) -> list[str]:
+def option_names(
+    argv: list[str],
+    schema: dict[str, Any] | None = None,
+    target_executable: str | pathlib.Path | None = None,
+) -> list[str]:
     """Return option names while respecting arity, so negative values are values."""
-    options, allow_unknown, _ = option_arities(schema)
+    options, allow_unknown, _ = option_arities(schema, target_executable)
     names: list[str] = []
     index = 0
     while index < len(argv):
@@ -450,22 +486,10 @@ def _validate_repetitions(manifest: dict[str, Any]) -> None:
 
 
 def variant_executables(variant: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Normalize a variant's executable roles (legacy single role is useful in tests)."""
-    if "executables" in variant:
-        executables = variant["executables"]
-        if not isinstance(executables, dict) or not executables:
-            raise ManifestError("variant executables must be a non-empty role object")
-        return executables
-    if variant.get("executable"):
-        return {
-            "default": {
-                "path": variant["executable"],
-                "expected_sha256": variant.get("expected_sha256"),
-                "build": variant.get("build"),
-                "direct_harness": variant.get("direct_harness"),
-            }
-        }
-    raise ManifestError("variant requires executable roles")
+    executables = variant.get("executables")
+    if not isinstance(executables, dict) or not executables:
+        raise ManifestError("variant executables must be a non-empty role object")
+    return executables
 
 
 def validate_manifest(manifest: dict[str, Any]) -> None:
@@ -608,17 +632,25 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
         if command.get("cli_schema", {}).get("allow_unknown_options", False):
             raise ManifestError("allow_unknown_options is not fail-closed; declare every option arity")
         executable_role = str(command.get("executable_role", "default"))
+        target_paths: dict[str, str] = {}
         for variant_name, variant in variants.items():
             if executable_role not in variant_executables(variant):
                 raise ManifestError(
                     f"stage {stage_id!r} executable role {executable_role!r} is absent from {variant_name}"
                 )
+            target_paths[variant_name] = str(
+                variant_executables(variant)[executable_role]["path"]
+            )
         common_args = [str(value) for value in command.get("common_args", [])]
         baseline_args = [str(value) for value in command.get("baseline_args", [])]
         candidate_args = [str(value) for value in command.get("candidate_args", [])]
         for variant_name in ("baseline", "candidate"):
             delta = baseline_args if variant_name == "baseline" else candidate_args
-            validate_argv(common_args + delta, command.get("cli_schema"))
+            validate_argv(
+                common_args + delta,
+                command.get("cli_schema"),
+                target_paths[variant_name],
+            )
         baseline_environment = {
             str(key): str(value) for key, value in command.get("baseline_environment", {}).items()
         }
@@ -638,8 +670,20 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             ) != candidate_environment:
                 raise ManifestError("controlled_delta must reproduce exact baseline/candidate environments")
             observed_options = sorted(
-                set(option_names(baseline_args, command.get("cli_schema")))
-                | set(option_names(candidate_args, command.get("cli_schema")))
+                set(
+                    option_names(
+                        baseline_args,
+                        command.get("cli_schema"),
+                        target_paths["baseline"],
+                    )
+                )
+                | set(
+                    option_names(
+                        candidate_args,
+                        command.get("cli_schema"),
+                        target_paths["candidate"],
+                    )
+                )
             )
             if sorted(controlled.get("allowed_options", [])) != observed_options:
                 raise ManifestError("controlled_delta.allowed_options must exactly name every delta option")
@@ -661,8 +705,16 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             if float(screen.get("weight", 0)) <= 0:
                 raise ManifestError("every screen weight must be positive")
             screen_args = [str(value) for value in screen.get("args", [])]
-            validate_argv(common_args + screen_args + baseline_args, command.get("cli_schema"))
-            validate_argv(common_args + screen_args + candidate_args, command.get("cli_schema"))
+            validate_argv(
+                common_args + screen_args + baseline_args,
+                command.get("cli_schema"),
+                target_paths["baseline"],
+            )
+            validate_argv(
+                common_args + screen_args + candidate_args,
+                command.get("cli_schema"),
+                target_paths["candidate"],
+            )
         if purpose == "kernel_screen":
             if selection["workload"] != "prefill" or selection["execution_mode"] != "direct_command":
                 raise ManifestError("kernel screens must use a direct-command prefill workload")
@@ -685,8 +737,30 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
                     raise ManifestError("kernel screens require positive ubatch_occurrences")
                 if float(screen["weight"]) != float(occurrences):
                     raise ManifestError("kernel screen weight must equal its real ubatch_occurrences")
-        if purpose != "exactness" and not isinstance(stage.get("metric"), dict):
-            raise ManifestError(f"performance stage {stage_id!r} requires a metric extractor")
+        if purpose != "exactness":
+            if not isinstance(stage.get("metric"), dict):
+                raise ManifestError(f"performance stage {stage_id!r} requires a metric extractor")
+            policy = stage.get("decision_policy")
+            if not isinstance(policy, dict):
+                raise ManifestError(
+                    f"performance stage {stage_id!r} requires an explicit decision_policy"
+                )
+            acceptable = policy.get("acceptable_decisions")
+            if (
+                not isinstance(acceptable, list)
+                or not acceptable
+                or not set(acceptable).issubset({"improvement", "equivalent"})
+            ):
+                raise ManifestError(
+                    "decision_policy.acceptable_decisions must be a non-empty subset of "
+                    "improvement/equivalent"
+                )
+            if policy.get("regression") != "fail":
+                raise ManifestError("decision_policy.regression must be fail")
+            if policy.get("inconclusive_after_maximum") != "unresolved_fail":
+                raise ManifestError(
+                    "decision_policy.inconclusive_after_maximum must be unresolved_fail"
+                )
         if purpose == "exactness" and stage.get("comparison", {}).get("mode") not in (
             "stdout_sha256",
             "file_sha256",
@@ -718,6 +792,30 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             raise ManifestError("profiler variant must be baseline or candidate")
         if not isinstance(profiler.get("selector"), dict) or not profiler["selector"].get("kernel_regex"):
             raise ManifestError("profiler requires a discovery selector with kernel_regex")
+        graph_trace = profiler.get("cuda_graph_trace")
+        if not isinstance(graph_trace, dict) or graph_trace.get("applicability") not in {
+            "required",
+            "not_applicable",
+        }:
+            raise ManifestError(
+                "profiler.cuda_graph_trace must preregister required or not_applicable"
+            )
+        profiled_stage = stage_by_id(manifest, str(stage_id))
+        graph_capable = "cuda_graphs" in profiled_stage["selection"]["backend_capabilities"]
+        if graph_capable or profiler["selector"].get("graph_only"):
+            if graph_trace["applicability"] != "required":
+                raise ManifestError(
+                    "CUDA-graph-capable or graph-only profiling requires graph-node tracing"
+                )
+        if graph_trace["applicability"] == "required":
+            if graph_trace.get("granularity") != "node":
+                raise ManifestError("required CUDA graph tracing must use granularity=node")
+            if graph_trace.get("launch_origin") not in {"host-only", "host-and-device"}:
+                raise ManifestError(
+                    "required CUDA graph tracing needs host-only or host-and-device launch_origin"
+                )
+        elif not graph_trace.get("reason"):
+            raise ManifestError("not-applicable CUDA graph tracing requires a reason")
 
 
 def load_and_validate_manifest(path: pathlib.Path) -> tuple[dict[str, Any], str]:
@@ -888,10 +986,19 @@ def verify_variant(name: str, variant: dict[str, Any]) -> dict[str, Any]:
         harness = executable.get("direct_harness")
         if harness:
             validate_direct_target(pathlib.Path(binary["resolved_path"]), direct_harness=harness)
+            source_files: list[dict[str, Any]] = []
             for item in harness["source_files"]:
                 source_path = pathlib.Path(item["path"]).expanduser().resolve()
                 if not source_path.is_file() or sha256_file(source_path) != item["sha256"]:
                     raise ProvenanceError(f"direct-harness source identity mismatch: {source_path}")
+                source_files.append(
+                    {
+                        "path": str(source_path),
+                        "sha256": item["sha256"],
+                        **stat_identity(source_path),
+                    }
+                )
+            harness = {**harness, "source_files": source_files}
         executables[role] = {
             "binary": binary,
             "build": cmake_snapshot(pathlib.Path(binary["resolved_path"]), executable["build"]),
@@ -922,6 +1029,15 @@ def capture_provenance(manifest: dict[str, Any], manifest_sha256: str) -> dict[s
                 "sha256": observed,
             }
         )
+    runtime_tools: dict[str, Any] = {}
+    nvidia_smi_path = shutil.which("nvidia-smi")
+    if nvidia_smi_path:
+        resolved_tool = pathlib.Path(nvidia_smi_path).resolve()
+        runtime_tools["nvidia-smi"] = {
+            "path": str(resolved_tool),
+            "sha256": sha256_file(resolved_tool),
+            **stat_identity(resolved_tool),
+        }
     host = {
         "captured_utc": utc_now(),
         "platform": platform.platform(),
@@ -935,12 +1051,14 @@ def capture_provenance(manifest: dict[str, Any], manifest_sha256: str) -> dict[s
         "nvidia_smi_version": command_capture(["nvidia-smi", "--version"]),
         "nsys_version": command_capture(["nsys", "--version"]),
         "ncu_version": command_capture(["ncu", "--version"]),
+        "runtime_tools": runtime_tools,
     }
     identity = {
         "manifest_sha256": manifest_sha256,
         "runner_schema_version": SCHEMA_VERSION,
         "variants": variants,
         "inputs": inputs,
+        "runtime_tools": runtime_tools,
     }
     body = {
         **identity,
@@ -949,6 +1067,81 @@ def capture_provenance(manifest: dict[str, Any], manifest_sha256: str) -> dict[s
     body["identity_fingerprint"] = canonical_sha256(identity)
     body["fingerprint"] = canonical_sha256(body)
     return body
+
+
+def provenance_identity_spec(
+    provenance: dict[str, Any],
+    selections: list[tuple[str, str]] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    """Build per-process identity guards from one fully hashed provenance capture.
+
+    Large binaries, libraries, inputs, and harness sources are hashed once when
+    provenance is captured.  Fresh processes recheck their size/mtime/device/
+    inode tuple; a new invocation or resume recaptures and rehashes provenance.
+    """
+    if selections is None:
+        selections = [
+            (variant_name, role)
+            for variant_name, variant in provenance["variants"].items()
+            for role in variant["executables"]
+        ]
+    files: dict[str, dict[str, Any]] = {}
+    sources: dict[str, dict[str, str]] = {}
+    for variant_name, role in selections:
+        variant = provenance["variants"][variant_name]
+        executable = variant["executables"][role]
+        binary = executable["binary"]
+        for item in [
+            binary,
+            *binary.get("libraries", []),
+            *(executable.get("direct_harness") or {}).get("source_files", []),
+        ]:
+            identity_path = item.get("resolved_path", item["path"])
+            files[identity_path] = {
+                "path": identity_path,
+                **{
+                    key: item[key]
+                    for key in ("sha256", "size", "mtime_ns", "ctime_ns", "device", "inode")
+                },
+                "rehash": False,
+                "verification": "stat_against_initial_sha256_capture",
+            }
+        build = executable["build"]
+        if build.get("cache"):
+            files[build["cache"]] = {
+                "path": build["cache"],
+                "sha256": build["cache_sha256"],
+                **build["cache_stat"],
+                "rehash": False,
+                "verification": "stat_against_initial_sha256_capture",
+            }
+        source = variant["source"]
+        sources[source["root"]] = {
+            "root": source["root"],
+            "head": source["head"],
+            "dirty_fingerprint": source["dirty_fingerprint"],
+        }
+    for item in provenance["inputs"]:
+        files[item["path"]] = {
+            "path": item["path"],
+            **{
+                key: item[key]
+                for key in ("sha256", "size", "mtime_ns", "ctime_ns", "device", "inode")
+            },
+            "rehash": False,
+            "verification": "stat_against_initial_sha256_capture",
+        }
+    for item in provenance.get("runtime_tools", {}).values():
+        files[item["path"]] = {
+            "path": item["path"],
+            **{
+                key: item[key]
+                for key in ("sha256", "size", "mtime_ns", "ctime_ns", "device", "inode")
+            },
+            "rehash": False,
+            "verification": "stat_against_initial_sha256_capture",
+        }
+    return ([files[key] for key in sorted(files)], [sources[key] for key in sorted(sources)])
 
 
 def build_schedule(manifest: dict[str, Any], stage: dict[str, Any]) -> list[dict[str, Any]]:
@@ -1086,6 +1279,17 @@ def paired_log_report(
         "thresholds": {key: float(value) for key, value in thresholds.items()},
         "raw_pairs": raw,
     }
+
+
+def performance_outcome(decision: str, policy: dict[str, Any]) -> str:
+    """Map an executed statistical decision to a fail-closed gate outcome."""
+    if decision in policy["acceptable_decisions"]:
+        return "passed"
+    if decision == "inconclusive":
+        return "unresolved"
+    if decision == "regression":
+        return "failed"
+    raise ValidationError(f"unknown performance decision {decision!r}")
 
 
 def sterile_environment(*parts: dict[str, Any]) -> dict[str, str]:

--- a/scripts/feature_validation/manifest.schema.json
+++ b/scripts/feature_validation/manifest.schema.json
@@ -85,7 +85,7 @@
     "profiler": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["pattern", "profile_repetitions", "stage", "variant", "selector"],
+      "required": ["pattern", "profile_repetitions", "stage", "variant", "selector", "cuda_graph_trace"],
       "properties": {
         "pattern": { "const": "one_nsys_discovery_then_one_filtered_ncu" },
         "profile_repetitions": { "const": 1 },
@@ -102,6 +102,29 @@
             "grid": { "$ref": "#/$defs/shape" },
             "block": { "$ref": "#/$defs/shape" }
           }
+        },
+        "cuda_graph_trace": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["applicability", "granularity", "launch_origin"],
+              "properties": {
+                "applicability": { "const": "required" },
+                "granularity": { "const": "node" },
+                "launch_origin": { "enum": ["host-only", "host-and-device"] }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["applicability", "reason"],
+              "properties": {
+                "applicability": { "const": "not_applicable" },
+                "reason": { "type": "string", "minLength": 1 }
+              }
+            }
+          ]
         },
         "metrics": {
           "type": "array",
@@ -315,6 +338,21 @@
         "group": { "type": ["integer", "string"] }
       }
     },
+    "decisionPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["acceptable_decisions", "regression", "inconclusive_after_maximum"],
+      "properties": {
+        "acceptable_decisions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["improvement", "equivalent"] }
+        },
+        "regression": { "const": "fail" },
+        "inconclusive_after_maximum": { "const": "unresolved_fail" }
+      }
+    },
     "shape": {
       "type": "array",
       "minItems": 3,
@@ -344,6 +382,7 @@
           }
         },
         "metric": { "$ref": "#/$defs/metric" },
+        "decision_policy": { "$ref": "#/$defs/decisionPolicy" },
         "comparison": {
           "type": "object",
           "required": ["mode"],

--- a/scripts/feature_validation/manifest.schema.json
+++ b/scripts/feature_validation/manifest.schema.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://anbeeld.example/schemas/feature-performance-validation-v1.json",
+  "title": "BeeLlama feature/performance validation manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "study",
+    "artifact_root",
+    "variants",
+    "inputs",
+    "repetition_policy",
+    "stages"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "study": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "early_decision_target_seconds"],
+      "properties": {
+        "id": { "$ref": "#/$defs/slug" },
+        "description": { "type": "string" },
+        "early_decision_target_seconds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimum", "maximum"],
+          "properties": {
+            "minimum": { "const": 30 },
+            "maximum": { "const": 90 }
+          }
+        }
+      }
+    },
+    "artifact_root": { "type": "string", "pattern": "^/" },
+    "variants": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseline", "candidate"],
+      "properties": {
+        "baseline": { "$ref": "#/$defs/variant" },
+        "candidate": { "$ref": "#/$defs/variant" }
+      }
+    },
+    "inputs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/hashedFile" }
+    },
+    "environment": { "$ref": "#/$defs/environment" },
+    "repetition_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum_pairs", "maximum_pairs", "order", "confidence_level", "extension_rule"],
+      "properties": {
+        "minimum_pairs": { "const": 3 },
+        "maximum_pairs": { "const": 5 },
+        "order": { "const": ["AB", "BA", "AB", "BA", "AB"] },
+        "confidence_level": { "const": 0.95 },
+        "extension_rule": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "thresholds"],
+          "properties": {
+            "kind": { "const": "extend_only_if_inconclusive" },
+            "thresholds": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["improvement_percent", "regression_percent", "equivalence_percent"],
+              "properties": {
+                "improvement_percent": { "type": "number", "minimum": 0 },
+                "regression_percent": { "type": "number", "minimum": 0 },
+                "equivalence_percent": { "type": "number", "minimum": 0 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 6,
+      "items": { "$ref": "#/$defs/stage" }
+    },
+    "profiler": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern", "profile_repetitions", "stage", "variant", "selector"],
+      "properties": {
+        "pattern": { "const": "one_nsys_discovery_then_one_filtered_ncu" },
+        "profile_repetitions": { "const": 1 },
+        "stage": { "$ref": "#/$defs/slug" },
+        "variant": { "enum": ["baseline", "candidate"] },
+        "screen": { "$ref": "#/$defs/slug" },
+        "timeout_seconds": { "type": "number", "exclusiveMinimum": 0, "maximum": 86400 },
+        "selector": {
+          "type": "object",
+          "required": ["kernel_regex"],
+          "properties": {
+            "kernel_regex": { "type": "string", "minLength": 1 },
+            "graph_only": { "type": "boolean" },
+            "grid": { "$ref": "#/$defs/shape" },
+            "block": { "$ref": "#/$defs/shape" }
+          }
+        },
+        "metrics": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "slug": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "hashedFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "role": { "type": "string" },
+        "path": { "type": "string", "pattern": "^/" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": { "type": ["string", "number", "boolean"] }
+    },
+    "build": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode"],
+          "properties": {
+            "mode": { "const": "cmake_required" },
+            "cache": { "type": "string", "pattern": "^/" },
+            "expected_options": {
+              "type": "object",
+              "additionalProperties": { "type": ["string", "number", "boolean"] }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "reason"],
+          "properties": {
+            "mode": { "const": "not_applicable" },
+            "reason": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    },
+    "directHarness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "native_llama_affinity", "source_files"],
+      "properties": {
+        "kind": { "const": "native_executable" },
+        "native_llama_affinity": { "const": true },
+        "source_files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/hashedFile" }
+        }
+      }
+    },
+    "executable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "expected_sha256", "build"],
+      "properties": {
+        "path": { "type": "string", "pattern": "^/" },
+        "expected_sha256": { "$ref": "#/$defs/sha256" },
+        "build": { "$ref": "#/$defs/build" },
+        "direct_harness": { "$ref": "#/$defs/directHarness" }
+      }
+    },
+    "variant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_root", "expected_commit", "tree_policy", "executables"],
+      "properties": {
+        "source_root": { "type": "string", "pattern": "^/" },
+        "expected_commit": { "type": "string", "pattern": "^[0-9a-fA-F]{40}$" },
+        "tree_policy": { "enum": ["clean", "expected_dirty"] },
+        "expected_dirty_fingerprint": { "$ref": "#/$defs/sha256" },
+        "environment": { "$ref": "#/$defs/environment" },
+        "executables": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": { "$ref": "#/$defs/slug" },
+          "additionalProperties": { "$ref": "#/$defs/executable" }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "tree_policy": { "const": "expected_dirty" } } },
+          "then": { "required": ["expected_dirty_fingerprint"] }
+        }
+      ]
+    },
+    "selection": {
+      "type": "object",
+      "required": ["workload", "tensor_layout", "backend_capabilities", "execution_mode"],
+      "properties": {
+        "workload": { "enum": ["exactness", "prefill", "decode", "mixed"] },
+        "tensor_layout": { "type": "object", "minProperties": 1 },
+        "backend_capabilities": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "execution_mode": {
+          "enum": ["direct_process", "direct_command", "cuda_graph_replay", "production_binary"]
+        },
+        "duration_class": { "enum": ["short"] },
+        "context_depth_tokens": { "type": "integer", "minimum": 1 },
+        "acceptance_class": { "const": "long_context" },
+        "cuda_graph_replay": {
+          "type": "object",
+          "required": ["applicability"],
+          "properties": {
+            "applicability": { "enum": ["required", "not_applicable"] },
+            "reason": { "type": "string" }
+          }
+        }
+      },
+      "not": {
+        "anyOf": [
+          { "required": ["architecture"] },
+          { "required": ["architecture_name"] },
+          { "required": ["model_family"] },
+          { "required": ["model_name"] }
+        ]
+      }
+    },
+    "cliSchema": {
+      "type": "object",
+      "properties": {
+        "builtin": { "enum": ["llama", "none"] },
+        "allow_unknown_options": { "type": "boolean" },
+        "allow_positionals": { "type": "boolean" },
+        "max_positionals": { "type": "integer", "minimum": 0 },
+        "options": {
+          "type": "object",
+          "additionalProperties": { "enum": [0, 1] }
+        }
+      }
+    },
+    "controlledDelta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason",
+        "baseline_args",
+        "candidate_args",
+        "baseline_environment",
+        "candidate_environment",
+        "allowed_options",
+        "allowed_environment"
+      ],
+      "properties": {
+        "reason": { "type": "string", "minLength": 1 },
+        "baseline_args": { "type": "array", "items": { "type": ["string", "number"] } },
+        "candidate_args": { "type": "array", "items": { "type": ["string", "number"] } },
+        "baseline_environment": { "$ref": "#/$defs/environment" },
+        "candidate_environment": { "$ref": "#/$defs/environment" },
+        "allowed_options": { "type": "array", "items": { "type": "string" } },
+        "allowed_environment": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["executable_role", "common_args", "baseline_args", "candidate_args", "cli_schema"],
+      "properties": {
+        "executable_role": { "$ref": "#/$defs/slug" },
+        "common_args": { "type": "array", "items": { "type": ["string", "number"] } },
+        "baseline_args": { "type": "array", "items": { "type": ["string", "number"] } },
+        "candidate_args": { "type": "array", "items": { "type": ["string", "number"] } },
+        "environment": { "$ref": "#/$defs/environment" },
+        "baseline_environment": { "$ref": "#/$defs/environment" },
+        "candidate_environment": { "$ref": "#/$defs/environment" },
+        "cli_schema": { "$ref": "#/$defs/cliSchema" },
+        "controlled_delta": { "$ref": "#/$defs/controlledDelta" }
+      }
+    },
+    "screen": {
+      "type": "object",
+      "required": ["id", "args", "weight"],
+      "properties": {
+        "id": { "$ref": "#/$defs/slug" },
+        "args": { "type": "array", "items": { "type": ["string", "number"] } },
+        "weight": { "type": "number", "exclusiveMinimum": 0 },
+        "span_class": { "enum": ["low", "mid", "high"] },
+        "span_tokens": { "type": "integer", "minimum": 1 },
+        "ubatch_occurrences": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "metric": {
+      "type": "object",
+      "required": ["regex", "direction"],
+      "properties": {
+        "regex": { "type": "string", "minLength": 1 },
+        "direction": { "enum": ["higher", "lower"] },
+        "stream": { "enum": ["stdout", "stderr", "combined"] },
+        "match": { "enum": ["first", "last", "only"] },
+        "group": { "type": ["integer", "string"] }
+      }
+    },
+    "shape": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": { "type": "integer", "minimum": 1 }
+    },
+    "stage": {
+      "type": "object",
+      "required": ["id", "purpose", "resource", "timeout_seconds", "mandatory", "progress", "selection", "command"],
+      "properties": {
+        "id": { "$ref": "#/$defs/slug" },
+        "purpose": {
+          "enum": ["exactness", "smoke", "kernel_screen", "production_confirmation", "long_context_acceptance"]
+        },
+        "resource": { "enum": ["cpu", "gpu"] },
+        "timeout_seconds": { "type": "number", "exclusiveMinimum": 0, "maximum": 86400 },
+        "mandatory": { "type": "boolean" },
+        "progress": { "type": "string", "minLength": 1 },
+        "selection": { "$ref": "#/$defs/selection" },
+        "command": { "$ref": "#/$defs/command" },
+        "screens": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/screen" } },
+        "aggregation": {
+          "type": "object",
+          "properties": {
+            "mode": { "enum": ["weighted_mean", "weighted_harmonic"] },
+            "weight_source": { "const": "real_ubatch_geometry" }
+          }
+        },
+        "metric": { "$ref": "#/$defs/metric" },
+        "comparison": {
+          "type": "object",
+          "required": ["mode"],
+          "properties": {
+            "mode": { "enum": ["stdout_sha256", "file_sha256"] },
+            "path": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/feature_validation/manifest.schema.json
+++ b/scripts/feature_validation/manifest.schema.json
@@ -93,42 +93,69 @@
         "variant": { "enum": ["baseline", "candidate"] },
         "screen": { "$ref": "#/$defs/slug" },
         "timeout_seconds": { "type": "number", "exclusiveMinimum": 0, "maximum": 86400 },
-        "selector": {
-          "type": "object",
-          "required": ["kernel_regex"],
-          "properties": {
-            "kernel_regex": { "type": "string", "minLength": 1 },
-            "graph_only": { "type": "boolean" },
-            "grid": { "$ref": "#/$defs/shape" },
-            "block": { "$ref": "#/$defs/shape" }
-          }
-        },
-        "cuda_graph_trace": {
-          "oneOf": [
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["applicability", "granularity", "launch_origin"],
-              "properties": {
-                "applicability": { "const": "required" },
-                "granularity": { "const": "node" },
-                "launch_origin": { "enum": ["host-only", "host-and-device"] }
-              }
-            },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["applicability", "reason"],
-              "properties": {
-                "applicability": { "const": "not_applicable" },
-                "reason": { "type": "string", "minLength": 1 }
-              }
-            }
-          ]
-        },
+        "selector": { "$ref": "#/$defs/profilerSelector" },
+        "cuda_graph_trace": { "$ref": "#/$defs/cudaGraphTrace" },
         "metrics": {
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "early_diagnostics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "trigger",
+          "on_clear",
+          "evidence_claim",
+          "pattern",
+          "profile_repetitions",
+          "stage",
+          "variants",
+          "screen_selection",
+          "selector",
+          "cuda_graph_trace"
+        ],
+        "properties": {
+          "id": { "$ref": "#/$defs/slug" },
+          "trigger": { "const": "regression_signal_only" },
+          "on_clear": { "const": "skip" },
+          "evidence_claim": { "const": "diagnostic_only" },
+          "pattern": { "const": "independent_nsys_then_filtered_ncu_per_variant" },
+          "profile_repetitions": { "const": 1 },
+          "stage": { "$ref": "#/$defs/slug" },
+          "variants": { "const": ["baseline", "candidate"] },
+          "screen_selection": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind", "screen"],
+                "properties": {
+                  "kind": { "const": "fixed" },
+                  "screen": { "$ref": "#/$defs/slug" }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind"],
+                "properties": {
+                  "kind": { "const": "largest_observed_regression" }
+                }
+              }
+            ]
+          },
+          "timeout_seconds": { "type": "number", "exclusiveMinimum": 0, "maximum": 86400 },
+          "selector": { "$ref": "#/$defs/profilerSelector" },
+          "cuda_graph_trace": { "$ref": "#/$defs/cudaGraphTrace" },
+          "metrics": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
         }
       }
     }
@@ -353,11 +380,64 @@
         "inconclusive_after_maximum": { "const": "unresolved_fail" }
       }
     },
+    "screeningPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "order", "regression_threshold_percent", "confidence_claim"],
+      "properties": {
+        "kind": { "const": "single_pair_fail_fast" },
+        "order": { "enum": ["AB", "BA"] },
+        "regression_threshold_percent": { "type": "number", "exclusiveMinimum": 0 },
+        "confidence_claim": { "const": "none" }
+      }
+    },
     "shape": {
       "type": "array",
       "minItems": 3,
       "maxItems": 3,
       "items": { "type": "integer", "minimum": 1 }
+    },
+    "profilerSelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kernel_regex"],
+      "properties": {
+        "kernel_regex": { "type": "string", "minLength": 1 },
+        "graph_only": { "type": "boolean" },
+        "grid": { "$ref": "#/$defs/shape" },
+        "block": { "$ref": "#/$defs/shape" },
+        "occurrence_policy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": {
+            "kind": { "enum": ["all", "first", "middle", "last"] }
+          }
+        }
+      }
+    },
+    "cudaGraphTrace": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["applicability", "granularity", "launch_origin"],
+          "properties": {
+            "applicability": { "const": "required" },
+            "granularity": { "const": "node" },
+            "launch_origin": { "enum": ["host-only", "host-and-device"] }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["applicability", "reason"],
+          "properties": {
+            "applicability": { "const": "not_applicable" },
+            "reason": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
     },
     "stage": {
       "type": "object",
@@ -383,6 +463,7 @@
         },
         "metric": { "$ref": "#/$defs/metric" },
         "decision_policy": { "$ref": "#/$defs/decisionPolicy" },
+        "screening_policy": { "$ref": "#/$defs/screeningPolicy" },
         "comparison": {
           "type": "object",
           "required": ["mode"],

--- a/scripts/feature_validation/profiler.py
+++ b/scripts/feature_validation/profiler.py
@@ -1,0 +1,330 @@
+"""Direct-target NSYS discovery and discovery-derived NCU planning."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sqlite3
+from contextlib import closing
+from typing import Any
+
+from .core import (
+    ManifestError,
+    ValidationError,
+    flock_argv,
+    quote_argv,
+    reject_forbidden_tokens,
+    validate_direct_target,
+)
+
+
+def _column(columns: list[str], *candidates: str) -> str | None:
+    lowered = {item.lower(): item for item in columns}
+    for candidate in candidates:
+        if candidate.lower() in lowered:
+            return lowered[candidate.lower()]
+    for candidate in candidates:
+        for item in columns:
+            if candidate.lower() in item.lower():
+                return item
+    return None
+
+
+def _normalize_shape(value: Any) -> list[int] | None:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return [int(item) for item in value]
+    text = str(value).strip().strip("()[]{}")
+    if not text:
+        return None
+    parts = re.split(r"[xX, ]+", text)
+    try:
+        return [int(part) for part in parts if part]
+    except ValueError:
+        return None
+
+
+def _parse_jsonl(path: pathlib.Path) -> list[dict[str, Any]]:
+    launches: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if not isinstance(value, dict) or not value.get("name"):
+            raise ValidationError(f"invalid profiler JSONL record on line {line_number}")
+        launches.append(value)
+    return launches
+
+
+def _string_lookup(connection: sqlite3.Connection) -> dict[int, str]:
+    names = {
+        row[0]
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    table = next((name for name in names if name.lower() == "stringids"), None)
+    if table is None:
+        return {}
+    columns = [row[1] for row in connection.execute(f'PRAGMA table_info("{table}")')]
+    id_column = _column(columns, "id")
+    value_column = _column(columns, "value", "string")
+    if id_column is None or value_column is None:
+        return {}
+    return {
+        int(row[0]): str(row[1])
+        for row in connection.execute(
+            f'SELECT "{id_column}", "{value_column}" FROM "{table}"'
+        )
+    }
+
+
+def _parse_sqlite(path: pathlib.Path) -> list[dict[str, Any]]:
+    with closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True)) as connection:
+        tables = [
+            row[0]
+            for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        ]
+        kernel_tables = [name for name in tables if "kernel" in name.lower()]
+        if not kernel_tables:
+            raise ValidationError("NSYS SQLite contains no kernel activity table")
+        preferred = next(
+            (name for name in kernel_tables if "cupti_activity_kind_kernel" in name.lower()),
+            kernel_tables[0],
+        )
+        columns = [row[1] for row in connection.execute(f'PRAGMA table_info("{preferred}")')]
+        name_column = _column(columns, "demangledName", "shortName", "name")
+        start_column = _column(columns, "start")
+        end_column = _column(columns, "end")
+        if name_column is None or start_column is None:
+            raise ValidationError(f"kernel table {preferred!r} lacks name/start columns")
+        graph_column = _column(columns, "graphNodeId", "graphNode", "graphId")
+        grid_columns = [_column(columns, f"grid{axis}") for axis in "XYZ"]
+        block_columns = [_column(columns, f"block{axis}") for axis in "XYZ"]
+        string_ids = _string_lookup(connection)
+        select_columns = [name_column, start_column]
+        optional = [end_column, graph_column, *grid_columns, *block_columns]
+        for item in optional:
+            if item is not None and item not in select_columns:
+                select_columns.append(item)
+        quoted = ", ".join(f'"{item}"' for item in select_columns)
+        rows = list(connection.execute(f'SELECT {quoted} FROM "{preferred}" ORDER BY "{start_column}"'))
+        index = {name: offset for offset, name in enumerate(select_columns)}
+        launches: list[dict[str, Any]] = []
+        for row in rows:
+            raw_name = row[index[name_column]]
+            name = string_ids.get(int(raw_name), str(raw_name)) if isinstance(raw_name, int) else str(raw_name)
+            record: dict[str, Any] = {
+                "name": name,
+                "start_ns": int(row[index[start_column]]),
+                "end_ns": int(row[index[end_column]]) if end_column and row[index[end_column]] is not None else None,
+                "graph_node_id": row[index[graph_column]] if graph_column else None,
+            }
+            if all(item is not None for item in grid_columns):
+                record["grid"] = [int(row[index[item]]) for item in grid_columns if item is not None]
+            if all(item is not None for item in block_columns):
+                record["block"] = [int(row[index[item]]) for item in block_columns if item is not None]
+            launches.append(record)
+        return launches
+
+
+def parse_discovery(path: pathlib.Path) -> dict[str, Any]:
+    """Parse an NSYS SQLite export, or JSONL for hermetic tests/fake logs."""
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise ValidationError(f"profiler discovery input is missing: {resolved}")
+    launches = _parse_jsonl(resolved) if resolved.suffix == ".jsonl" else _parse_sqlite(resolved)
+    launches.sort(key=lambda item: int(item.get("start_ns", item.get("start", 0))))
+    occurrences: dict[str, int] = {}
+    normalized: list[dict[str, Any]] = []
+    for launch_index, raw in enumerate(launches, start=1):
+        name = str(raw["name"])
+        occurrences[name] = occurrences.get(name, 0) + 1
+        normalized.append(
+            {
+                "launch_index": launch_index,
+                "name_occurrence": occurrences[name],
+                "name": name,
+                "graph_node_id": raw.get("graph_node_id", raw.get("graph_id")),
+                "start_ns": raw.get("start_ns", raw.get("start")),
+                "end_ns": raw.get("end_ns", raw.get("end")),
+                "grid": _normalize_shape(raw.get("grid")),
+                "block": _normalize_shape(raw.get("block")),
+            }
+        )
+    groups: dict[str, dict[str, Any]] = {}
+    for launch in normalized:
+        shape_key = json.dumps(
+            {
+                "name": launch["name"],
+                "grid": launch["grid"],
+                "block": launch["block"],
+                "graph_node_id": launch["graph_node_id"],
+            },
+            sort_keys=True,
+        )
+        group = groups.setdefault(
+            shape_key,
+            {
+                "name": launch["name"],
+                "grid": launch["grid"],
+                "block": launch["block"],
+                "graph_node_id": launch["graph_node_id"],
+                "count": 0,
+                "launch_indices": [],
+                "name_occurrences": [],
+            },
+        )
+        group["count"] += 1
+        group["launch_indices"].append(launch["launch_index"])
+        group["name_occurrences"].append(launch["name_occurrence"])
+    return {
+        "source": str(resolved),
+        "launch_count": len(normalized),
+        "launches": normalized,
+        "groups": sorted(groups.values(), key=lambda item: item["launch_indices"][0]),
+    }
+
+
+def validate_native_affinity(target_argv: list[str], direct_harness: dict[str, Any] | None = None) -> None:
+    if not target_argv:
+        raise ValidationError("profiler target argv is empty")
+    executable = pathlib.Path(target_argv[0])
+    validate_direct_target(executable, profiler=True, direct_harness=direct_harness)
+    reject_forbidden_tokens(target_argv)
+    if direct_harness is not None:
+        if direct_harness.get("native_llama_affinity") is not True:
+            raise ValidationError("direct profiler harness must declare native_llama_affinity=true")
+        return
+    args = target_argv[1:]
+    values: dict[str, str] = {}
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token in {"-C", "--cpu-mask", "--cpu-range", "--cpu-range-batch", "--cpu-strict"}:
+            if index + 1 >= len(args):
+                raise ValidationError(f"native affinity option {token} has no value")
+            values[token] = args[index + 1]
+            index += 2
+        else:
+            index += 1
+    strict = values.get("--cpu-strict") == "1"
+    mask = values.get("-C", values.get("--cpu-mask"))
+    ranged = "--cpu-range" in values and "--cpu-range-batch" in values
+    bench_mask = executable.name == "llama-bench" and mask == "0x7"
+    if not strict or not (bench_mask or ranged):
+        raise ValidationError(
+            "direct llama profiler target requires --cpu-strict 1 and either -C 0x7 "
+            "for the established 0-2 llama-bench shape or both native cpu ranges"
+        )
+
+
+def nsys_discovery_argv(
+    target_argv: list[str],
+    output_prefix: pathlib.Path,
+    direct_harness: dict[str, Any] | None = None,
+) -> list[str]:
+    validate_native_affinity(target_argv, direct_harness)
+    return [
+        "nsys",
+        "profile",
+        "--trace=cuda,nvtx,osrt",
+        "--sample=none",
+        "--cpuctxsw=none",
+        "--force-overwrite=true",
+        "--output",
+        str(output_prefix),
+        *target_argv,
+    ]
+
+
+def _selector_matches(launch: dict[str, Any], selector: dict[str, Any]) -> bool:
+    pattern = selector.get("kernel_regex")
+    if not isinstance(pattern, str) or not pattern:
+        raise ManifestError("profiler selector requires kernel_regex")
+    if re.search(pattern, launch["name"]) is None:
+        return False
+    if selector.get("graph_only") and launch.get("graph_node_id") in {None, 0, "0"}:
+        return False
+    for key in ("grid", "block"):
+        if key in selector and _normalize_shape(selector[key]) != launch.get(key):
+            return False
+    return True
+
+
+def build_ncu_plan(
+    discovery: dict[str, Any],
+    selector: dict[str, Any],
+    target_argv: list[str],
+    output_root: pathlib.Path,
+    *,
+    metrics: list[str] | None = None,
+    direct_harness: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create one filtered NCU capture from the current NSYS discovery.
+
+    The selected occurrences must be contiguous among one exact kernel name;
+    otherwise one skip/count range would silently include unselected launches.
+    Every value is derived from this discovery, never carried across builds.
+    """
+    validate_native_affinity(target_argv, direct_harness)
+    selected = [launch for launch in discovery["launches"] if _selector_matches(launch, selector)]
+    if not selected:
+        raise ValidationError("profiler selector matched no discovered kernel launches")
+    names = {launch["name"] for launch in selected}
+    if len(names) != 1:
+        raise ValidationError("one filtered NCU capture requires one discovered kernel name")
+    occurrences = [int(launch["name_occurrence"]) for launch in selected]
+    expected = list(range(min(occurrences), max(occurrences) + 1))
+    if occurrences != expected:
+        raise ValidationError(
+            "selected same-kernel occurrences are not contiguous; narrow the discovery stage or selector"
+        )
+    output_root.mkdir(parents=True, exist_ok=True)
+    kernel_name = selected[0]["name"]
+    kernel_regex = f"^{re.escape(kernel_name)}$"
+    launch_skip = min(occurrences) - 1
+    launch_count = len(occurrences)
+    argv = [
+        "ncu",
+        "--target-processes",
+        "all",
+        "--kernel-name-base",
+        "demangled",
+        "--kernel-name",
+        f"regex:{kernel_regex}",
+        "--launch-skip",
+        str(launch_skip),
+        "--launch-count",
+        str(launch_count),
+    ]
+    if metrics:
+        argv.extend(["--metrics", ",".join(metrics)])
+    prefix = output_root / f"capture-launch-{selected[0]['launch_index']:06d}"
+    argv.extend(["--export", str(prefix), "--force-overwrite", *target_argv])
+    command = {
+        "selected_launches": selected,
+        "derivation": {
+            "kernel_name": kernel_name,
+            "name_occurrences": occurrences,
+            "launch_skip": launch_skip,
+            "launch_count": launch_count,
+            "discovery_launch_indices": [item["launch_index"] for item in selected],
+        },
+        "direct_argv": argv,
+        "direct_command": quote_argv(argv),
+        "flock_argv": flock_argv(argv),
+        "flock_command": quote_argv(flock_argv(argv)),
+    }
+    return {
+        "pattern": "one_nsys_discovery_then_one_filtered_ncu",
+        "scope": "one preregistered investigation stage, not benchmark repetitions",
+        "discovery_source": discovery["source"],
+        "selector": selector,
+        "selected_count": len(selected),
+        "command": command,
+        "limitations": [
+            "Kernel and occurrence filters are valid only for the recorded discovery identity.",
+            "Filtered kernel evidence does not prove end-to-end performance, resource use, output exactness, or long-context behavior.",
+        ],
+    }

--- a/scripts/feature_validation/profiler.py
+++ b/scripts/feature_validation/profiler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 import pathlib
 import re
@@ -181,6 +183,18 @@ def parse_discovery(path: pathlib.Path) -> dict[str, Any]:
     return {
         "source": str(resolved),
         "launch_count": len(normalized),
+        "graph_node_trace": {
+            "launches_with_graph_node": sum(
+                item["graph_node_id"] not in {None, 0, "0"} for item in normalized
+            ),
+            "distinct_graph_node_ids": sorted(
+                {
+                    str(item["graph_node_id"])
+                    for item in normalized
+                    if item["graph_node_id"] not in {None, 0, "0"}
+                }
+            ),
+        },
         "launches": normalized,
         "groups": sorted(groups.values(), key=lambda item: item["launch_indices"][0]),
     }
@@ -223,10 +237,13 @@ def nsys_discovery_argv(
     target_argv: list[str],
     output_prefix: pathlib.Path,
     direct_harness: dict[str, Any] | None = None,
+    *,
+    cuda_graph_trace: dict[str, Any] | None = None,
+    nsys_executable: str = "nsys",
 ) -> list[str]:
     validate_native_affinity(target_argv, direct_harness)
-    return [
-        "nsys",
+    argv = [
+        nsys_executable,
         "profile",
         "--trace=cuda,nvtx,osrt",
         "--sample=none",
@@ -234,8 +251,61 @@ def nsys_discovery_argv(
         "--force-overwrite=true",
         "--output",
         str(output_prefix),
-        *target_argv,
     ]
+    if cuda_graph_trace and cuda_graph_trace["applicability"] == "required":
+        argv.append(
+            "--cuda-graph-trace="
+            f"{cuda_graph_trace['granularity']}:{cuda_graph_trace['launch_origin']}"
+        )
+    return [*argv, *target_argv]
+
+
+def verify_nsys_graph_trace_capability(
+    config: dict[str, Any],
+    *,
+    help_text: str,
+    version_text: str,
+) -> dict[str, Any]:
+    """Fail before capture when required node tracing is unavailable."""
+    required = config["applicability"] == "required"
+    evidence = {
+        "applicability": config["applicability"],
+        "requested": (
+            f"{config.get('granularity')}:{config.get('launch_origin')}" if required else None
+        ),
+        "nsys_version": version_text.strip(),
+        "help_mentions_cuda_graph_trace": "--cuda-graph-trace" in help_text,
+        "help_mentions_node_granularity": bool(re.search(r"\bnode\b", help_text)),
+    }
+    if required and not (
+        evidence["help_mentions_cuda_graph_trace"]
+        and evidence["help_mentions_node_granularity"]
+    ):
+        raise ValidationError(
+            "this NSYS version does not advertise required --cuda-graph-trace node support"
+        )
+    evidence["status"] = "supported" if required else "not_applicable"
+    return evidence
+
+
+def verify_graph_node_discovery(
+    discovery: dict[str, Any], config: dict[str, Any]
+) -> dict[str, Any]:
+    observed = int(discovery["graph_node_trace"]["launches_with_graph_node"])
+    result = {
+        "applicability": config["applicability"],
+        "requested": config.get("granularity"),
+        "observed_launches_with_graph_node": observed,
+        "status": "not_applicable",
+    }
+    if config["applicability"] == "required":
+        if observed == 0:
+            raise ValidationError(
+                "NSYS graph-node tracing was required and explicitly requested, but the export "
+                "contains no nonzero graph node IDs"
+            )
+        result["status"] = "verified"
+    return result
 
 
 def _selector_matches(launch: dict[str, Any], selector: dict[str, Any]) -> bool:
@@ -289,6 +359,8 @@ def build_ncu_plan(
         "ncu",
         "--target-processes",
         "all",
+        "--graph-profiling",
+        "node",
         "--kernel-name-base",
         "demangled",
         "--kernel-name",
@@ -302,6 +374,13 @@ def build_ncu_plan(
         argv.extend(["--metrics", ",".join(metrics)])
     prefix = output_root / f"capture-launch-{selected[0]['launch_index']:06d}"
     argv.extend(["--export", str(prefix), "--force-overwrite", *target_argv])
+    report_path = pathlib.Path(f"{prefix}.ncu-rep")
+    expected_shapes = sorted(
+        {
+            json.dumps({"grid": item.get("grid"), "block": item.get("block")}, sort_keys=True)
+            for item in selected
+        }
+    )
     command = {
         "selected_launches": selected,
         "derivation": {
@@ -310,7 +389,9 @@ def build_ncu_plan(
             "launch_skip": launch_skip,
             "launch_count": launch_count,
             "discovery_launch_indices": [item["launch_index"] for item in selected],
+            "expected_shapes": [json.loads(item) for item in expected_shapes],
         },
+        "report_path": str(report_path),
         "direct_argv": argv,
         "direct_command": quote_argv(argv),
         "flock_argv": flock_argv(argv),
@@ -324,7 +405,101 @@ def build_ncu_plan(
         "selected_count": len(selected),
         "command": command,
         "limitations": [
-            "Kernel and occurrence filters are valid only for the recorded discovery identity.",
+            "Cross-process launch order can drift; the exported report must be verified against kernel, count, and available shapes before it is usable.",
             "Filtered kernel evidence does not prove end-to-end performance, resource use, output exactness, or long-context behavior.",
         ],
+    }
+
+
+def parse_ncu_raw_csv(text: str) -> dict[str, Any]:
+    """Extract unique kernel captures from ``ncu --import --csv --page raw``."""
+    lines = text.splitlines()
+    header_index = next(
+        (index for index, line in enumerate(lines) if "Kernel Name" in line and "ID" in line),
+        None,
+    )
+    if header_index is None:
+        return {"captures": [], "columns": [], "parse_status": "unverifiable_no_header"}
+    reader = csv.DictReader(io.StringIO("\n".join(lines[header_index:])))
+    columns = reader.fieldnames or []
+    captures: dict[str, dict[str, Any]] = {}
+    for row_number, row in enumerate(reader, start=1):
+        name = (row.get("Kernel Name") or "").strip()
+        capture_id = (row.get("ID") or "").strip()
+        if not name or not capture_id:
+            continue
+        capture_key = "|".join(
+            (row.get(column) or "").strip()
+            for column in ("Process ID", "Context", "Stream", "ID")
+        )
+        capture = captures.setdefault(
+            capture_key,
+            {
+                "id": capture_id,
+                "process_id": (row.get("Process ID") or "").strip() or None,
+                "context": (row.get("Context") or "").strip() or None,
+                "stream": (row.get("Stream") or "").strip() or None,
+                "kernel_name": name,
+                "grid": _normalize_shape(row.get("Grid Size")),
+                "block": _normalize_shape(row.get("Block Size")),
+                "raw_row_numbers": [],
+            },
+        )
+        if capture["kernel_name"] != name:
+            raise ValidationError(f"NCU capture ID {capture_key} has conflicting kernel names")
+        capture["raw_row_numbers"].append(row_number)
+    return {
+        "captures": list(captures.values()),
+        "columns": columns,
+        "parse_status": "parsed" if captures else "unverifiable_no_captures",
+    }
+
+
+def verify_ncu_capture(plan: dict[str, Any], parsed: dict[str, Any]) -> dict[str, Any]:
+    """Verify a fresh NCU report and expose launch-order drift instead of assuming it away."""
+    derivation = plan["command"]["derivation"]
+    expected_name = str(derivation["kernel_name"])
+    expected_count = int(derivation["launch_count"])
+    captures = parsed["captures"]
+    issues: list[str] = []
+    if parsed["parse_status"] != "parsed":
+        return {
+            "status": "unverifiable",
+            "issues": [parsed["parse_status"]],
+            "expected_kernel": expected_name,
+            "expected_capture_count": expected_count,
+            "observed_captures": captures,
+        }
+    if len(captures) != expected_count:
+        issues.append(f"expected {expected_count} captures, observed {len(captures)}")
+    observed_names = sorted({item["kernel_name"] for item in captures})
+    if observed_names != [expected_name]:
+        issues.append(f"expected kernel {expected_name!r}, observed {observed_names!r}")
+    expected_shapes = {
+        json.dumps(item, sort_keys=True) for item in derivation.get("expected_shapes", [])
+    }
+    observed_shapes = {
+        json.dumps({"grid": item["grid"], "block": item["block"]}, sort_keys=True)
+        for item in captures
+    }
+    if expected_shapes and any(item["grid"] is None or item["block"] is None for item in captures):
+        return {
+            "status": "unverifiable",
+            "issues": [*issues, "NCU raw export lacks grid/block shape data"],
+            "expected_kernel": expected_name,
+            "expected_capture_count": expected_count,
+            "observed_captures": captures,
+        }
+    if expected_shapes and not observed_shapes.issubset(expected_shapes):
+        issues.append("observed NCU launch shape was absent from NSYS discovery selection")
+    return {
+        "status": "verified" if not issues else "failed",
+        "issues": issues,
+        "expected_kernel": expected_name,
+        "expected_capture_count": expected_count,
+        "observed_capture_count": len(captures),
+        "observed_captures": captures,
+        "cross_process_launch_order": (
+            "not assumed; report kernel/count/shapes were checked after the separate NCU process"
+        ),
     }

--- a/scripts/feature_validation/profiler.py
+++ b/scripts/feature_validation/profiler.py
@@ -308,6 +308,83 @@ def verify_graph_node_discovery(
     return result
 
 
+def select_regression_diagnostic(
+    stage: dict[str, Any],
+    stage_report: dict[str, Any] | None,
+    screen_selection: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve a preregistered diagnostic target only after a regression signal."""
+    if not stage_report:
+        return {"triggered": False, "reason": "screening_stage_not_executed"}
+    observation = stage_report.get("screening_observation")
+    if not isinstance(observation, dict):
+        return {"triggered": False, "reason": "stage_has_no_screening_observation"}
+    if observation.get("signal") != "regression_signal":
+        return {"triggered": False, "reason": "no_regression_signal"}
+    raw_pairs = observation.get("raw_pairs")
+    if not isinstance(raw_pairs, list) or len(raw_pairs) != 1:
+        raise ValidationError("early diagnostic requires exactly one preserved screening pair")
+    pair = raw_pairs[0]
+    raw_screens = pair.get("raw_screens")
+    if not isinstance(raw_screens, dict):
+        raise ValidationError("screening report lacks raw per-screen observations")
+    values: dict[str, dict[str, float]] = {}
+    for variant in ("baseline", "candidate"):
+        rows = raw_screens.get(variant)
+        if not isinstance(rows, list):
+            raise ValidationError(f"screening report lacks {variant} per-screen observations")
+        for row in rows:
+            screen = str(row["screen"])
+            values.setdefault(screen, {})[variant] = float(row["value"])
+    stage_screens = [
+        str(item["id"])
+        for item in stage.get("screens", [{"id": "default"}])
+    ]
+    for screen in stage_screens:
+        if set(values.get(screen, {})) != {"baseline", "candidate"}:
+            raise ValidationError(f"screening report lacks a matched pair for screen {screen!r}")
+    direction = str(observation.get("direction", stage["metric"]["direction"]))
+
+    def details(screen: str) -> dict[str, Any]:
+        baseline = values[screen]["baseline"]
+        candidate = values[screen]["candidate"]
+        if baseline <= 0 or candidate <= 0:
+            raise ValidationError("diagnostic screen selection requires positive observations")
+        percent = 100.0 * (candidate / baseline - 1.0)
+        benefit = percent if direction == "higher" else -percent
+        return {
+            "screen": screen,
+            "baseline": baseline,
+            "candidate": candidate,
+            "percent_change": percent,
+            "benefit_percent": benefit,
+            "regression_severity_percent": -benefit,
+        }
+
+    candidates = [details(screen) for screen in stage_screens]
+    if screen_selection["kind"] == "fixed":
+        selected = next(
+            item for item in candidates if item["screen"] == screen_selection["screen"]
+        )
+    else:
+        selected = max(
+            candidates,
+            key=lambda item: (
+                item["regression_severity_percent"],
+                -stage_screens.index(item["screen"]),
+            ),
+        )
+    return {
+        "triggered": True,
+        "reason": "preregistered_regression_signal",
+        "stage": stage["id"],
+        "selection_policy": screen_selection,
+        "selected_screen": selected,
+        "all_screen_observations": candidates,
+        "confidence_claim": "none",
+    }
+
+
 def _selector_matches(launch: dict[str, Any], selector: dict[str, Any]) -> bool:
     pattern = selector.get("kernel_regex")
     if not isinstance(pattern, str) or not pattern:
@@ -338,9 +415,18 @@ def build_ncu_plan(
     Every value is derived from this discovery, never carried across builds.
     """
     validate_native_affinity(target_argv, direct_harness)
-    selected = [launch for launch in discovery["launches"] if _selector_matches(launch, selector)]
-    if not selected:
+    matches = [launch for launch in discovery["launches"] if _selector_matches(launch, selector)]
+    if not matches:
         raise ValidationError("profiler selector matched no discovered kernel launches")
+    occurrence_kind = selector.get("occurrence_policy", {"kind": "all"}).get("kind", "all")
+    if occurrence_kind == "first":
+        selected = matches[:1]
+    elif occurrence_kind == "middle":
+        selected = matches[(len(matches) - 1) // 2 : (len(matches) - 1) // 2 + 1]
+    elif occurrence_kind == "last":
+        selected = matches[-1:]
+    else:
+        selected = matches
     names = {launch["name"] for launch in selected}
     if len(names) != 1:
         raise ValidationError("one filtered NCU capture requires one discovered kernel name")
@@ -385,6 +471,8 @@ def build_ncu_plan(
         "selected_launches": selected,
         "derivation": {
             "kernel_name": kernel_name,
+            "matching_launch_count": len(matches),
+            "occurrence_policy": occurrence_kind,
             "name_occurrences": occurrences,
             "launch_skip": launch_skip,
             "launch_count": launch_count,
@@ -442,17 +530,33 @@ def parse_ncu_raw_csv(text: str) -> dict[str, Any]:
                 "kernel_name": name,
                 "grid": _normalize_shape(row.get("Grid Size")),
                 "block": _normalize_shape(row.get("Block Size")),
+                "metrics": [],
                 "raw_row_numbers": [],
             },
         )
         if capture["kernel_name"] != name:
             raise ValidationError(f"NCU capture ID {capture_key} has conflicting kernel names")
+        metric_name = (row.get("Metric Name") or "").strip()
+        metric_value = (row.get("Metric Value") or "").strip()
+        if metric_name and metric_value:
+            metric = {
+                "name": metric_name,
+                "unit": (row.get("Metric Unit") or "").strip() or None,
+                "value": metric_value,
+            }
+            if metric not in capture["metrics"]:
+                capture["metrics"].append(metric)
         capture["raw_row_numbers"].append(row_number)
     return {
         "captures": list(captures.values()),
         "columns": columns,
         "parse_status": "parsed" if captures else "unverifiable_no_captures",
     }
+
+
+def _canonical_kernel_name(name: str) -> str:
+    """Normalize only known NSYS/NCU template-constant demangler differences."""
+    return re.sub(r"\((?:int|bool|ggml_type)\)([-+]?[0-9]+)", r"\1", name)
 
 
 def verify_ncu_capture(plan: dict[str, Any], parsed: dict[str, Any]) -> dict[str, Any]:
@@ -473,7 +577,9 @@ def verify_ncu_capture(plan: dict[str, Any], parsed: dict[str, Any]) -> dict[str
     if len(captures) != expected_count:
         issues.append(f"expected {expected_count} captures, observed {len(captures)}")
     observed_names = sorted({item["kernel_name"] for item in captures})
-    if observed_names != [expected_name]:
+    canonical_expected_name = _canonical_kernel_name(expected_name)
+    canonical_observed_names = sorted({_canonical_kernel_name(item) for item in observed_names})
+    if canonical_observed_names != [canonical_expected_name]:
         issues.append(f"expected kernel {expected_name!r}, observed {observed_names!r}")
     expected_shapes = {
         json.dumps(item, sort_keys=True) for item in derivation.get("expected_shapes", [])
@@ -496,10 +602,157 @@ def verify_ncu_capture(plan: dict[str, Any], parsed: dict[str, Any]) -> dict[str
         "status": "verified" if not issues else "failed",
         "issues": issues,
         "expected_kernel": expected_name,
+        "canonical_expected_kernel": canonical_expected_name,
+        "observed_kernel_names": observed_names,
+        "canonical_observed_kernel_names": canonical_observed_names,
+        "kernel_name_normalization": (
+            "known NSYS/NCU integral template-cast spelling only; raw names retained"
+        ),
         "expected_capture_count": expected_count,
         "observed_capture_count": len(captures),
         "observed_captures": captures,
         "cross_process_launch_order": (
             "not assumed; report kernel/count/shapes were checked after the separate NCU process"
+        ),
+    }
+
+
+def agent_profile_summary(profile_root: pathlib.Path) -> dict[str, Any]:
+    """Expose a compact, machine-readable view while retaining all raw artifacts."""
+    root = profile_root.resolve()
+
+    def read_json(name: str) -> dict[str, Any] | None:
+        path = root / name
+        if not path.is_file():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise ValidationError(f"profiler artifact is not an object: {path}")
+        return value
+
+    plan = read_json("ncu-plan.json")
+    discovery = read_json("discovery-inventory.json")
+    verification = read_json("ncu-verification.json")
+    state = read_json("profile-state.json")
+    if plan is None or discovery is None or state is None:
+        raise ValidationError(f"profiler artifacts are incomplete: {root}")
+    derivation = plan["command"]["derivation"]
+    selected = plan["command"]["selected_launches"]
+    timings: dict[str, Any] = {}
+    for kind, filename in (("nsys", "nsys-result.json"), ("ncu", "ncu-result.json")):
+        result = read_json(filename)
+        if result is not None:
+            timing = result.get("timing", {})
+            timings[kind] = {
+                "target_process_seconds": timing.get("target_process_seconds"),
+                "locked_lifecycle_wall_seconds": timing.get("locked_lifecycle_wall_seconds"),
+                "toolkit_overhead_seconds": timing.get("toolkit_overhead_seconds"),
+            }
+    captures = (
+        verification.get("parsed_export", {}).get("captures", [])
+        if verification is not None
+        else []
+    )
+    return {
+        "status": (
+            "verified"
+            if verification is not None and verification.get("status") == "verified"
+            else state.get("ncu_verification_status", "not_executed")
+        ),
+        "stage": plan["stage"],
+        "variant": plan["variant"],
+        "screen": plan["screen"],
+        "nsys": {
+            "total_launch_count": discovery["launch_count"],
+            "graph_node_trace": discovery["graph_node_trace"],
+            "selected_kernel": derivation["kernel_name"],
+            "matching_launch_count": derivation["matching_launch_count"],
+            "selected_launch_count": derivation["launch_count"],
+            "selected_launch_indices": derivation["discovery_launch_indices"],
+            "selected_name_occurrences": derivation["name_occurrences"],
+            "selected_shapes": derivation.get("expected_shapes", []),
+            "selected_graph_node_ids": sorted(
+                {
+                    str(item["graph_node_id"])
+                    for item in selected
+                    if item.get("graph_node_id") not in {None, 0, "0"}
+                }
+            ),
+        },
+        "ncu": {
+            "verification_status": (
+                verification.get("status") if verification is not None else "not_executed"
+            ),
+            "issues": verification.get("issues", []) if verification is not None else [],
+            "observed_capture_count": (
+                verification.get("observed_capture_count") if verification is not None else None
+            ),
+            "captures": captures,
+        },
+        "timing_seconds": timings,
+        "artifacts": {
+            "root": str(root),
+            "discovery_inventory": str(root / "discovery-inventory.json"),
+            "nsys_report": str(root / "discovery.nsys-rep"),
+            "nsys_stdout": str(root / "nsys-stdout.log"),
+            "nsys_stderr": str(root / "nsys-stderr.log"),
+            "ncu_plan": str(root / "ncu-plan.json"),
+            "ncu_report": plan["command"]["report_path"],
+            "ncu_stdout": str(root / "ncu-stdout.log"),
+            "ncu_stderr": str(root / "ncu-stderr.log"),
+            "ncu_verification": str(root / "ncu-verification.json"),
+        },
+        "evidence_boundary": (
+            "Diagnostic-only NSYS/NCU evidence; it is not a statistical performance, "
+            "correctness, resource, production, or long-context acceptance result."
+        ),
+    }
+
+
+def compare_agent_profiles(
+    baseline: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    """Place independently discovered evidence side by side without inventing statistics."""
+    if baseline.get("variant") != "baseline" or candidate.get("variant") != "candidate":
+        raise ValidationError("agent profile comparison requires baseline then candidate")
+
+    def metric_inventory(profile: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            {
+                "capture_id": capture.get("id"),
+                "kernel_name": capture.get("kernel_name"),
+                "metrics": capture.get("metrics", []),
+            }
+            for capture in profile.get("ncu", {}).get("captures", [])
+        ]
+
+    return {
+        "status": "diagnostic_side_by_side_only",
+        "same_selected_kernel": (
+            baseline["nsys"]["selected_kernel"] == candidate["nsys"]["selected_kernel"]
+        ),
+        "same_selected_shapes": (
+            baseline["nsys"]["selected_shapes"] == candidate["nsys"]["selected_shapes"]
+        ),
+        "launch_inventory": {
+            variant: {
+                "total": profile["nsys"]["total_launch_count"],
+                "matching": profile["nsys"]["matching_launch_count"],
+                "selected": profile["nsys"]["selected_launch_count"],
+            }
+            for variant, profile in (("baseline", baseline), ("candidate", candidate))
+        },
+        "raw_ncu_metrics": {
+            "baseline": metric_inventory(baseline),
+            "candidate": metric_inventory(candidate),
+        },
+        "timing_seconds": {
+            "baseline": baseline.get("timing_seconds", {}),
+            "candidate": candidate.get("timing_seconds", {}),
+        },
+        "comparison_boundary": (
+            "Raw one-capture diagnostics are shown side by side; no paired interval, "
+            "equivalence, acceptance decision, or generic aggregation across metric kinds "
+            "is inferred."
         ),
     }

--- a/scripts/feature_validation/runner.py
+++ b/scripts/feature_validation/runner.py
@@ -66,7 +66,7 @@ def _verify_spec_identity(spec: dict[str, Any]) -> None:
         if not path.is_file():
             raise core.ProvenanceError(f"run identity file disappeared: {path}")
         stat = core.stat_identity(path)
-        for key in ("size", "mtime_ns", "device", "inode"):
+        for key in ("size", "mtime_ns", "ctime_ns", "device", "inode"):
             if key in item and stat[key] != item[key]:
                 raise core.ProvenanceError(
                     f"run identity metadata changed for {path}: {key} expected {item[key]}, observed {stat[key]}"
@@ -99,6 +99,7 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
         spec["resource"],
         nvidia_smi=spec.get("nvidia_smi", "nvidia-smi"),
         first_sample_timeout=float(spec.get("telemetry_first_sample_timeout", 12.0)),
+        sampler_identity=spec.get("nvidia_smi_identity"),
     )
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
@@ -107,11 +108,21 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
     timed_out = False
     returncode: int | None = None
     telemetry_report: dict[str, Any] | None = None
+    identity_seconds: float | None = None
+    telemetry_startup_seconds: float | None = None
+    target_started: float | None = None
+    target_finished: float | None = None
+    cleanup_seconds: float | None = None
     try:
+        phase_start = time.monotonic()
         _verify_spec_identity(spec)
+        identity_seconds = time.monotonic() - phase_start
+        phase_start = time.monotonic()
         telemetry.start()
+        telemetry_startup_seconds = time.monotonic() - phase_start
         argv = [str(value) for value in spec["argv"]]
         environment = {str(key): str(value) for key, value in spec["environment"].items()}
+        target_started = time.monotonic()
         process = subprocess.Popen(
             argv,
             cwd=spec.get("cwd"),
@@ -158,12 +169,16 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
                 next_heartbeat += 5.0
             time.sleep(0.05)
         returncode = process.wait()
+        target_finished = time.monotonic()
     except Exception as caught:  # the result must preserve every failed attempt
+        if target_started is not None and target_finished is None:
+            target_finished = time.monotonic()
         error = f"{type(caught).__name__}: {caught}"
         if process is not None:
             _kill_group(process)
             returncode = process.poll()
     finally:
+        cleanup_started = time.monotonic()
         for thread in threads:
             thread.join(timeout=3.0)
         if process is not None:
@@ -176,6 +191,7 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
         except Exception as caught:
             telemetry_error = f"{type(caught).__name__}: {caught}"
             error = f"{error}; telemetry cleanup: {telemetry_error}" if error else telemetry_error
+        cleanup_seconds = time.monotonic() - cleanup_started
     stdout = b"".join(stdout_chunks)
     stderr = b"".join(stderr_chunks)
     stdout_path.parent.mkdir(parents=True, exist_ok=True)
@@ -189,6 +205,12 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
     if contamination and error is None:
         error = "GPU clean-process evidence was contaminated"
     status = "success" if returncode == 0 and not timed_out and error is None else "failed"
+    total_seconds = time.monotonic() - start_monotonic
+    target_seconds = (
+        target_finished - target_started
+        if target_started is not None and target_finished is not None
+        else 0.0
+    )
     result: dict[str, Any] = {
         "run_id": spec["run_id"],
         "status": status,
@@ -196,7 +218,19 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
         "schedule": spec.get("schedule"),
         "started_utc": started,
         "finished_utc": core.utc_now(),
-        "elapsed_seconds": time.monotonic() - start_monotonic,
+        "elapsed_seconds": total_seconds,
+        "timing": {
+            "identity_verification_seconds": identity_seconds,
+            "telemetry_startup_seconds": telemetry_startup_seconds,
+            "target_process_seconds": target_seconds,
+            "cleanup_seconds": cleanup_seconds,
+            "toolkit_overhead_seconds": max(0.0, total_seconds - target_seconds),
+            "locked_wrapper_to_executor_seconds": (
+                max(0.0, start_monotonic - float(spec["launcher_requested_monotonic"]))
+                if spec.get("launcher_requested_monotonic") is not None
+                else None
+            ),
+        },
         "pid": process.pid if process is not None else None,
         "returncode": returncode,
         "timed_out": timed_out,
@@ -252,6 +286,48 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def launch_locked_spec(
+    spec: dict[str, Any], spec_path: pathlib.Path, tool_script: pathlib.Path
+) -> dict[str, Any]:
+    """Launch one internal lifecycle under the required whole-command GPU lock."""
+    result_path = pathlib.Path(spec["result_path"])
+    if spec_path.exists() or result_path.exists():
+        raise core.ValidationError(
+            f"refusing to overwrite an existing attempt: {spec_path} / {result_path}"
+        )
+    inner = [sys.executable, str(tool_script), "_execute-run", str(spec_path)]
+    wrapper = core.flock_argv(inner)
+    spec["gpu_lock"] = {
+        "path": core.GPU_LOCK,
+        "whole_command_argv": wrapper,
+        "whole_command": core.quote_argv(wrapper),
+        "inner_lifecycle": "telemetry preflight, direct target, telemetry cleanup",
+    }
+    spec["launcher_requested_monotonic"] = time.monotonic()
+    core.write_json_atomic(spec_path, spec)
+    print(f"[feature-validation] launch {core.quote_argv(wrapper)}", flush=True)
+    completed = subprocess.run(wrapper, check=False)
+    if result_path.is_file():
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        launcher_seconds = time.monotonic() - spec["launcher_requested_monotonic"]
+        result.setdefault("timing", {})["locked_lifecycle_wall_seconds"] = launcher_seconds
+        result["timing"]["locked_lifecycle_overhead_seconds"] = max(
+            0.0,
+            launcher_seconds - float(result["timing"].get("target_process_seconds", 0.0)),
+        )
+        core.write_json_atomic(result_path, result)
+        return result
+    result = {
+        "run_id": spec["run_id"],
+        "attempt": spec["attempt"],
+        "status": "failed",
+        "error": f"flock/internal executor returned {completed.returncode} without result",
+        "gpu_lock": spec["gpu_lock"],
+    }
+    core.write_json_atomic(result_path, result)
+    return result
+
+
 class StudyRunner:
     def __init__(self, manifest_path: pathlib.Path, tool_script: pathlib.Path) -> None:
         self.manifest_path = manifest_path.expanduser().resolve()
@@ -264,6 +340,8 @@ class StudyRunner:
         self.state_path = self.study_root / "state.json"
         self.provenance: dict[str, Any] | None = None
         self.state: dict[str, Any] | None = None
+        self.preparation_elapsed_seconds = 0.0
+        self.resume_mode = False
 
     def prepare(self, *, resume: bool) -> None:
         provenance = core.capture_provenance(self.manifest, self.manifest_sha256)
@@ -302,49 +380,6 @@ class StudyRunner:
         self.state["updated_utc"] = core.utc_now()
         core.write_json_atomic(self.state_path, self.state)
 
-    def _identity_spec(
-        self, stage: dict[str, Any], scheduled: dict[str, Any]
-    ) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
-        assert self.provenance is not None
-        files: dict[str, dict[str, Any]] = {}
-        sources: list[dict[str, str]] = []
-        variant_name = scheduled["variant"]
-        variant = self.provenance["variants"][variant_name]
-        role = str(stage["command"].get("executable_role", "default"))
-        executable = variant["executables"][role]
-        binary = executable["binary"]
-        files[binary["resolved_path"]] = {
-            "path": binary["resolved_path"],
-            **{key: binary[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
-            "rehash": True,
-        }
-        for library in binary.get("libraries", []):
-            files[library["path"]] = {"path": library["path"], **library}
-        build = executable["build"]
-        if build.get("cache"):
-            files[build["cache"]] = {
-                "path": build["cache"],
-                "sha256": build["cache_sha256"],
-                **build["cache_stat"],
-            }
-        source = variant["source"]
-        sources.append(
-            {
-                "root": source["root"],
-                "head": source["head"],
-                "dirty_fingerprint": source["dirty_fingerprint"],
-            }
-        )
-        for item in self.provenance["inputs"]:
-            files[item["path"]] = {
-                "path": item["path"],
-                **{key: item[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
-            }
-        return (
-            [files[path] for path in sorted(files)],
-            sources,
-        )
-
     def _execute(
         self,
         stage: dict[str, Any],
@@ -375,7 +410,11 @@ class StudyRunner:
         }
         argv = [_render(value, context) for value in argv]
         environment = {key: _render(value, context) for key, value in environment.items()}
-        identity_files, source_identities = self._identity_spec(stage, scheduled)
+        assert self.provenance is not None
+        role = str(stage["command"].get("executable_role", "default"))
+        identity_files, source_identities = core.provenance_identity_spec(
+            self.provenance, [(scheduled["variant"], role)]
+        )
         result_path = run_root / "result.json"
         spec_path = run_root / "run-spec.json"
         comparison = stage.get("comparison", {})
@@ -402,31 +441,16 @@ class StudyRunner:
             "comparison_path": comparison_path,
             "identity_files": identity_files,
             "source_identities": source_identities,
+            "nvidia_smi_identity": self.provenance.get("runtime_tools", {}).get("nvidia-smi"),
+            "nvidia_smi": (
+                self.provenance.get("runtime_tools", {})
+                .get("nvidia-smi", {})
+                .get("path", "nvidia-smi")
+            ),
             "host_load_before": core.host_load_snapshot(),
         }
         if stage["resource"] == "gpu":
-            inner = [sys.executable, str(self.tool_script), "_execute-run", str(spec_path)]
-            wrapper = core.flock_argv(inner)
-            spec["gpu_lock"] = {
-                "path": core.GPU_LOCK,
-                "whole_command_argv": wrapper,
-                "whole_command": core.quote_argv(wrapper),
-                "inner_lifecycle": "telemetry preflight, direct target, telemetry cleanup",
-            }
-            core.write_json_atomic(spec_path, spec)
-            print(f"[feature-validation] launch {core.quote_argv(wrapper)}", flush=True)
-            launch = subprocess.run(wrapper, check=False)
-            if result_path.exists():
-                result = json.loads(result_path.read_text(encoding="utf-8"))
-            else:
-                result = {
-                    "run_id": run_id,
-                    "attempt": attempt,
-                    "status": "failed",
-                    "error": f"flock/internal executor returned {launch.returncode} without result",
-                    "gpu_lock": spec["gpu_lock"],
-                }
-                core.write_json_atomic(result_path, result)
+            result = launch_locked_spec(spec, spec_path, self.tool_script)
         else:
             spec["gpu_lock"] = None
             core.write_json_atomic(spec_path, spec)
@@ -488,17 +512,13 @@ class StudyRunner:
         }
         report = {
             "purpose": stage["purpose"],
+            "execution_status": "completed",
             "status": "passed" if not mismatches else "failed",
             "comparison_mode": mode,
             "hashes": hashes,
             "mismatches": mismatches,
             "raw_run_ids": [result["run_id"] for result in results],
         }
-        if mismatches:
-            assert self.state is not None
-            self.state["stages"][stage["id"]] = report
-            self._save_state()
-            raise core.ValidationError(f"exactness gate {stage['id']} failed: {mismatches}")
         return report
 
     def _run_performance(
@@ -548,19 +568,132 @@ class StudyRunner:
             ]
         return {
             "purpose": stage["purpose"],
-            "status": "completed",
+            "execution_status": "completed",
+            "status": core.performance_outcome(report["decision"], stage["decision_policy"]),
+            "decision_policy": stage["decision_policy"],
             "statistics": report,
             "adaptive_repetition": extension,
             "raw_run_ids": [result["run_id"] for result in results.values()],
         }
 
+    def _summary(self, through: str, early_elapsed: float | None) -> dict[str, Any]:
+        assert self.state is not None
+        final_gate = next(
+            item
+            for item in self.manifest["stages"]
+            if item["purpose"] == "long_context_acceptance"
+        )
+        final_report = self.state["stages"].get(final_gate["id"])
+        final_executed = bool(
+            final_report and final_report.get("execution_status") == "completed"
+        )
+        final_passed = bool(final_report and final_report.get("status") == "passed")
+        blocking = next(
+            (
+                (stage, self.state["stages"][stage["id"]])
+                for stage in self.manifest["stages"]
+                if self.state["stages"].get(stage["id"], {}).get("status")
+                in {"failed", "unresolved"}
+            ),
+            None,
+        )
+        if blocking:
+            blocking_stage, blocking_report = blocking
+            prefix = (
+                "acceptance"
+                if blocking_stage["purpose"] == "long_context_acceptance"
+                else blocking_stage["purpose"]
+            )
+            status = f"{prefix}_{blocking_report['status']}"
+        elif through == "acceptance" and final_report:
+            status = {
+                "passed": "acceptance_complete",
+                "failed": "acceptance_failed",
+                "unresolved": "acceptance_unresolved",
+            }.get(final_report.get("status"), "acceptance_not_completed")
+        elif through == "production":
+            status = "production_confirmation_only_not_final_acceptance"
+        else:
+            status = "early_screen_only_not_production_or_final_acceptance"
+        early_stage_ids = {
+            stage["id"]
+            for stage in self.manifest["stages"]
+            if core.PURPOSE_ORDER[stage["purpose"]] <= core.PURPOSE_ORDER["kernel_screen"]
+        }
+        early_attempts = [
+            attempts[-1]
+            for run_id, attempts in self.state["runs"].items()
+            if run_id.split("--", 1)[0] in early_stage_ids and attempts
+        ]
+        target_seconds = sum(
+            float(item.get("timing", {}).get("target_process_seconds", 0.0))
+            for item in early_attempts
+        )
+        per_run_overhead = sum(
+            float(item.get("timing", {}).get("toolkit_overhead_seconds", 0.0))
+            for item in early_attempts
+        )
+        locked_lifecycle = sum(
+            float(
+                item.get("timing", {}).get(
+                    "locked_lifecycle_wall_seconds", item.get("elapsed_seconds", 0.0)
+                )
+            )
+            for item in early_attempts
+        )
+        return {
+            "study_id": self.manifest["study"]["id"],
+            "artifact_root": str(self.study_root),
+            "through": through,
+            "early_elapsed_seconds": early_elapsed,
+            "early_target_seconds": self.manifest["study"]["early_decision_target_seconds"],
+            "early_timing": {
+                "mode": "resume" if self.resume_mode else "fresh",
+                "run_count": len(early_attempts),
+                "preparation_seconds": self.preparation_elapsed_seconds,
+                "target_process_seconds": target_seconds,
+                "recorded_per_run_toolkit_overhead_seconds": per_run_overhead,
+                "locked_lifecycle_wall_seconds": locked_lifecycle,
+                "locked_wrapper_to_executor_seconds": sum(
+                    float(
+                        item.get("timing", {}).get("locked_wrapper_to_executor_seconds")
+                        or 0.0
+                    )
+                    for item in early_attempts
+                ),
+                "identity_verification_seconds": sum(
+                    float(item.get("timing", {}).get("identity_verification_seconds") or 0.0)
+                    for item in early_attempts
+                ),
+                "telemetry_startup_seconds": sum(
+                    float(item.get("timing", {}).get("telemetry_startup_seconds") or 0.0)
+                    for item in early_attempts
+                ),
+                "wall_minus_target_seconds": (
+                    max(0.0, early_elapsed - target_seconds)
+                    if early_elapsed is not None and not self.resume_mode
+                    else None
+                ),
+            },
+            "final_long_context_acceptance_executed": final_executed,
+            "final_long_context_acceptance_passed": final_passed,
+            "status": status,
+            "evidence_boundary": (
+                "Early/direct-kernel/Nsight evidence does not prove end-to-end performance, resource use, "
+                "output exactness, or long-context behavior; each has its own gate."
+            ),
+            "stages": self.state["stages"],
+        }
+
     def run(self, *, through: str, resume: bool, retry_failed: bool) -> dict[str, Any]:
+        start = time.monotonic()
+        self.resume_mode = resume
         self.prepare(resume=resume)
+        self.preparation_elapsed_seconds = time.monotonic() - start
         assert self.state is not None
         limits = {"early": 2, "production": 3, "acceptance": 4}
         if through not in limits:
             raise core.ValidationError(f"unknown validation phase {through!r}")
-        start = time.monotonic()
         early_elapsed: float | None = None
         for stage in self.manifest["stages"]:
             if core.PURPOSE_ORDER[stage["purpose"]] > limits[through]:
@@ -578,25 +711,12 @@ class StudyRunner:
             self._save_state()
             if stage["purpose"] == "kernel_screen":
                 early_elapsed = time.monotonic() - start
-        final_gate = next(item for item in self.manifest["stages"] if item["purpose"] == "long_context_acceptance")
-        final_passed = self.state["stages"].get(final_gate["id"], {}).get("status") == "completed"
-        summary = {
-            "study_id": self.manifest["study"]["id"],
-            "artifact_root": str(self.study_root),
-            "through": through,
-            "early_elapsed_seconds": early_elapsed,
-            "early_target_seconds": self.manifest["study"]["early_decision_target_seconds"],
-            "final_long_context_acceptance_completed": final_passed,
-            "status": "acceptance_complete" if final_passed else (
-                "production_confirmation_only_not_final_acceptance"
-                if through == "production"
-                else "early_screen_only_not_production_or_final_acceptance"
-            ),
-            "evidence_boundary": (
-                "Early/direct-kernel/Nsight evidence does not prove end-to-end performance, resource use, "
-                "output exactness, or long-context behavior; each has its own gate."
-            ),
-            "stages": self.state["stages"],
-        }
+            if report["status"] != "passed":
+                summary = self._summary(through, early_elapsed)
+                core.write_json_atomic(self.study_root / "summary.json", summary)
+                raise core.ValidationError(
+                    f"stage {stage['id']} executed but is not acceptable: {report['status']}"
+                )
+        summary = self._summary(through, early_elapsed)
         core.write_json_atomic(self.study_root / "summary.json", summary)
         return summary

--- a/scripts/feature_validation/runner.py
+++ b/scripts/feature_validation/runner.py
@@ -526,6 +526,34 @@ class StudyRunner:
     ) -> dict[str, Any]:
         schedule = core.build_schedule(self.manifest, stage)
         results: dict[str, dict[str, Any]] = {}
+        screening_policy = stage.get("screening_policy")
+        if screening_policy is not None:
+            for item in schedule:
+                results[item["run_id"]] = self._execute(
+                    stage, item, retry_failed=retry_failed
+                )
+            pair = self._pair_values(stage, schedule, results, 1)
+            observation = core.single_pair_screen_report(
+                pair,
+                direction=stage["metric"]["direction"],
+                regression_threshold_percent=screening_policy[
+                    "regression_threshold_percent"
+                ],
+            )
+            passed = observation["signal"] == "clear_to_continue"
+            return {
+                "purpose": stage["purpose"],
+                "execution_status": "completed",
+                "status": "passed" if passed else "failed",
+                "screening_policy": screening_policy,
+                "screening_observation": observation,
+                "adaptive_repetition": {
+                    "applicable": False,
+                    "reason": "single_pair_fail_fast_screen",
+                    "statistical_pairs": "not_applicable_by_preregistered_screening_policy",
+                },
+                "raw_run_ids": [result["run_id"] for result in results.values()],
+            }
         pairs: list[dict[str, Any]] = []
         thresholds = self.manifest["repetition_policy"]["extension_rule"]["thresholds"]
         for pair in range(1, 4):

--- a/scripts/feature_validation/runner.py
+++ b/scripts/feature_validation/runner.py
@@ -1,0 +1,602 @@
+"""Study execution, clean-process isolation, adaptive pairs, and safe resume."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import threading
+import time
+from typing import Any
+
+from . import core
+from .telemetry import TelemetrySession
+
+
+def _render(value: str, context: dict[str, Any]) -> str:
+    try:
+        return value.format_map({key: str(item) for key, item in context.items()})
+    except KeyError as error:
+        raise core.ValidationError(f"unknown command template field {error.args[0]!r}") from error
+
+
+def _environment_command(environment: dict[str, str], argv: list[str]) -> list[str]:
+    return ["env", "-i", *[f"{key}={environment[key]}" for key in sorted(environment)], *argv]
+
+
+def _kill_group(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        process.terminate()
+    try:
+        process.wait(timeout=3.0)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        process.kill()
+    process.wait(timeout=3.0)
+
+
+def _drain(stream: Any, chunks: list[bytes], label: str, output_lock: threading.Lock) -> None:
+    while True:
+        chunk = stream.readline()
+        if not chunk:
+            return
+        chunks.append(chunk)
+        with output_lock:
+            sys.stdout.buffer.write(f"[{label}] ".encode("utf-8") + chunk)
+            if not chunk.endswith(b"\n"):
+                sys.stdout.buffer.write(b"\n")
+            sys.stdout.buffer.flush()
+
+
+def _verify_spec_identity(spec: dict[str, Any]) -> None:
+    for item in spec.get("identity_files", []):
+        path = pathlib.Path(item["path"]).resolve()
+        if not path.is_file():
+            raise core.ProvenanceError(f"run identity file disappeared: {path}")
+        stat = core.stat_identity(path)
+        for key in ("size", "mtime_ns", "device", "inode"):
+            if key in item and stat[key] != item[key]:
+                raise core.ProvenanceError(
+                    f"run identity metadata changed for {path}: {key} expected {item[key]}, observed {stat[key]}"
+                )
+        if item.get("rehash", False) or "mtime_ns" not in item:
+            observed = core.sha256_file(path)
+            if observed != item["sha256"]:
+                raise core.ProvenanceError(
+                    f"run identity changed for {path}: expected {item['sha256']}, observed {observed}"
+                )
+    for item in spec.get("source_identities", []):
+        observed = core.git_snapshot(pathlib.Path(item["root"]))
+        for key in ("head", "dirty_fingerprint"):
+            if observed[key] != item[key]:
+                raise core.ProvenanceError(
+                    f"source identity changed for {item['root']}: {key} expected {item[key]}, observed {observed[key]}"
+                )
+
+
+def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
+    """Execute one fresh direct process.  GPU callers invoke this under flock."""
+    output_path = pathlib.Path(spec["result_path"])
+    stdout_path = pathlib.Path(spec["stdout_path"])
+    stderr_path = pathlib.Path(spec["stderr_path"])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    started = core.utc_now()
+    start_monotonic = time.monotonic()
+    process: subprocess.Popen[bytes] | None = None
+    telemetry = TelemetrySession(
+        spec["resource"],
+        nvidia_smi=spec.get("nvidia_smi", "nvidia-smi"),
+        first_sample_timeout=float(spec.get("telemetry_first_sample_timeout", 12.0)),
+    )
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    threads: list[threading.Thread] = []
+    error: str | None = None
+    timed_out = False
+    returncode: int | None = None
+    telemetry_report: dict[str, Any] | None = None
+    try:
+        _verify_spec_identity(spec)
+        telemetry.start()
+        argv = [str(value) for value in spec["argv"]]
+        environment = {str(key): str(value) for key, value in spec["environment"].items()}
+        process = subprocess.Popen(
+            argv,
+            cwd=spec.get("cwd"),
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        telemetry.attach(process.pid)
+        print(
+            f"[feature-validation] started run={spec['run_id']} pid={process.pid} "
+            f"timeout={spec['timeout_seconds']}s progress={spec['progress']}",
+            flush=True,
+        )
+        output_lock = threading.Lock()
+        assert process.stdout is not None and process.stderr is not None
+        threads = [
+            threading.Thread(
+                target=_drain,
+                args=(process.stdout, stdout_chunks, "target stdout", output_lock),
+                daemon=True,
+            ),
+            threading.Thread(
+                target=_drain,
+                args=(process.stderr, stderr_chunks, "target stderr", output_lock),
+                daemon=True,
+            ),
+        ]
+        for thread in threads:
+            thread.start()
+        next_heartbeat = time.monotonic() + 5.0
+        timeout = float(spec["timeout_seconds"])
+        while process.poll() is None:
+            elapsed = time.monotonic() - start_monotonic
+            if elapsed > timeout:
+                timed_out = True
+                _kill_group(process)
+                break
+            if time.monotonic() >= next_heartbeat:
+                print(
+                    f"[feature-validation] progress run={spec['run_id']} elapsed={elapsed:.1f}s",
+                    flush=True,
+                )
+                next_heartbeat += 5.0
+            time.sleep(0.05)
+        returncode = process.wait()
+    except Exception as caught:  # the result must preserve every failed attempt
+        error = f"{type(caught).__name__}: {caught}"
+        if process is not None:
+            _kill_group(process)
+            returncode = process.poll()
+    finally:
+        for thread in threads:
+            thread.join(timeout=3.0)
+        if process is not None:
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.stderr is not None:
+                process.stderr.close()
+        try:
+            telemetry_report = telemetry.stop()
+        except Exception as caught:
+            telemetry_error = f"{type(caught).__name__}: {caught}"
+            error = f"{error}; telemetry cleanup: {telemetry_error}" if error else telemetry_error
+    stdout = b"".join(stdout_chunks)
+    stderr = b"".join(stderr_chunks)
+    stdout_path.parent.mkdir(parents=True, exist_ok=True)
+    stdout_path.write_bytes(stdout)
+    stderr_path.write_bytes(stderr)
+    contamination = bool(
+        spec["resource"] == "gpu"
+        and telemetry_report
+        and not telemetry_report["clean_process_evidence"]["clean_throughout"]
+    )
+    if contamination and error is None:
+        error = "GPU clean-process evidence was contaminated"
+    status = "success" if returncode == 0 and not timed_out and error is None else "failed"
+    result: dict[str, Any] = {
+        "run_id": spec["run_id"],
+        "status": status,
+        "attempt": spec["attempt"],
+        "schedule": spec.get("schedule"),
+        "started_utc": started,
+        "finished_utc": core.utc_now(),
+        "elapsed_seconds": time.monotonic() - start_monotonic,
+        "pid": process.pid if process is not None else None,
+        "returncode": returncode,
+        "timed_out": timed_out,
+        "error": error,
+        "argv": spec["argv"],
+        "direct_command": core.quote_argv(spec["argv"]),
+        "environment": spec["environment"],
+        "environment_command": core.quote_argv(_environment_command(spec["environment"], spec["argv"])),
+        "gpu_lock": spec.get("gpu_lock"),
+        "progress": spec["progress"],
+        "host_load_before": spec["host_load_before"],
+        "host_load_after": core.host_load_snapshot(),
+        "stdout": {
+            "path": str(stdout_path),
+            "size": len(stdout),
+            "sha256": hashlib.sha256(stdout).hexdigest(),
+        },
+        "stderr": {
+            "path": str(stderr_path),
+            "size": len(stderr),
+            "sha256": hashlib.sha256(stderr).hexdigest(),
+        },
+        "telemetry": telemetry_report,
+    }
+    if status == "success" and spec.get("metric"):
+        try:
+            result["metric_value"] = core.extract_metric(
+                spec["metric"],
+                stdout.decode("utf-8", errors="replace"),
+                stderr.decode("utf-8", errors="replace"),
+            )
+        except core.ValidationError as caught:
+            result["status"] = "failed"
+            result["error"] = f"ValidationError: {caught}"
+    comparison_path = spec.get("comparison_path")
+    if result["status"] == "success" and comparison_path:
+        path = pathlib.Path(comparison_path)
+        if not path.is_file():
+            result["status"] = "failed"
+            result["error"] = f"comparison artifact is missing: {path}"
+        else:
+            result["comparison_artifact"] = {
+                "path": str(path.resolve()),
+                "size": path.stat().st_size,
+                "sha256": core.sha256_file(path),
+            }
+    core.write_json_atomic(output_path, result)
+    print(
+        f"[feature-validation] finished run={spec['run_id']} status={result['status']} "
+        f"elapsed={result['elapsed_seconds']:.3f}s",
+        flush=True,
+    )
+    return result
+
+
+class StudyRunner:
+    def __init__(self, manifest_path: pathlib.Path, tool_script: pathlib.Path) -> None:
+        self.manifest_path = manifest_path.expanduser().resolve()
+        self.manifest, self.manifest_sha256 = core.load_and_validate_manifest(self.manifest_path)
+        self.tool_script = tool_script.expanduser().resolve()
+        study_id = core.safe_slug(str(self.manifest["study"]["id"]))
+        self.study_root = pathlib.Path(self.manifest["artifact_root"]) / (
+            f"{study_id}-{self.manifest_sha256[:12]}"
+        )
+        self.state_path = self.study_root / "state.json"
+        self.provenance: dict[str, Any] | None = None
+        self.state: dict[str, Any] | None = None
+
+    def prepare(self, *, resume: bool) -> None:
+        provenance = core.capture_provenance(self.manifest, self.manifest_sha256)
+        if self.state_path.exists():
+            if not resume:
+                raise core.ValidationError(
+                    f"deterministic study directory already exists; use --resume: {self.study_root}"
+                )
+            state = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if state.get("manifest_sha256") != self.manifest_sha256:
+                raise core.ProvenanceError("resume manifest identity mismatch")
+            if state.get("provenance_identity_fingerprint") != provenance["identity_fingerprint"]:
+                raise core.ProvenanceError("resume provenance identity mismatch")
+            self.state = state
+        else:
+            if resume:
+                raise core.ValidationError(f"no resumable study exists at {self.study_root}")
+            self.study_root.mkdir(parents=True, exist_ok=False)
+            core.write_json_atomic(self.study_root / "manifest.snapshot.json", self.manifest)
+            core.write_json_atomic(self.study_root / "provenance.json", provenance)
+            self.state = {
+                "schema_version": 1,
+                "study_id": self.manifest["study"]["id"],
+                "manifest_sha256": self.manifest_sha256,
+                "provenance_identity_fingerprint": provenance["identity_fingerprint"],
+                "created_utc": core.utc_now(),
+                "updated_utc": core.utc_now(),
+                "runs": {},
+                "stages": {},
+            }
+            self._save_state()
+        self.provenance = provenance
+
+    def _save_state(self) -> None:
+        assert self.state is not None
+        self.state["updated_utc"] = core.utc_now()
+        core.write_json_atomic(self.state_path, self.state)
+
+    def _identity_spec(
+        self, stage: dict[str, Any], scheduled: dict[str, Any]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+        assert self.provenance is not None
+        files: dict[str, dict[str, Any]] = {}
+        sources: list[dict[str, str]] = []
+        variant_name = scheduled["variant"]
+        variant = self.provenance["variants"][variant_name]
+        role = str(stage["command"].get("executable_role", "default"))
+        executable = variant["executables"][role]
+        binary = executable["binary"]
+        files[binary["resolved_path"]] = {
+            "path": binary["resolved_path"],
+            **{key: binary[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
+            "rehash": True,
+        }
+        for library in binary.get("libraries", []):
+            files[library["path"]] = {"path": library["path"], **library}
+        build = executable["build"]
+        if build.get("cache"):
+            files[build["cache"]] = {
+                "path": build["cache"],
+                "sha256": build["cache_sha256"],
+                **build["cache_stat"],
+            }
+        source = variant["source"]
+        sources.append(
+            {
+                "root": source["root"],
+                "head": source["head"],
+                "dirty_fingerprint": source["dirty_fingerprint"],
+            }
+        )
+        for item in self.provenance["inputs"]:
+            files[item["path"]] = {
+                "path": item["path"],
+                **{key: item[key] for key in ("sha256", "size", "mtime_ns", "device", "inode")},
+            }
+        return (
+            [files[path] for path in sorted(files)],
+            sources,
+        )
+
+    def _execute(
+        self,
+        stage: dict[str, Any],
+        scheduled: dict[str, Any],
+        *,
+        retry_failed: bool,
+    ) -> dict[str, Any]:
+        assert self.state is not None
+        run_id = f"{stage['id']}--{scheduled['run_id']}"
+        prior = self.state["runs"].get(run_id, [])
+        if prior and prior[-1]["status"] == "success":
+            print(f"[feature-validation] resume skip successful run={run_id}", flush=True)
+            return prior[-1]
+        if prior and not retry_failed:
+            raise core.ValidationError(
+                f"run {run_id} has a preserved failed attempt; use --retry-failed explicitly"
+            )
+        attempt = len(prior) + 1
+        run_root = self.study_root / "runs" / stage["id"] / scheduled["run_id"] / f"attempt-{attempt:02d}"
+        run_root.mkdir(parents=True, exist_ok=False)
+        argv, environment = core.command_for_run(self.manifest, stage, scheduled)
+        context = {
+            "artifact_dir": run_root,
+            "variant": scheduled["variant"],
+            "pair": scheduled["pair"],
+            "screen": scheduled["screen"],
+            "run_id": scheduled["run_id"],
+        }
+        argv = [_render(value, context) for value in argv]
+        environment = {key: _render(value, context) for key, value in environment.items()}
+        identity_files, source_identities = self._identity_spec(stage, scheduled)
+        result_path = run_root / "result.json"
+        spec_path = run_root / "run-spec.json"
+        comparison = stage.get("comparison", {})
+        comparison_path = None
+        if comparison.get("mode") == "file_sha256":
+            if not comparison.get("path"):
+                raise core.ManifestError("file_sha256 comparison requires path")
+            comparison_path = _render(str(comparison["path"]), context)
+        spec: dict[str, Any] = {
+            "schema_version": 1,
+            "run_id": run_id,
+            "attempt": attempt,
+            "schedule": scheduled,
+            "resource": stage["resource"],
+            "argv": argv,
+            "environment": environment,
+            "cwd": str(run_root),
+            "timeout_seconds": float(stage["timeout_seconds"]),
+            "progress": stage["progress"],
+            "result_path": str(result_path),
+            "stdout_path": str(run_root / "stdout.log"),
+            "stderr_path": str(run_root / "stderr.log"),
+            "metric": stage.get("metric"),
+            "comparison_path": comparison_path,
+            "identity_files": identity_files,
+            "source_identities": source_identities,
+            "host_load_before": core.host_load_snapshot(),
+        }
+        if stage["resource"] == "gpu":
+            inner = [sys.executable, str(self.tool_script), "_execute-run", str(spec_path)]
+            wrapper = core.flock_argv(inner)
+            spec["gpu_lock"] = {
+                "path": core.GPU_LOCK,
+                "whole_command_argv": wrapper,
+                "whole_command": core.quote_argv(wrapper),
+                "inner_lifecycle": "telemetry preflight, direct target, telemetry cleanup",
+            }
+            core.write_json_atomic(spec_path, spec)
+            print(f"[feature-validation] launch {core.quote_argv(wrapper)}", flush=True)
+            launch = subprocess.run(wrapper, check=False)
+            if result_path.exists():
+                result = json.loads(result_path.read_text(encoding="utf-8"))
+            else:
+                result = {
+                    "run_id": run_id,
+                    "attempt": attempt,
+                    "status": "failed",
+                    "error": f"flock/internal executor returned {launch.returncode} without result",
+                    "gpu_lock": spec["gpu_lock"],
+                }
+                core.write_json_atomic(result_path, result)
+        else:
+            spec["gpu_lock"] = None
+            core.write_json_atomic(spec_path, spec)
+            result = execute_run_spec(spec)
+        prior.append(result)
+        self.state["runs"][run_id] = prior
+        self._save_state()
+        if result["status"] != "success":
+            raise core.ValidationError(
+                f"run {run_id} attempt {attempt} failed; preserved at {result_path}: {result.get('error')}"
+            )
+        return result
+
+    def _pair_values(
+        self,
+        stage: dict[str, Any],
+        schedule: list[dict[str, Any]],
+        results: dict[str, dict[str, Any]],
+        pair: int,
+    ) -> dict[str, Any]:
+        aggregation = stage.get("aggregation", {"mode": "weighted_mean"})["mode"]
+        values: dict[str, float] = {}
+        raw_screens: dict[str, list[dict[str, Any]]] = {}
+        for variant in ("baseline", "candidate"):
+            screen_values: list[tuple[float, float]] = []
+            raw_screens[variant] = []
+            for scheduled in [item for item in schedule if item["pair"] == pair and item["variant"] == variant]:
+                result = results[scheduled["run_id"]]
+                value = float(result["metric_value"])
+                screen_values.append((value, float(scheduled["weight"])))
+                raw_screens[variant].append(
+                    {"screen": scheduled["screen"], "value": value, "weight": scheduled["weight"]}
+                )
+            values[variant] = core.aggregate_screen_values(screen_values, aggregation)
+        orientation = next(item["orientation"] for item in schedule if item["pair"] == pair)
+        return {
+            "pair": pair,
+            "orientation": orientation,
+            "baseline": values["baseline"],
+            "candidate": values["candidate"],
+            "aggregation": aggregation,
+            "raw_screens": raw_screens,
+        }
+
+    def _run_exactness(
+        self, stage: dict[str, Any], *, retry_failed: bool
+    ) -> dict[str, Any]:
+        schedule = core.build_schedule(self.manifest, stage)
+        results = [self._execute(stage, item, retry_failed=retry_failed) for item in schedule]
+        mode = stage["comparison"]["mode"]
+        hashes: dict[str, dict[str, str]] = {}
+        for scheduled, result in zip(schedule, results, strict=True):
+            source = result["stdout"] if mode == "stdout_sha256" else result["comparison_artifact"]
+            hashes.setdefault(scheduled["screen"], {})[scheduled["variant"]] = source["sha256"]
+        mismatches = {
+            screen: values
+            for screen, values in hashes.items()
+            if values.get("baseline") != values.get("candidate")
+        }
+        report = {
+            "purpose": stage["purpose"],
+            "status": "passed" if not mismatches else "failed",
+            "comparison_mode": mode,
+            "hashes": hashes,
+            "mismatches": mismatches,
+            "raw_run_ids": [result["run_id"] for result in results],
+        }
+        if mismatches:
+            assert self.state is not None
+            self.state["stages"][stage["id"]] = report
+            self._save_state()
+            raise core.ValidationError(f"exactness gate {stage['id']} failed: {mismatches}")
+        return report
+
+    def _run_performance(
+        self, stage: dict[str, Any], *, retry_failed: bool
+    ) -> dict[str, Any]:
+        schedule = core.build_schedule(self.manifest, stage)
+        results: dict[str, dict[str, Any]] = {}
+        pairs: list[dict[str, Any]] = []
+        thresholds = self.manifest["repetition_policy"]["extension_rule"]["thresholds"]
+        for pair in range(1, 4):
+            for item in [entry for entry in schedule if entry["pair"] == pair]:
+                results[item["run_id"]] = self._execute(stage, item, retry_failed=retry_failed)
+            pairs.append(self._pair_values(stage, schedule, results, pair))
+        report = core.paired_log_report(
+            pairs,
+            direction=stage["metric"]["direction"],
+            thresholds=thresholds,
+        )
+        initial_report = report
+        extension = {
+            "rule": "extend_only_if_inconclusive",
+            "initial_decision": report["decision"],
+            "initial_statistics": initial_report,
+            "extended": report["decision"] == "inconclusive",
+        }
+        if report["decision"] == "inconclusive":
+            for pair in range(4, 6):
+                for item in [entry for entry in schedule if entry["pair"] == pair]:
+                    results[item["run_id"]] = self._execute(stage, item, retry_failed=retry_failed)
+                pairs.append(self._pair_values(stage, schedule, results, pair))
+            report = core.paired_log_report(
+                pairs,
+                direction=stage["metric"]["direction"],
+                thresholds=thresholds,
+            )
+            extension["final_decision"] = report["decision"]
+            extension["not_run"] = []
+        else:
+            extension["final_decision"] = report["decision"]
+            extension["not_run"] = [
+                {
+                    "pair": pair,
+                    "status": "not_run_by_preregistered_conclusive_rule",
+                    "orientation": self.manifest["repetition_policy"]["order"][pair - 1],
+                }
+                for pair in (4, 5)
+            ]
+        return {
+            "purpose": stage["purpose"],
+            "status": "completed",
+            "statistics": report,
+            "adaptive_repetition": extension,
+            "raw_run_ids": [result["run_id"] for result in results.values()],
+        }
+
+    def run(self, *, through: str, resume: bool, retry_failed: bool) -> dict[str, Any]:
+        self.prepare(resume=resume)
+        assert self.state is not None
+        limits = {"early": 2, "production": 3, "acceptance": 4}
+        if through not in limits:
+            raise core.ValidationError(f"unknown validation phase {through!r}")
+        start = time.monotonic()
+        early_elapsed: float | None = None
+        for stage in self.manifest["stages"]:
+            if core.PURPOSE_ORDER[stage["purpose"]] > limits[through]:
+                continue
+            print(
+                f"[feature-validation] stage={stage['id']} purpose={stage['purpose']} "
+                f"progress={stage['progress']}",
+                flush=True,
+            )
+            if stage["purpose"] == "exactness":
+                report = self._run_exactness(stage, retry_failed=retry_failed)
+            else:
+                report = self._run_performance(stage, retry_failed=retry_failed)
+            self.state["stages"][stage["id"]] = report
+            self._save_state()
+            if stage["purpose"] == "kernel_screen":
+                early_elapsed = time.monotonic() - start
+        final_gate = next(item for item in self.manifest["stages"] if item["purpose"] == "long_context_acceptance")
+        final_passed = self.state["stages"].get(final_gate["id"], {}).get("status") == "completed"
+        summary = {
+            "study_id": self.manifest["study"]["id"],
+            "artifact_root": str(self.study_root),
+            "through": through,
+            "early_elapsed_seconds": early_elapsed,
+            "early_target_seconds": self.manifest["study"]["early_decision_target_seconds"],
+            "final_long_context_acceptance_completed": final_passed,
+            "status": "acceptance_complete" if final_passed else (
+                "production_confirmation_only_not_final_acceptance"
+                if through == "production"
+                else "early_screen_only_not_production_or_final_acceptance"
+            ),
+            "evidence_boundary": (
+                "Early/direct-kernel/Nsight evidence does not prove end-to-end performance, resource use, "
+                "output exactness, or long-context behavior; each has its own gate."
+            ),
+            "stages": self.state["stages"],
+        }
+        core.write_json_atomic(self.study_root / "summary.json", summary)
+        return summary

--- a/scripts/feature_validation/telemetry.py
+++ b/scripts/feature_validation/telemetry.py
@@ -208,6 +208,7 @@ class TelemetrySession:
         gpu_period_seconds: float = 1.0,
         proc_period_seconds: float = 0.25,
         first_sample_timeout: float = 12.0,
+        sampler_identity: dict[str, Any] | None = None,
     ) -> None:
         if resource not in {"cpu", "gpu"}:
             raise ValidationError(f"unknown telemetry resource {resource!r}")
@@ -216,6 +217,7 @@ class TelemetrySession:
         self.gpu_period_seconds = gpu_period_seconds
         self.proc_period_seconds = proc_period_seconds
         self.first_sample_timeout = first_sample_timeout
+        self.expected_sampler_identity = sampler_identity
         self.gpu_samples: list[dict[str, Any]] = []
         self.proc_samples: list[dict[str, Any]] = []
         self.parse_errors: list[str] = []
@@ -436,13 +438,22 @@ class TelemetrySession:
             vm_lck_values.append(sum(int(item.get("VmLck_kib", 0)) for item in statuses))
             vm_pin_values.append(sum(int(item.get("VmPin_kib", 0)) for item in statuses))
         sampler_reaped = self._sampler is None or self._sampler.poll() is not None
-        sampler_path_text = shutil.which(self.nvidia_smi) or self.nvidia_smi
-        sampler_path = pathlib.Path(sampler_path_text).expanduser().resolve()
-        sampler_identity = {
-            "path": str(sampler_path),
-            "sha256": sha256_file(sampler_path) if sampler_path.is_file() else None,
-            "argv": [self.nvidia_smi, "-q", "-x", "-l", str(max(1, int(round(self.gpu_period_seconds))))],
-        }
+        if self.expected_sampler_identity is not None:
+            sampler_identity = dict(self.expected_sampler_identity)
+        else:
+            sampler_path_text = shutil.which(self.nvidia_smi) or self.nvidia_smi
+            sampler_path = pathlib.Path(sampler_path_text).expanduser().resolve()
+            sampler_identity = {
+                "path": str(sampler_path),
+                "sha256": sha256_file(sampler_path) if sampler_path.is_file() else None,
+            }
+        sampler_identity["argv"] = [
+            self.nvidia_smi,
+            "-q",
+            "-x",
+            "-l",
+            str(max(1, int(round(self.gpu_period_seconds)))),
+        ]
         return {
             "started_utc": self._started_utc,
             "stopped_utc": self._stopped_utc,

--- a/scripts/feature_validation/telemetry.py
+++ b/scripts/feature_validation/telemetry.py
@@ -1,0 +1,503 @@
+"""Low-overhead, process-owned telemetry for validation runs."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import pty
+import re
+import shutil
+import signal
+import subprocess
+import threading
+import time
+import xml.etree.ElementTree as ET
+from typing import Any
+
+from .core import ValidationError, sha256_file, utc_now
+
+
+PROC_STATUS_FIELDS = {
+    "VmRSS",
+    "VmHWM",
+    "VmSize",
+    "RssAnon",
+    "RssFile",
+    "RssShmem",
+    "VmPin",
+    "VmLck",
+}
+MEMINFO_FIELDS = {
+    "MemTotal",
+    "MemFree",
+    "MemAvailable",
+    "Buffers",
+    "Cached",
+    "SwapTotal",
+    "SwapFree",
+    "Mlocked",
+    "AnonPages",
+    "PageTables",
+}
+
+
+def _kib_value(value: str | None) -> int | None:
+    if value is None:
+        return None
+    match = re.search(r"([0-9]+)", value)
+    return int(match.group(1)) if match else None
+
+
+def _number(value: str | None) -> float | None:
+    if value is None or value.strip().upper() in {"N/A", "[N/A]", "NOT SUPPORTED"}:
+        return None
+    match = re.search(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)", value)
+    return float(match.group(0)) if match else None
+
+
+def _text(node: ET.Element, path: str) -> str | None:
+    child = node.find(path)
+    return child.text.strip() if child is not None and child.text else None
+
+
+def parse_nvidia_smi_xml(document: str, captured_utc: str | None = None) -> dict[str, Any]:
+    """Parse the useful subset of one ``nvidia-smi -q -x`` document."""
+    try:
+        root = ET.fromstring(document.lstrip("\ufeff \t\r\n"))
+    except ET.ParseError as error:
+        raise ValidationError(f"invalid nvidia-smi XML: {error}") from error
+    gpus: list[dict[str, Any]] = []
+    for index, gpu in enumerate(root.findall("gpu")):
+        processes: list[dict[str, Any]] = []
+        for process in gpu.findall("./processes/process_info"):
+            pid_text = _text(process, "pid")
+            if not pid_text or not pid_text.isdigit():
+                continue
+            processes.append(
+                {
+                    "pid": int(pid_text),
+                    "name": _text(process, "process_name"),
+                    "type": _text(process, "type"),
+                    "used_memory_mib": _number(_text(process, "used_memory")),
+                }
+            )
+        gpus.append(
+            {
+                "index": index,
+                "uuid": _text(gpu, "uuid"),
+                "name": _text(gpu, "product_name"),
+                "temperature_c": _number(_text(gpu, "./temperature/gpu_temp")),
+                "power_draw_w": _number(_text(gpu, "./gpu_power_readings/instant_power_draw"))
+                or _number(_text(gpu, "./gpu_power_readings/average_power_draw"))
+                or _number(_text(gpu, "./gpu_power_readings/power_draw"))
+                or _number(_text(gpu, "./power_readings/power_draw")),
+                "power_limit_w": _number(_text(gpu, "./gpu_power_readings/current_power_limit"))
+                or _number(_text(gpu, "./power_readings/power_limit")),
+                "graphics_clock_mhz": _number(_text(gpu, "./clocks/graphics_clock")),
+                "sm_clock_mhz": _number(_text(gpu, "./clocks/sm_clock")),
+                "memory_clock_mhz": _number(_text(gpu, "./clocks/mem_clock")),
+                "memory_used_mib": _number(_text(gpu, "./fb_memory_usage/used")),
+                "memory_total_mib": _number(_text(gpu, "./fb_memory_usage/total")),
+                "processes": processes,
+            }
+        )
+    return {
+        "captured_utc": captured_utc or utc_now(),
+        "driver_version": _text(root, "driver_version"),
+        "cuda_version": _text(root, "cuda_version"),
+        "gpus": gpus,
+    }
+
+
+def _read_status(pid: int) -> dict[str, int] | None:
+    path = pathlib.Path("/proc") / str(pid) / "status"
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        return None
+    values: dict[str, int] = {}
+    for line in lines:
+        key, separator, remainder = line.partition(":")
+        if separator and key in PROC_STATUS_FIELDS:
+            parsed = _kib_value(remainder)
+            if parsed is not None:
+                values[f"{key}_kib"] = parsed
+    return values
+
+
+def _read_meminfo() -> dict[str, int]:
+    path = pathlib.Path("/proc/meminfo")
+    if not path.is_file():
+        return {}
+    values: dict[str, int] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        key, separator, remainder = line.partition(":")
+        if separator and key in MEMINFO_FIELDS:
+            parsed = _kib_value(remainder)
+            if parsed is not None:
+                values[f"{key}_kib"] = parsed
+    return values
+
+
+def _process_tree(root_pid: int) -> set[int]:
+    parents: dict[int, int] = {}
+    proc = pathlib.Path("/proc")
+    try:
+        entries = list(proc.iterdir())
+    except OSError:
+        return {root_pid}
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            fields = (entry / "stat").read_text(encoding="utf-8", errors="replace").split()
+            if len(fields) >= 4:
+                parents[int(entry.name)] = int(fields[3])
+        except (FileNotFoundError, PermissionError, ProcessLookupError, ValueError):
+            continue
+    descendants = {root_pid}
+    changed = True
+    while changed:
+        changed = False
+        for pid, parent in parents.items():
+            if parent in descendants and pid not in descendants:
+                descendants.add(pid)
+                changed = True
+    return descendants
+
+
+def _terminate_owned(process: subprocess.Popen[Any], timeout: float = 3.0) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        process.terminate()
+    try:
+        process.wait(timeout=timeout)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        process.kill()
+    process.wait(timeout=timeout)
+
+
+def _is_compute_process(process: dict[str, Any]) -> bool:
+    process_type = process.get("type")
+    if not process_type:
+        return True
+    return "C" in str(process_type).upper().split("+")
+
+
+class TelemetrySession:
+    """Own one persistent GPU sampler and one lightweight proc reader.
+
+    A session is constructed before the target starts, performs the GPU-clean
+    preflight, then attaches to the direct target PID.  ``stop`` is idempotent
+    and always reaps the sampler it started.
+    """
+
+    def __init__(
+        self,
+        resource: str,
+        *,
+        nvidia_smi: str = "nvidia-smi",
+        gpu_period_seconds: float = 1.0,
+        proc_period_seconds: float = 0.25,
+        first_sample_timeout: float = 12.0,
+    ) -> None:
+        if resource not in {"cpu", "gpu"}:
+            raise ValidationError(f"unknown telemetry resource {resource!r}")
+        self.resource = resource
+        self.nvidia_smi = nvidia_smi
+        self.gpu_period_seconds = gpu_period_seconds
+        self.proc_period_seconds = proc_period_seconds
+        self.first_sample_timeout = first_sample_timeout
+        self.gpu_samples: list[dict[str, Any]] = []
+        self.proc_samples: list[dict[str, Any]] = []
+        self.parse_errors: list[str] = []
+        self.sampler_stderr: list[str] = []
+        self.target_pid: int | None = None
+        self.sampler_pid: int | None = None
+        self._sampler: subprocess.Popen[str] | None = None
+        self._gpu_stream: Any | None = None
+        self._reader: threading.Thread | None = None
+        self._stderr_reader: threading.Thread | None = None
+        self._proc_reader: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._first_sample = threading.Event()
+        self._lock = threading.Lock()
+        self._started_utc: str | None = None
+        self._stopped_utc: str | None = None
+        self.clean_preflight: dict[str, Any] | None = None
+
+    def start(self) -> None:
+        if self._started_utc is not None:
+            raise ValidationError("telemetry session was already started")
+        self._started_utc = utc_now()
+        if self.resource == "cpu":
+            return
+        interval = max(1, int(round(self.gpu_period_seconds)))
+        master_fd, slave_fd = pty.openpty()
+        try:
+            self._sampler = subprocess.Popen(
+                [self.nvidia_smi, "-q", "-x", "-l", str(interval)],
+                stdout=slave_fd,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                start_new_session=True,
+            )
+        except OSError as error:
+            os.close(master_fd)
+            os.close(slave_fd)
+            raise ValidationError(f"cannot start persistent nvidia-smi sampler: {error}") from error
+        os.close(slave_fd)
+        self._gpu_stream = os.fdopen(
+            master_fd,
+            "r",
+            encoding="utf-8",
+            errors="replace",
+            newline=None,
+        )
+        self.sampler_pid = self._sampler.pid
+        self._reader = threading.Thread(target=self._read_gpu_stream, name="fperf-nvidia-smi", daemon=True)
+        self._stderr_reader = threading.Thread(
+            target=self._read_sampler_stderr,
+            name="fperf-nvidia-smi-stderr",
+            daemon=True,
+        )
+        self._reader.start()
+        self._stderr_reader.start()
+        if not self._first_sample.wait(self.first_sample_timeout):
+            self.stop()
+            stderr = "; ".join(self.sampler_stderr)
+            raise ValidationError(
+                "persistent nvidia-smi sampler produced no complete XML sample"
+                + (f": {stderr}" if stderr else "")
+            )
+        try:
+            self.assert_gpu_clean()
+        except Exception:
+            self.stop()
+            raise
+
+    def _read_gpu_stream(self) -> None:
+        assert self._sampler is not None and self._gpu_stream is not None
+        buffer = ""
+        closing = "</nvidia_smi_log>"
+        try:
+            while not self._stop.is_set():
+                chunk = self._gpu_stream.readline()
+                if chunk == "":
+                    break
+                buffer += chunk
+                while closing in buffer:
+                    document, buffer = buffer.split(closing, 1)
+                    document += closing
+                    try:
+                        sample = parse_nvidia_smi_xml(document)
+                    except ValidationError as error:
+                        self.parse_errors.append(str(error))
+                    else:
+                        with self._lock:
+                            self.gpu_samples.append(sample)
+                        self._first_sample.set()
+        except (OSError, ValueError) as error:
+            if not self._stop.is_set():
+                self.parse_errors.append(f"sampler reader: {type(error).__name__}: {error}")
+
+    def _read_sampler_stderr(self) -> None:
+        assert self._sampler is not None and self._sampler.stderr is not None
+        try:
+            for line in self._sampler.stderr:
+                self.sampler_stderr.append(line.rstrip())
+        except (OSError, ValueError) as error:
+            self.parse_errors.append(f"sampler stderr reader: {type(error).__name__}: {error}")
+
+    def assert_gpu_clean(self) -> None:
+        if self.resource != "gpu":
+            return
+        with self._lock:
+            sample = self.gpu_samples[-1] if self.gpu_samples else None
+        if sample is None:
+            raise ValidationError("no GPU sample exists for clean-process preflight")
+        all_processes = [
+            process
+            for gpu in sample["gpus"]
+            for process in gpu.get("processes", [])
+            if process.get("pid") not in {None, self.sampler_pid}
+        ]
+        processes = [process for process in all_processes if _is_compute_process(process)]
+        self.clean_preflight = {
+            "captured_utc": sample["captured_utc"],
+            "observed_compute_processes": processes,
+            "ambient_noncompute_processes": [
+                process for process in all_processes if not _is_compute_process(process)
+            ],
+            "clean": not processes,
+        }
+        if processes:
+            raise ValidationError(f"GPU clean-process preflight failed: {processes}")
+
+    def attach(self, pid: int) -> None:
+        if self._started_utc is None:
+            raise ValidationError("telemetry must start before attaching a target")
+        if self.target_pid is not None:
+            raise ValidationError("telemetry is already attached")
+        self.target_pid = int(pid)
+        self._sample_proc()
+        self._proc_reader = threading.Thread(target=self._read_proc_loop, name="fperf-proc", daemon=True)
+        self._proc_reader.start()
+
+    def _sample_proc(self) -> None:
+        if self.target_pid is None:
+            return
+        pids = _process_tree(self.target_pid)
+        processes: dict[str, Any] = {}
+        for pid in sorted(pids):
+            status = _read_status(pid)
+            if status is not None:
+                processes[str(pid)] = status
+        self.proc_samples.append(
+            {
+                "captured_utc": utc_now(),
+                "root_pid": self.target_pid,
+                "processes": processes,
+                "host_meminfo": _read_meminfo(),
+            }
+        )
+
+    def _read_proc_loop(self) -> None:
+        while not self._stop.wait(self.proc_period_seconds):
+            self._sample_proc()
+
+    def stop(self) -> dict[str, Any]:
+        if self._stopped_utc is None:
+            self._stopped_utc = utc_now()
+        self._stop.set()
+        if self._sampler is not None:
+            _terminate_owned(self._sampler)
+        if self._reader is not None:
+            self._reader.join(timeout=3.0)
+        if self._stderr_reader is not None:
+            self._stderr_reader.join(timeout=3.0)
+        if self._proc_reader is not None:
+            self._proc_reader.join(timeout=3.0)
+        if self._gpu_stream is not None:
+            self._gpu_stream.close()
+        if self._sampler is not None:
+            if self._sampler.stderr is not None:
+                self._sampler.stderr.close()
+        if self.target_pid is not None:
+            self._sample_proc()
+        return self.report()
+
+    def report(self) -> dict[str, Any]:
+        allowed = _process_tree(self.target_pid) if self.target_pid else set()
+        for sample in self.proc_samples:
+            allowed.update(int(pid) for pid in sample.get("processes", {}))
+        gpu_vram: list[float] = []
+        foreign: list[dict[str, Any]] = []
+        ambient: list[dict[str, Any]] = []
+        for sample in self.gpu_samples:
+            total = 0.0
+            observed_target = False
+            for gpu in sample.get("gpus", []):
+                for process in gpu.get("processes", []):
+                    pid = process.get("pid")
+                    used = process.get("used_memory_mib")
+                    if pid in allowed and used is not None:
+                        total += float(used)
+                        observed_target = True
+                    elif pid not in {None, self.sampler_pid}:
+                        observation = {
+                            "captured_utc": sample["captured_utc"],
+                            "gpu_uuid": gpu.get("uuid"),
+                            **process,
+                        }
+                        if _is_compute_process(process):
+                            foreign.append(observation)
+                        else:
+                            ambient.append(observation)
+            if observed_target:
+                gpu_vram.append(total)
+        rss_values: list[int] = []
+        hwm_values: list[int] = []
+        vm_lck_values: list[int] = []
+        vm_pin_values: list[int] = []
+        for sample in self.proc_samples:
+            statuses = sample.get("processes", {}).values()
+            rss_values.append(sum(int(item.get("VmRSS_kib", 0)) for item in statuses))
+            hwm_values.append(sum(int(item.get("VmHWM_kib", 0)) for item in statuses))
+            vm_lck_values.append(sum(int(item.get("VmLck_kib", 0)) for item in statuses))
+            vm_pin_values.append(sum(int(item.get("VmPin_kib", 0)) for item in statuses))
+        sampler_reaped = self._sampler is None or self._sampler.poll() is not None
+        sampler_path_text = shutil.which(self.nvidia_smi) or self.nvidia_smi
+        sampler_path = pathlib.Path(sampler_path_text).expanduser().resolve()
+        sampler_identity = {
+            "path": str(sampler_path),
+            "sha256": sha256_file(sampler_path) if sampler_path.is_file() else None,
+            "argv": [self.nvidia_smi, "-q", "-x", "-l", str(max(1, int(round(self.gpu_period_seconds))))],
+        }
+        return {
+            "started_utc": self._started_utc,
+            "stopped_utc": self._stopped_utc,
+            "resource": self.resource,
+            "sampler": {
+                "kind": "one persistent nvidia-smi -q -x -l process" if self.resource == "gpu" else None,
+                "pid": self.sampler_pid,
+                "period_seconds": self.gpu_period_seconds if self.resource == "gpu" else None,
+                "reaped": sampler_reaped,
+                "invocation_count": 1 if self.resource == "gpu" else 0,
+                "identity": sampler_identity if self.resource == "gpu" else None,
+                "stderr": self.sampler_stderr,
+            },
+            "clean_process_evidence": {
+                "preflight": self.clean_preflight,
+                "foreign_compute_process_observations": foreign,
+                "ambient_noncompute_process_observations": ambient,
+                "clean_throughout": bool(self.clean_preflight and self.clean_preflight["clean"] and not foreign)
+                if self.resource == "gpu"
+                else None,
+            },
+            "process_vram": {
+                "unit": "MiB",
+                "peak": max(gpu_vram) if gpu_vram else None,
+                "source": "nvidia-smi process used_memory",
+            },
+            "ordinary_host_memory": {
+                "unit": "KiB",
+                "peak_process_tree_vmrss": max(rss_values) if rss_values else None,
+                "peak_process_tree_vmhwm": max(hwm_values) if hwm_values else None,
+                "source": "/proc/PID/status plus /proc/meminfo",
+            },
+            "pinned_host_memory": {
+                "directly_measured": False,
+                "bytes": None,
+                "limitation": (
+                    "No direct per-process page-locked allocation counter was available. "
+                    "VmLck/VmPin observations are retained only as ordinary proc fields; pinned "
+                    "bytes are never inferred from VmLck, VmPin, or process VRAM."
+                ),
+                "observed_vm_lck_kib_peak_not_pinned_inference": max(vm_lck_values)
+                if vm_lck_values
+                else None,
+                "observed_vm_pin_kib_peak_not_pinned_inference": max(vm_pin_values)
+                if vm_pin_values
+                else None,
+            },
+            "gpu_samples": self.gpu_samples,
+            "proc_samples": self.proc_samples,
+            "parse_errors": self.parse_errors,
+        }
+
+    def __enter__(self) -> "TelemetrySession":
+        self.start()
+        return self
+
+    def __exit__(self, _type: Any, _value: Any, _traceback: Any) -> None:
+        self.stop()

--- a/scripts/test-feature-validation.py
+++ b/scripts/test-feature-validation.py
@@ -15,13 +15,14 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest import mock
 
 
 SCRIPTS = pathlib.Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS))
 
 from feature_validation import core, profiler, telemetry  # noqa: E402
-from feature_validation.runner import StudyRunner  # noqa: E402
+from feature_validation.runner import StudyRunner, _verify_spec_identity  # noqa: E402
 
 
 def file_sha256(path: pathlib.Path) -> str:
@@ -63,12 +64,16 @@ class FixtureMixin:
             text=True,
         ).stdout.strip()
         variant = {
-            "executable": str(self.executable),
-            "expected_sha256": file_sha256(self.executable),
             "source_root": str(self.repo),
             "expected_commit": head,
             "tree_policy": "clean",
-            "build": {"mode": "not_applicable", "reason": "test script"},
+            "executables": {
+                "default": {
+                    "path": str(self.executable),
+                    "expected_sha256": file_sha256(self.executable),
+                    "build": {"mode": "not_applicable", "reason": "test script"},
+                }
+            },
         }
         selection = {
             "workload": "decode",
@@ -82,7 +87,7 @@ class FixtureMixin:
             "candidate_args": [],
             "cli_schema": {"builtin": "none", "allow_positionals": False},
         }
-        return {
+        manifest = {
             "schema_version": 1,
             "study": {
                 "id": "unit-fixture",
@@ -228,6 +233,15 @@ class FixtureMixin:
                 },
             ],
         }
+        decision_policy = {
+            "acceptable_decisions": ["improvement", "equivalent"],
+            "regression": "fail",
+            "inconclusive_after_maximum": "unresolved_fail",
+        }
+        for stage in manifest["stages"]:
+            if stage["purpose"] != "exactness":
+                stage["decision_policy"] = copy.deepcopy(decision_policy)
+        return manifest
 
 
 class QuotingAndArityTest(unittest.TestCase):
@@ -243,6 +257,30 @@ class QuotingAndArityTest(unittest.TestCase):
     def test_zero_arity_option_rejects_equals_value(self) -> None:
         with self.assertRaisesRegex(core.ValidationError, "zero-arity"):
             core.validate_argv(["--no-kv-offload=1"])
+
+    def test_common_no_kv_offload_is_bare(self) -> None:
+        core.validate_argv(
+            ["--no-kv-offload"],
+            {"builtin": "llama", "allow_positionals": False},
+            "/tmp/llama-cli",
+        )
+        with self.assertRaisesRegex(core.ValidationError, "unexpected positional"):
+            core.validate_argv(
+                ["--no-kv-offload", "1"],
+                {"builtin": "llama", "allow_positionals": False},
+                "/tmp/llama-cli",
+            )
+
+    def test_bench_no_kv_offload_short_and_long_aliases_take_values(self) -> None:
+        schema = {"builtin": "llama", "allow_positionals": False}
+        core.validate_argv(["-nkvo", "1"], schema, "/tmp/llama-bench")
+        core.validate_argv(["--no-kv-offload", "0"], schema, "/tmp/llama-bench")
+        with self.assertRaisesRegex(core.ValidationError, "requires one value"):
+            core.validate_argv(["--no-kv-offload"], schema, "/tmp/llama-bench")
+
+    def test_llama_schema_rejects_unidentified_harness_without_override(self) -> None:
+        with self.assertRaisesRegex(core.ManifestError, "cannot identify target"):
+            core.validate_argv([], {"builtin": "llama"}, "/tmp/custom-harness")
 
     def test_value_option_accepts_negative_numeric_value(self) -> None:
         core.validate_argv(["--kv-gpu-layers", "-1"])
@@ -299,11 +337,36 @@ class ManifestAndScheduleTest(FixtureMixin, unittest.TestCase):
         with self.assertRaisesRegex(core.ManifestError, "prefill and short decode"):
             core.validate_manifest(manifest)
 
+    def test_performance_stage_requires_fail_closed_decision_policy(self) -> None:
+        manifest = self.manifest()
+        del manifest["stages"][1]["decision_policy"]
+        with self.assertRaisesRegex(core.ManifestError, "decision_policy"):
+            core.validate_manifest(manifest)
+
+    def test_graph_capable_profiler_requires_node_trace(self) -> None:
+        example_path = (
+            SCRIPTS.parent
+            / "examples"
+            / "feature-performance-validation"
+            / "manifest.example.json"
+        )
+        manifest = json.loads(example_path.read_text(encoding="utf-8"))
+        manifest["profiler"]["cuda_graph_trace"] = {
+            "applicability": "not_applicable",
+            "reason": "invalid for this graph-capable stage",
+        }
+        with self.assertRaisesRegex(core.ManifestError, "requires graph-node tracing"):
+            core.validate_manifest(manifest)
+
     def test_workload_setting_cannot_hide_in_candidate_delta(self) -> None:
         manifest = self.manifest()
         stage = next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")
         stage["command"]["candidate_args"] = ["-ub", "128"]
-        stage["command"]["cli_schema"] = {"builtin": "llama", "allow_positionals": False}
+        stage["command"]["cli_schema"] = {
+            "builtin": "none",
+            "allow_positionals": False,
+            "options": {"-ub": 1},
+        }
         stage["command"]["controlled_delta"] = {
             "reason": "invalid test delta",
             "baseline_args": [],
@@ -329,7 +392,9 @@ class ProvenanceTest(FixtureMixin, unittest.TestCase):
 
     def test_wrong_binary_hash_fails_closed(self) -> None:
         manifest = self.manifest()
-        manifest["variants"]["candidate"]["expected_sha256"] = "0" * 64
+        manifest["variants"]["candidate"]["executables"]["default"][
+            "expected_sha256"
+        ] = "0" * 64
         with self.assertRaisesRegex(core.ProvenanceError, "binary SHA-256 mismatch"):
             core.capture_provenance(manifest, "manifest-hash")
 
@@ -338,6 +403,36 @@ class ProvenanceTest(FixtureMixin, unittest.TestCase):
         (self.repo / "untracked").write_text("dirt", encoding="utf-8")
         with self.assertRaisesRegex(core.ProvenanceError, "dirty"):
             core.capture_provenance(manifest, "manifest-hash")
+
+    def test_fresh_runs_use_stat_guards_without_rehashing_large_identity_files(self) -> None:
+        provenance = core.capture_provenance(self.manifest(), "manifest-hash")
+        files, _ = core.provenance_identity_spec(
+            provenance, [("baseline", "default")]
+        )
+        self.assertTrue(files)
+        self.assertTrue(all(item["rehash"] is False for item in files))
+        with mock.patch.object(
+            core,
+            "sha256_file",
+            side_effect=AssertionError("per-run rehash should not occur"),
+        ):
+            _verify_spec_identity({"identity_files": files, "source_identities": []})
+
+    def test_stat_cache_rejects_same_size_change_with_restored_mtime(self) -> None:
+        provenance = core.capture_provenance(self.manifest(), "manifest-hash")
+        files, _ = core.provenance_identity_spec(
+            provenance, [("baseline", "default")]
+        )
+        original = self.executable.stat()
+        changed = self.executable.read_text(encoding="utf-8").replace("100.0", "999.9")
+        self.executable.write_text(changed, encoding="utf-8")
+        self.executable.chmod(0o755)
+        __import__("os").utime(
+            self.executable,
+            ns=(original.st_atime_ns, original.st_mtime_ns),
+        )
+        with self.assertRaisesRegex(core.ProvenanceError, "ctime_ns"):
+            _verify_spec_identity({"identity_files": files, "source_identities": []})
 
 
 class StatisticsTest(unittest.TestCase):
@@ -386,8 +481,54 @@ class StatisticsTest(unittest.TestCase):
         with self.assertRaisesRegex(core.ValidationError, "did not match"):
             core.extract_metric({"regex": r"metric=([0-9.]+)"}, "nothing", "")
 
+    def test_gate_outcome_distinguishes_completed_from_acceptable(self) -> None:
+        policy = {
+            "acceptable_decisions": ["improvement", "equivalent"],
+            "regression": "fail",
+            "inconclusive_after_maximum": "unresolved_fail",
+        }
+        self.assertEqual(core.performance_outcome("improvement", policy), "passed")
+        self.assertEqual(core.performance_outcome("regression", policy), "failed")
+        self.assertEqual(core.performance_outcome("inconclusive", policy), "unresolved")
+
 
 class ProfilerTest(unittest.TestCase):
+    def test_nsys_explicitly_requests_and_verifies_graph_node_trace(self) -> None:
+        config = {
+            "applicability": "required",
+            "granularity": "node",
+            "launch_origin": "host-only",
+        }
+        evidence = profiler.verify_nsys_graph_trace_capability(
+            config,
+            help_text="--cuda-graph-trace graph|node",
+            version_text="Nsight Systems 2026.1",
+        )
+        self.assertEqual(evidence["status"], "supported")
+        argv = profiler.nsys_discovery_argv(
+            ["/tmp/llama-bench", "-C", "0x7", "--cpu-strict", "1"],
+            pathlib.Path("/tmp/discovery"),
+            cuda_graph_trace=config,
+        )
+        self.assertIn("--cuda-graph-trace=node:host-only", argv)
+
+    def test_nsys_unsupported_or_missing_graph_nodes_fails_closed(self) -> None:
+        config = {
+            "applicability": "required",
+            "granularity": "node",
+            "launch_origin": "host-only",
+        }
+        with self.assertRaisesRegex(core.ValidationError, "does not advertise"):
+            profiler.verify_nsys_graph_trace_capability(
+                config,
+                help_text="old help without graph node tracing",
+                version_text="Nsight Systems old",
+            )
+        with self.assertRaisesRegex(core.ValidationError, "contains no nonzero"):
+            profiler.verify_graph_node_discovery(
+                {"graph_node_trace": {"launches_with_graph_node": 0}}, config
+            )
+
     def test_jsonl_discovery_and_one_filtered_ncu_plan(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)
@@ -432,7 +573,41 @@ class ProfilerTest(unittest.TestCase):
             self.assertEqual(plan["selected_count"], 2)
             self.assertEqual(plan["command"]["derivation"]["launch_skip"], 0)
             self.assertEqual(plan["command"]["derivation"]["launch_count"], 2)
+            self.assertIn("--graph-profiling", plan["command"]["direct_argv"])
             self.assertIn("flock /tmp/beellama-single-gpu.lock -c", plan["command"]["flock_command"])
+
+            csv_text = (
+                '==PROF== fake\n'
+                '"ID","Kernel Name","Grid Size","Block Size","Metric Name","Metric Value"\n'
+                '"1","kernel<q8>","1 2 3","32 1 1","gpu__time_duration.sum","10"\n'
+                '"2","kernel<q8>","1 2 3","32 1 1","gpu__time_duration.sum","11"\n'
+            )
+            parsed = profiler.parse_ncu_raw_csv(csv_text)
+            verified = profiler.verify_ncu_capture(plan, parsed)
+            self.assertEqual(verified["status"], "verified")
+            self.assertEqual(verified["observed_capture_count"], 2)
+
+    def test_ncu_report_count_mismatch_and_missing_columns_do_not_verify(self) -> None:
+        plan = {
+            "command": {
+                "derivation": {
+                    "kernel_name": "kernel",
+                    "launch_count": 2,
+                    "expected_shapes": [{"grid": [1, 1, 1], "block": [32, 1, 1]}],
+                }
+            }
+        }
+        one = profiler.parse_ncu_raw_csv(
+            '"ID","Kernel Name","Grid Size","Block Size"\n'
+            '"1","kernel","1 1 1","32 1 1"\n'
+        )
+        self.assertEqual(profiler.verify_ncu_capture(plan, one)["status"], "failed")
+        missing_shapes = profiler.parse_ncu_raw_csv(
+            '"ID","Kernel Name"\n"1","kernel"\n"2","kernel"\n'
+        )
+        self.assertEqual(
+            profiler.verify_ncu_capture(plan, missing_shapes)["status"], "unverifiable"
+        )
 
     def test_fake_nsys_sqlite_parses_names_shapes_counts_and_indices(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -567,6 +742,58 @@ class TelemetryTest(unittest.TestCase):
 
 
 class RunnerTest(FixtureMixin, unittest.TestCase):
+    def test_final_gate_execution_is_not_acceptance_without_a_pass(self) -> None:
+        manifest_path = self.root / "gate-status.json"
+        manifest_path.write_text(json.dumps(self.manifest()), encoding="utf-8")
+        for gate_status, expected in (
+            ("failed", "acceptance_failed"),
+            ("unresolved", "acceptance_unresolved"),
+        ):
+            runner = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+            runner.state = {
+                "runs": {},
+                "stages": {
+                    "long": {
+                        "purpose": "long_context_acceptance",
+                        "execution_status": "completed",
+                        "status": gate_status,
+                    }
+                }
+            }
+            summary = runner._summary("acceptance", None)
+            self.assertEqual(summary["status"], expected)
+            self.assertTrue(summary["final_long_context_acceptance_executed"])
+            self.assertFalse(summary["final_long_context_acceptance_passed"])
+
+    def test_final_gate_regression_and_inconclusive_statistics_fail_closed(self) -> None:
+        manifest = self.manifest()
+        manifest_path = self.root / "statistical-gate.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        stage = manifest["stages"][-1]
+        scenarios = {
+            "failed": [90, 90, 90, 90, 90],
+            "unresolved": [98, 102, 100, 99, 101],
+        }
+        for expected_status, candidates in scenarios.items():
+            runner = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+
+            def fake_execute(_stage: dict, scheduled: dict, **_kwargs: object) -> dict:
+                value = (
+                    candidates[scheduled["pair"] - 1]
+                    if scheduled["variant"] == "candidate"
+                    else 100
+                )
+                return {"run_id": scheduled["run_id"], "metric_value": value}
+
+            with mock.patch.object(runner, "_execute", side_effect=fake_execute):
+                report = runner._run_performance(stage, retry_failed=False)
+            self.assertEqual(report["execution_status"], "completed")
+            self.assertEqual(report["status"], expected_status)
+            runner.state = {"stages": {"long": report}, "runs": {}}
+            summary = runner._summary("acceptance", None)
+            self.assertNotEqual(summary["status"], "acceptance_complete")
+            self.assertFalse(summary["final_long_context_acceptance_passed"])
+
     def test_resume_rejects_changed_binary_provenance(self) -> None:
         manifest = self.manifest()
         manifest_path = self.root / "resume-provenance.json"
@@ -586,6 +813,10 @@ class RunnerTest(FixtureMixin, unittest.TestCase):
         first = StudyRunner(manifest_path, tool_script)
         summary = first.run(through="early", resume=False, retry_failed=False)
         self.assertEqual(summary["status"], "early_screen_only_not_production_or_final_acceptance")
+        self.assertEqual(summary["early_timing"]["mode"], "fresh")
+        self.assertEqual(summary["early_timing"]["run_count"], 32)
+        self.assertGreater(summary["early_timing"]["target_process_seconds"], 0)
+        self.assertGreater(summary["early_timing"]["identity_verification_seconds"], 0)
         state = json.loads(first.state_path.read_text(encoding="utf-8"))
         attempts = [attempt for values in state["runs"].values() for attempt in values]
         self.assertEqual(len(attempts), 32)
@@ -639,12 +870,15 @@ class RunnerTest(FixtureMixin, unittest.TestCase):
         manifest_path = self.root / "adaptive.json"
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         runner = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
-        runner.run(through="early", resume=False, retry_failed=False)
+        with self.assertRaisesRegex(core.ValidationError, "not acceptable: unresolved"):
+            runner.run(through="early", resume=False, retry_failed=False)
         state = json.loads(runner.state_path.read_text(encoding="utf-8"))
         report = state["stages"]["kernel"]
         self.assertTrue(report["adaptive_repetition"]["extended"])
         self.assertEqual(report["statistics"]["pair_count"], 5)
         self.assertEqual(len(report["statistics"]["raw_pairs"]), 5)
+        self.assertEqual(report["execution_status"], "completed")
+        self.assertEqual(report["status"], "unresolved")
 
     def test_failed_attempt_is_preserved_and_retry_requires_opt_in(self) -> None:
         flag = self.root / "allow-run"

--- a/scripts/test-feature-validation.py
+++ b/scripts/test-feature-validation.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+
+"""CPU-only tests for the feature/performance validation toolkit."""
+
+from __future__ import annotations
+
+import copy
+import contextlib
+import hashlib
+import json
+import pathlib
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+SCRIPTS = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+from feature_validation import core, profiler, telemetry  # noqa: E402
+from feature_validation.runner import StudyRunner  # noqa: E402
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class FixtureMixin:
+    temporary: tempfile.TemporaryDirectory[str]
+    root: pathlib.Path
+    repo: pathlib.Path
+    executable: pathlib.Path
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary.name)
+        self.repo = self.root / "source tree"
+        self.repo.mkdir()
+        self.executable = self.repo / "fake bench"
+        self.executable.write_text(
+            "#!/usr/bin/env python3\nprint('metric=100.0')\n",
+            encoding="utf-8",
+        )
+        self.executable.chmod(0o755)
+        subprocess.run(["git", "init", "-q"], cwd=self.repo, check=True)
+        subprocess.run(["git", "config", "user.email", "tests@example.invalid"], cwd=self.repo, check=True)
+        subprocess.run(["git", "config", "user.name", "Feature Tests"], cwd=self.repo, check=True)
+        subprocess.run(["git", "add", "."], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=self.repo, check=True)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def manifest(self) -> dict:
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        variant = {
+            "executable": str(self.executable),
+            "expected_sha256": file_sha256(self.executable),
+            "source_root": str(self.repo),
+            "expected_commit": head,
+            "tree_policy": "clean",
+            "build": {"mode": "not_applicable", "reason": "test script"},
+        }
+        selection = {
+            "workload": "decode",
+            "tensor_layout": {"k": "q8_0", "v": "q8_0", "query_width": 1},
+            "backend_capabilities": ["direct_standard_quant_attention"],
+            "execution_mode": "direct_process",
+        }
+        command = {
+            "common_args": [],
+            "baseline_args": [],
+            "candidate_args": [],
+            "cli_schema": {"builtin": "none", "allow_positionals": False},
+        }
+        return {
+            "schema_version": 1,
+            "study": {
+                "id": "unit-fixture",
+                "early_decision_target_seconds": {"minimum": 30, "maximum": 90},
+            },
+            "artifact_root": str(self.root / "artifacts"),
+            "variants": {"baseline": copy.deepcopy(variant), "candidate": copy.deepcopy(variant)},
+            "inputs": [],
+            "repetition_policy": {
+                "minimum_pairs": 3,
+                "maximum_pairs": 5,
+                "order": ["AB", "BA", "AB", "BA", "AB"],
+                "confidence_level": 0.95,
+                "extension_rule": {
+                    "kind": "extend_only_if_inconclusive",
+                    "thresholds": {
+                        "improvement_percent": 1.0,
+                        "regression_percent": 1.0,
+                        "equivalence_percent": 0.5,
+                    },
+                },
+            },
+            "stages": [
+                {
+                    "id": "exactness",
+                    "purpose": "exactness",
+                    "resource": "cpu",
+                    "timeout_seconds": 5,
+                    "mandatory": True,
+                    "progress": "fake process exits immediately",
+                    "selection": {**copy.deepcopy(selection), "workload": "exactness"},
+                    "command": copy.deepcopy(command),
+                    "comparison": {"mode": "stdout_sha256"},
+                },
+                {
+                    "id": "prefill-smoke",
+                    "purpose": "smoke",
+                    "resource": "cpu",
+                    "timeout_seconds": 5,
+                    "mandatory": True,
+                    "progress": "one line per fake process",
+                    "selection": {
+                        **copy.deepcopy(selection),
+                        "workload": "prefill",
+                        "duration_class": "short",
+                    },
+                    "command": copy.deepcopy(command),
+                    "metric": {"regex": r"metric=([0-9.]+)", "direction": "higher"},
+                },
+                {
+                    "id": "decode-smoke",
+                    "purpose": "smoke",
+                    "resource": "cpu",
+                    "timeout_seconds": 5,
+                    "mandatory": True,
+                    "progress": "one line per fake process",
+                    "selection": {
+                        **copy.deepcopy(selection),
+                        "duration_class": "short",
+                        "cuda_graph_replay": {
+                            "applicability": "not_applicable",
+                            "reason": "CPU-only fake fixture",
+                        },
+                    },
+                    "command": copy.deepcopy(command),
+                    "metric": {"regex": r"metric=([0-9.]+)", "direction": "higher"},
+                },
+                {
+                    "id": "kernel",
+                    "purpose": "kernel_screen",
+                    "resource": "cpu",
+                    "timeout_seconds": 5,
+                    "mandatory": True,
+                    "progress": "one line per fake process",
+                    "selection": {
+                        **copy.deepcopy(selection),
+                        "workload": "prefill",
+                        "execution_mode": "direct_command",
+                    },
+                    "command": copy.deepcopy(command),
+                    "screens": [
+                        {
+                            "id": "low",
+                            "span_class": "low",
+                            "span_tokens": 64,
+                            "ubatch_occurrences": 1,
+                            "args": [],
+                            "weight": 1,
+                        },
+                        {
+                            "id": "mid",
+                            "span_class": "mid",
+                            "span_tokens": 256,
+                            "ubatch_occurrences": 2,
+                            "args": [],
+                            "weight": 2,
+                        },
+                        {
+                            "id": "high",
+                            "span_class": "high",
+                            "span_tokens": 512,
+                            "ubatch_occurrences": 1,
+                            "args": [],
+                            "weight": 1,
+                        },
+                    ],
+                    "aggregation": {
+                        "mode": "weighted_harmonic",
+                        "weight_source": "real_ubatch_geometry",
+                    },
+                    "metric": {"regex": r"metric=([0-9.]+)", "direction": "higher"},
+                },
+                {
+                    "id": "production",
+                    "purpose": "production_confirmation",
+                    "resource": "cpu",
+                    "timeout_seconds": 5,
+                    "mandatory": True,
+                    "progress": "one line per fake process",
+                    "selection": {
+                        **copy.deepcopy(selection),
+                        "execution_mode": "production_binary",
+                        "context_depth_tokens": 4096,
+                    },
+                    "command": copy.deepcopy(command),
+                    "metric": {"regex": r"metric=([0-9.]+)", "direction": "higher"},
+                },
+                {
+                    "id": "long",
+                    "purpose": "long_context_acceptance",
+                    "resource": "cpu",
+                    "timeout_seconds": 5,
+                    "mandatory": True,
+                    "progress": "one line per fake process",
+                    "selection": {
+                        **copy.deepcopy(selection),
+                        "execution_mode": "production_binary",
+                        "context_depth_tokens": 32768,
+                        "acceptance_class": "long_context",
+                    },
+                    "command": copy.deepcopy(command),
+                    "metric": {"regex": r"metric=([0-9.]+)", "direction": "higher"},
+                },
+            ],
+        }
+
+
+class QuotingAndArityTest(unittest.TestCase):
+    def test_safe_quoting_round_trips_spaces_quotes_and_metacharacters(self) -> None:
+        argv = ["/tmp/a b", "single'quote", 'double"quote', "$(do-not-run)", "semi;colon"]
+        rendered = core.quote_argv(argv)
+        self.assertEqual(shlex.split(rendered), argv)
+
+    def test_zero_arity_option_rejects_separate_value(self) -> None:
+        with self.assertRaisesRegex(core.ValidationError, "unexpected positional"):
+            core.validate_argv(["--no-kv-offload", "1"])
+
+    def test_zero_arity_option_rejects_equals_value(self) -> None:
+        with self.assertRaisesRegex(core.ValidationError, "zero-arity"):
+            core.validate_argv(["--no-kv-offload=1"])
+
+    def test_value_option_accepts_negative_numeric_value(self) -> None:
+        core.validate_argv(["--kv-gpu-layers", "-1"])
+
+    def test_taskset_is_rejected_anywhere(self) -> None:
+        with self.assertRaisesRegex(core.ValidationError, "taskset"):
+            core.reject_forbidden_tokens(["ncu", "/usr/bin/taskset", "llama-bench"])
+
+    def test_profiler_wrapper_target_is_rejected(self) -> None:
+        with self.assertRaisesRegex(core.ValidationError, "wrapper"):
+            core.validate_direct_target(pathlib.Path("/usr/bin/bash"), profiler=True)
+
+
+class ManifestAndScheduleTest(FixtureMixin, unittest.TestCase):
+    def test_checked_in_example_is_structurally_valid_and_schema_is_json(self) -> None:
+        schema_path = SCRIPTS / "feature_validation" / "manifest.schema.json"
+        example_path = SCRIPTS.parent / "examples" / "feature-performance-validation" / "manifest.example.json"
+        self.assertEqual(json.loads(schema_path.read_text(encoding="utf-8"))["$schema"], "https://json-schema.org/draft/2020-12/schema")
+        core.validate_manifest(json.loads(example_path.read_text(encoding="utf-8")))
+
+    def test_valid_manifest_and_balanced_schedule(self) -> None:
+        manifest = self.manifest()
+        core.validate_manifest(manifest)
+        stage = next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")
+        schedule = core.build_schedule(manifest, stage)
+        orientations = []
+        for pair in range(1, 6):
+            pair_runs = [item for item in schedule if item["pair"] == pair]
+            orientations.append(pair_runs[0]["orientation"])
+            self.assertEqual(len({item["variant"] for item in pair_runs}), 2)
+        self.assertEqual(orientations, ["AB", "BA", "AB", "BA", "AB"])
+
+    def test_architecture_selector_is_rejected(self) -> None:
+        manifest = self.manifest()
+        manifest["stages"][1]["selection"]["architecture"] = "forbidden"
+        with self.assertRaisesRegex(core.ManifestError, "forbidden"):
+            core.validate_manifest(manifest)
+
+    def test_kernel_screen_requires_low_mid_high(self) -> None:
+        manifest = self.manifest()
+        next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")["screens"].pop()
+        with self.assertRaisesRegex(core.ManifestError, "low, mid, and high"):
+            core.validate_manifest(manifest)
+
+    def test_long_context_gate_must_be_final_and_mandatory(self) -> None:
+        manifest = self.manifest()
+        manifest["stages"][-1]["mandatory"] = False
+        with self.assertRaisesRegex(core.ManifestError, "mandatory"):
+            core.validate_manifest(manifest)
+
+    def test_short_prefill_and_decode_smokes_are_both_required(self) -> None:
+        manifest = self.manifest()
+        manifest["stages"] = [stage for stage in manifest["stages"] if stage["id"] != "decode-smoke"]
+        with self.assertRaisesRegex(core.ManifestError, "prefill and short decode"):
+            core.validate_manifest(manifest)
+
+    def test_workload_setting_cannot_hide_in_candidate_delta(self) -> None:
+        manifest = self.manifest()
+        stage = next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")
+        stage["command"]["candidate_args"] = ["-ub", "128"]
+        stage["command"]["cli_schema"] = {"builtin": "llama", "allow_positionals": False}
+        stage["command"]["controlled_delta"] = {
+            "reason": "invalid test delta",
+            "baseline_args": [],
+            "candidate_args": ["-ub", "128"],
+            "baseline_environment": {},
+            "candidate_environment": {},
+            "allowed_options": ["-ub"],
+            "allowed_environment": [],
+        }
+        with self.assertRaisesRegex(core.ManifestError, "immutable"):
+            core.validate_manifest(manifest)
+
+
+class ProvenanceTest(FixtureMixin, unittest.TestCase):
+    def test_clean_provenance_succeeds(self) -> None:
+        manifest = self.manifest()
+        provenance = core.capture_provenance(manifest, "manifest-hash")
+        self.assertEqual(
+            provenance["variants"]["baseline"]["executables"]["default"]["binary"]["sha256"],
+            file_sha256(self.executable),
+        )
+        self.assertFalse(provenance["variants"]["baseline"]["source"]["status"])
+
+    def test_wrong_binary_hash_fails_closed(self) -> None:
+        manifest = self.manifest()
+        manifest["variants"]["candidate"]["expected_sha256"] = "0" * 64
+        with self.assertRaisesRegex(core.ProvenanceError, "binary SHA-256 mismatch"):
+            core.capture_provenance(manifest, "manifest-hash")
+
+    def test_dirty_tree_fails_closed(self) -> None:
+        manifest = self.manifest()
+        (self.repo / "untracked").write_text("dirt", encoding="utf-8")
+        with self.assertRaisesRegex(core.ProvenanceError, "dirty"):
+            core.capture_provenance(manifest, "manifest-hash")
+
+
+class StatisticsTest(unittest.TestCase):
+    def test_paired_log_report_keeps_all_raw_samples(self) -> None:
+        pairs = [
+            {"pair": 1, "orientation": "AB", "baseline": 100.0, "candidate": 102.0},
+            {"pair": 2, "orientation": "BA", "baseline": 101.0, "candidate": 103.0},
+            {"pair": 3, "orientation": "AB", "baseline": 99.0, "candidate": 101.0},
+        ]
+        report = core.paired_log_report(
+            pairs,
+            direction="higher",
+            thresholds={
+                "improvement_percent": 1.0,
+                "regression_percent": 1.0,
+                "equivalence_percent": 0.5,
+            },
+        )
+        self.assertEqual(report["pair_count"], 3)
+        self.assertEqual(len(report["raw_pairs"]), 3)
+        self.assertGreater(report["percent_change"], 1.9)
+        self.assertEqual(report["decision"], "improvement")
+
+    def test_inconclusive_result_is_explicit(self) -> None:
+        pairs = [
+            {"pair": 1, "orientation": "AB", "baseline": 100.0, "candidate": 98.0},
+            {"pair": 2, "orientation": "BA", "baseline": 100.0, "candidate": 102.0},
+            {"pair": 3, "orientation": "AB", "baseline": 100.0, "candidate": 100.0},
+        ]
+        report = core.paired_log_report(
+            pairs,
+            direction="higher",
+            thresholds={
+                "improvement_percent": 1.0,
+                "regression_percent": 1.0,
+                "equivalence_percent": 0.5,
+            },
+        )
+        self.assertEqual(report["decision"], "inconclusive")
+
+    def test_weighted_harmonic_matches_prefill_throughput_geometry(self) -> None:
+        value = core.aggregate_screen_values([(100.0, 1.0), (200.0, 3.0)], "weighted_harmonic")
+        self.assertAlmostEqual(value, 160.0)
+
+    def test_metric_parser_fails_when_no_sample_exists(self) -> None:
+        with self.assertRaisesRegex(core.ValidationError, "did not match"):
+            core.extract_metric({"regex": r"metric=([0-9.]+)"}, "nothing", "")
+
+
+class ProfilerTest(unittest.TestCase):
+    def test_jsonl_discovery_and_one_filtered_ncu_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            discovery_path = root / "fake.jsonl"
+            discovery_path.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "name": "kernel<q8>",
+                                "start_ns": 10,
+                                "end_ns": 20,
+                                "grid": [1, 2, 3],
+                                "block": [32, 1, 1],
+                                "graph_node_id": 7,
+                            }
+                        ),
+                        json.dumps({"name": "other", "start_ns": 30, "end_ns": 40}),
+                        json.dumps(
+                            {
+                                "name": "kernel<q8>",
+                                "start_ns": 50,
+                                "end_ns": 60,
+                                "grid": [1, 2, 3],
+                                "block": [32, 1, 1],
+                                "graph_node_id": 8,
+                            }
+                        ),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            discovery = profiler.parse_discovery(discovery_path)
+            plan = profiler.build_ncu_plan(
+                discovery,
+                {"kernel_regex": r"kernel<q8>", "graph_only": True},
+                ["/tmp/llama-bench", "-C", "0x7", "--cpu-strict", "1"],
+                root / "ncu",
+            )
+            self.assertEqual(discovery["launch_count"], 3)
+            self.assertEqual(plan["selected_count"], 2)
+            self.assertEqual(plan["command"]["derivation"]["launch_skip"], 0)
+            self.assertEqual(plan["command"]["derivation"]["launch_count"], 2)
+            self.assertIn("flock /tmp/beellama-single-gpu.lock -c", plan["command"]["flock_command"])
+
+    def test_fake_nsys_sqlite_parses_names_shapes_counts_and_indices(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = pathlib.Path(temporary) / "fake.sqlite"
+            import sqlite3
+
+            with contextlib.closing(sqlite3.connect(path)) as connection:
+                connection.execute("CREATE TABLE StringIds (id INTEGER, value TEXT)")
+                connection.execute("INSERT INTO StringIds VALUES (1, 'graph_kernel')")
+                connection.execute(
+                    "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL ("
+                    "start INTEGER, end INTEGER, demangledName INTEGER, graphNodeId INTEGER, "
+                    "gridX INTEGER, gridY INTEGER, gridZ INTEGER, blockX INTEGER, blockY INTEGER, blockZ INTEGER)"
+                )
+                connection.execute(
+                    "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (10, 20, 1, 9, 3, 2, 1, 32, 1, 1)"
+                )
+                connection.commit()
+            parsed = profiler.parse_discovery(path)
+            self.assertEqual(parsed["launches"][0]["name"], "graph_kernel")
+            self.assertEqual(parsed["launches"][0]["grid"], [3, 2, 1])
+            self.assertEqual(parsed["groups"][0]["count"], 1)
+            self.assertEqual(parsed["groups"][0]["launch_indices"], [1])
+
+    def test_profiler_requires_native_affinity(self) -> None:
+        with self.assertRaisesRegex(core.ValidationError, "native"):
+            profiler.validate_native_affinity(["/tmp/llama-bench", "--progress"])
+
+    def test_non_bench_profiler_target_requires_native_ranges(self) -> None:
+        with self.assertRaisesRegex(core.ValidationError, "native"):
+            profiler.validate_native_affinity(
+                ["/tmp/llama-cli", "-C", "0x7", "--cpu-strict", "1"]
+            )
+
+    def test_noncontiguous_selected_occurrences_fail_closed(self) -> None:
+        discovery = {
+            "source": "fake",
+            "launches": [
+                {"name": "kernel", "name_occurrence": 1, "launch_index": 1, "graph_node_id": 1},
+                {"name": "kernel", "name_occurrence": 2, "launch_index": 2, "graph_node_id": None},
+                {"name": "kernel", "name_occurrence": 3, "launch_index": 3, "graph_node_id": 3},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temporary, self.assertRaisesRegex(
+            core.ValidationError, "not contiguous"
+        ):
+            profiler.build_ncu_plan(
+                discovery,
+                {"kernel_regex": "kernel", "graph_only": True},
+                ["/tmp/llama-bench", "-C", "0x7", "--cpu-strict", "1"],
+                pathlib.Path(temporary),
+            )
+
+
+class TelemetryTest(unittest.TestCase):
+    def test_persistent_sampler_parses_gpu_state_and_is_reaped(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            fake = root / "fake-nvidia-smi"
+            fake.write_text(
+                "#!/usr/bin/env python3\n"
+                "import sys, time\n"
+                "if '--version' in sys.argv:\n"
+                "    print('fake nvidia-smi 1.0')\n"
+                "    raise SystemExit\n"
+                "doc = '''<nvidia_smi_log><driver_version>test-driver</driver_version>"
+                "<cuda_version>test-cuda</cuda_version><gpu><product_name>fake-gpu</product_name>"
+                "<uuid>GPU-FAKE</uuid><fb_memory_usage><total>100 MiB</total><used>0 MiB</used>"
+                "</fb_memory_usage><temperature><gpu_temp>42 C</gpu_temp></temperature>"
+                "<gpu_power_readings><power_draw>50 W</power_draw><current_power_limit>100 W</current_power_limit>"
+                "</gpu_power_readings><clocks><graphics_clock>1000 MHz</graphics_clock>"
+                "<sm_clock>900 MHz</sm_clock><mem_clock>800 MHz</mem_clock></clocks>"
+                "<processes><process_info><pid>42</pid><type>G</type>"
+                "<process_name>display</process_name><used_memory>4 MiB</used_memory>"
+                "</process_info></processes></gpu></nvidia_smi_log>'''\n"
+                "while True:\n"
+                "    print(doc, flush=True)\n"
+                "    time.sleep(0.1)\n",
+                encoding="utf-8",
+            )
+            fake.chmod(0o755)
+            target = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(.35)"])
+            session = telemetry.TelemetrySession(
+                "gpu",
+                nvidia_smi=str(fake),
+                proc_period_seconds=0.05,
+                first_sample_timeout=2.0,
+            )
+            try:
+                session.start()
+                sampler_pid = session.sampler_pid
+                session.attach(target.pid)
+                target.wait(timeout=2.0)
+                report = session.stop()
+            finally:
+                if target.poll() is None:
+                    target.terminate()
+                    target.wait()
+            self.assertTrue(report["sampler"]["reaped"])
+            self.assertEqual(report["sampler"]["invocation_count"], 1)
+            self.assertEqual(report["gpu_samples"][0]["gpus"][0]["temperature_c"], 42.0)
+            self.assertTrue(report["clean_process_evidence"]["clean_throughout"])
+            self.assertTrue(report["clean_process_evidence"]["ambient_noncompute_process_observations"])
+            self.assertFalse(report["pinned_host_memory"]["directly_measured"])
+            self.assertIn("never inferred", report["pinned_host_memory"]["limitation"])
+            assert sampler_pid is not None
+            with self.assertRaises(ProcessLookupError):
+                __import__("os").kill(sampler_pid, 0)
+
+    def test_contaminated_preflight_fails_and_reaps_sampler(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            fake = pathlib.Path(temporary) / "fake-nvidia-smi"
+            fake.write_text(
+                "#!/usr/bin/env python3\n"
+                "import time\n"
+                "doc = '''<nvidia_smi_log><gpu><uuid>GPU-FAKE</uuid><processes><process_info>"
+                "<pid>123</pid><process_name>foreign</process_name><used_memory>5 MiB</used_memory>"
+                "</process_info></processes></gpu></nvidia_smi_log>'''\n"
+                "while True:\n"
+                "    print(doc, flush=True)\n"
+                "    time.sleep(.1)\n",
+                encoding="utf-8",
+            )
+            fake.chmod(0o755)
+            session = telemetry.TelemetrySession("gpu", nvidia_smi=str(fake), first_sample_timeout=2.0)
+            with self.assertRaisesRegex(core.ValidationError, "preflight"):
+                session.start()
+            self.assertTrue(session.report()["sampler"]["reaped"])
+            assert session.sampler_pid is not None
+            with self.assertRaises(ProcessLookupError):
+                __import__("os").kill(session.sampler_pid, 0)
+
+
+class RunnerTest(FixtureMixin, unittest.TestCase):
+    def test_resume_rejects_changed_binary_provenance(self) -> None:
+        manifest = self.manifest()
+        manifest_path = self.root / "resume-provenance.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        first = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        first.prepare(resume=False)
+        self.executable.write_text("#!/usr/bin/env python3\nprint('changed')\n", encoding="utf-8")
+        second = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        with self.assertRaisesRegex(core.ProvenanceError, "dirty|binary SHA-256 mismatch"):
+            second.prepare(resume=True)
+
+    def test_clean_balanced_processes_and_resume(self) -> None:
+        manifest = self.manifest()
+        manifest_path = self.root / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        tool_script = SCRIPTS / "feature-performance-validation.py"
+        first = StudyRunner(manifest_path, tool_script)
+        summary = first.run(through="early", resume=False, retry_failed=False)
+        self.assertEqual(summary["status"], "early_screen_only_not_production_or_final_acceptance")
+        state = json.loads(first.state_path.read_text(encoding="utf-8"))
+        attempts = [attempt for values in state["runs"].values() for attempt in values]
+        self.assertEqual(len(attempts), 32)
+        self.assertEqual(len({attempt["pid"] for attempt in attempts}), 32)
+        orientations = {
+            attempt["schedule"]["pair"]: attempt["schedule"]["orientation"]
+            for attempt in attempts
+            if attempt["schedule"]["pair"] <= 3 and attempt["schedule"]["screen"] == "low"
+        }
+        self.assertEqual(orientations, {1: "AB", 2: "BA", 3: "AB"})
+        second = StudyRunner(manifest_path, tool_script)
+        second.run(through="early", resume=True, retry_failed=False)
+        resumed = json.loads(second.state_path.read_text(encoding="utf-8"))
+        self.assertTrue(all(len(values) == 1 for values in resumed["runs"].values()))
+
+    def test_inconclusive_three_pairs_extends_to_five_only(self) -> None:
+        self.executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            "args = dict(zip(sys.argv[1::2], sys.argv[2::2]))\n"
+            "pair = int(args.get('--pair', 1))\n"
+            "variant = args.get('--variant', 'same')\n"
+            "candidate = [0, 98, 102, 100, 99, 101][pair]\n"
+            "print(f\"metric={candidate if variant == 'candidate' else 100}\")\n",
+            encoding="utf-8",
+        )
+        self.executable.chmod(0o755)
+        subprocess.run(["git", "add", "."], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "adaptive fixture"], cwd=self.repo, check=True)
+        manifest = self.manifest()
+        stage = next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")
+        stage["command"] = {
+            "common_args": ["--pair", "{pair}"],
+            "baseline_args": ["--variant", "baseline"],
+            "candidate_args": ["--variant", "candidate"],
+            "cli_schema": {
+                "builtin": "none",
+                "allow_positionals": False,
+                "options": {"--pair": 1, "--variant": 1},
+            },
+            "controlled_delta": {
+                "reason": "fake candidate values exercise the preregistered extension rule",
+                "baseline_args": ["--variant", "baseline"],
+                "candidate_args": ["--variant", "candidate"],
+                "baseline_environment": {},
+                "candidate_environment": {},
+                "allowed_options": ["--variant"],
+                "allowed_environment": [],
+            },
+        }
+        manifest_path = self.root / "adaptive.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        runner = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        runner.run(through="early", resume=False, retry_failed=False)
+        state = json.loads(runner.state_path.read_text(encoding="utf-8"))
+        report = state["stages"]["kernel"]
+        self.assertTrue(report["adaptive_repetition"]["extended"])
+        self.assertEqual(report["statistics"]["pair_count"], 5)
+        self.assertEqual(len(report["statistics"]["raw_pairs"]), 5)
+
+    def test_failed_attempt_is_preserved_and_retry_requires_opt_in(self) -> None:
+        flag = self.root / "allow-run"
+        self.executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os, sys\n"
+            "flag = os.environ['TEST_ALLOW_FLAG']\n"
+            "if not os.path.exists(flag):\n"
+            "    print('not yet', file=sys.stderr)\n"
+            "    raise SystemExit(7)\n"
+            "print('metric=100.0')\n",
+            encoding="utf-8",
+        )
+        self.executable.chmod(0o755)
+        subprocess.run(["git", "add", "."], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "retry fixture"], cwd=self.repo, check=True)
+        manifest = self.manifest()
+        manifest["environment"] = {"TEST_ALLOW_FLAG": str(flag)}
+        manifest_path = self.root / "retry.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        first = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        with self.assertRaisesRegex(core.ValidationError, "preserved"):
+            first.run(through="early", resume=False, retry_failed=False)
+        second = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        with self.assertRaisesRegex(core.ValidationError, "--retry-failed"):
+            second.run(through="early", resume=True, retry_failed=False)
+        flag.write_text("go", encoding="utf-8")
+        third = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        third.run(through="early", resume=True, retry_failed=True)
+        state = json.loads(third.state_path.read_text(encoding="utf-8"))
+        first_run = state["runs"]["exactness--pair-01-default-01-baseline"]
+        self.assertEqual([item["status"] for item in first_run], ["failed", "success"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-feature-validation.py
+++ b/scripts/test-feature-validation.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import copy
 import contextlib
 import hashlib
+import importlib.util
+import io
 import json
 import pathlib
 import shlex
@@ -23,6 +25,14 @@ sys.path.insert(0, str(SCRIPTS))
 
 from feature_validation import core, profiler, telemetry  # noqa: E402
 from feature_validation.runner import StudyRunner, _verify_spec_identity  # noqa: E402
+
+
+CLI_SPEC = importlib.util.spec_from_file_location(
+    "feature_performance_validation_cli", SCRIPTS / "feature-performance-validation.py"
+)
+assert CLI_SPEC is not None and CLI_SPEC.loader is not None
+CLI = importlib.util.module_from_spec(CLI_SPEC)
+CLI_SPEC.loader.exec_module(CLI)
 
 
 def file_sha256(path: pathlib.Path) -> str:
@@ -250,6 +260,13 @@ class QuotingAndArityTest(unittest.TestCase):
         rendered = core.quote_argv(argv)
         self.assertEqual(shlex.split(rendered), argv)
 
+    def test_elf_snapshot_is_stable_across_ldd_aslr_addresses(self) -> None:
+        first = core.binary_snapshot(pathlib.Path("/bin/true"))
+        second = core.binary_snapshot(pathlib.Path("/bin/true"))
+
+        self.assertEqual(core.canonical_sha256(first), core.canonical_sha256(second))
+        self.assertNotIn("stdout", first["ldd"])
+
     def test_zero_arity_option_rejects_separate_value(self) -> None:
         with self.assertRaisesRegex(core.ValidationError, "unexpected positional"):
             core.validate_argv(["--no-kv-offload", "1"])
@@ -313,6 +330,71 @@ class ManifestAndScheduleTest(FixtureMixin, unittest.TestCase):
             self.assertEqual(len({item["variant"] for item in pair_runs}), 2)
         self.assertEqual(orientations, ["AB", "BA", "AB", "BA", "AB"])
 
+    def test_single_pair_screening_is_explicit_and_limited_to_early_stages(self) -> None:
+        manifest = self.manifest()
+        stage = next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")
+        del stage["decision_policy"]
+        stage["screening_policy"] = {
+            "kind": "single_pair_fail_fast",
+            "order": "BA",
+            "regression_threshold_percent": 2.0,
+            "confidence_claim": "none",
+        }
+
+        core.validate_manifest(manifest)
+        schedule = core.build_schedule(manifest, stage)
+
+        self.assertEqual(len(schedule), 6)
+        self.assertEqual({item["pair"] for item in schedule}, {1})
+        self.assertEqual({item["orientation"] for item in schedule}, {"BA"})
+        production = next(
+            item for item in manifest["stages"] if item["purpose"] == "production_confirmation"
+        )
+        del production["decision_policy"]
+        production["screening_policy"] = copy.deepcopy(stage["screening_policy"])
+        with self.assertRaisesRegex(core.ManifestError, "limited to smoke and kernel_screen"):
+            core.validate_manifest(manifest)
+
+    def test_single_pair_screening_rejects_statistical_claims(self) -> None:
+        manifest = self.manifest()
+        stage = manifest["stages"][1]
+        stage["screening_policy"] = {
+            "kind": "single_pair_fail_fast",
+            "order": "AB",
+            "regression_threshold_percent": 2.0,
+            "confidence_claim": "none",
+        }
+        with self.assertRaisesRegex(core.ManifestError, "statistical decision_policy"):
+            core.validate_manifest(manifest)
+
+    def test_adjacent_single_pair_screens_must_alternate_order(self) -> None:
+        manifest = self.manifest()
+        for stage in manifest["stages"][1:3]:
+            del stage["decision_policy"]
+            stage["screening_policy"] = {
+                "kind": "single_pair_fail_fast",
+                "order": "AB",
+                "regression_threshold_percent": 2.0,
+                "confidence_claim": "none",
+            }
+        with self.assertRaisesRegex(core.ManifestError, "must alternate AB/BA"):
+            core.validate_manifest(manifest)
+
+    def test_command_for_run_preserves_bench_specific_arity(self) -> None:
+        manifest = self.manifest()
+        bench = self.repo / "llama-bench"
+        self.executable.rename(bench)
+        for variant in manifest["variants"].values():
+            variant["executables"]["default"]["path"] = str(bench)
+        stage = manifest["stages"][1]
+        stage["command"]["common_args"] = ["--no-kv-offload", "0"]
+        stage["command"]["cli_schema"] = {"builtin": "llama", "allow_positionals": False}
+        scheduled = core.build_schedule(manifest, stage)[0]
+
+        argv, _ = core.command_for_run(manifest, stage, scheduled)
+
+        self.assertEqual(argv[-2:], ["--no-kv-offload", "0"])
+
     def test_architecture_selector_is_rejected(self) -> None:
         manifest = self.manifest()
         manifest["stages"][1]["selection"]["architecture"] = "forbidden"
@@ -343,7 +425,7 @@ class ManifestAndScheduleTest(FixtureMixin, unittest.TestCase):
         with self.assertRaisesRegex(core.ManifestError, "decision_policy"):
             core.validate_manifest(manifest)
 
-    def test_graph_capable_profiler_requires_node_trace(self) -> None:
+    def test_graph_replay_profiler_requires_node_trace(self) -> None:
         example_path = (
             SCRIPTS.parent
             / "examples"
@@ -353,8 +435,56 @@ class ManifestAndScheduleTest(FixtureMixin, unittest.TestCase):
         manifest = json.loads(example_path.read_text(encoding="utf-8"))
         manifest["profiler"]["cuda_graph_trace"] = {
             "applicability": "not_applicable",
-            "reason": "invalid for this graph-capable stage",
+            "reason": "invalid for this graph-replay stage",
         }
+        stage = core.stage_by_id(manifest, manifest["profiler"]["stage"])
+        stage["selection"]["cuda_graph_replay"] = {"applicability": "required"}
+        with self.assertRaisesRegex(core.ManifestError, "requires graph-node tracing"):
+            core.validate_manifest(manifest)
+
+    def test_cuda_graph_capability_alone_does_not_claim_graph_replay(self) -> None:
+        example_path = (
+            SCRIPTS.parent
+            / "examples"
+            / "feature-performance-validation"
+            / "manifest.example.json"
+        )
+        manifest = json.loads(example_path.read_text(encoding="utf-8"))
+        manifest["profiler"]["cuda_graph_trace"] = {
+            "applicability": "not_applicable",
+            "reason": "production prefill launches kernels directly despite backend support",
+        }
+        manifest["profiler"]["selector"]["graph_only"] = False
+        core.validate_manifest(manifest)
+
+    def test_early_diagnostic_is_explicitly_regression_gated_and_paired(self) -> None:
+        example_path = (
+            SCRIPTS.parent
+            / "examples"
+            / "feature-performance-validation"
+            / "manifest.example.json"
+        )
+        manifest = json.loads(example_path.read_text(encoding="utf-8"))
+        diagnostic = manifest["early_diagnostics"][0]
+        diagnostic["trigger"] = "always"
+        with self.assertRaisesRegex(core.ManifestError, "regression_signal_only"):
+            core.validate_manifest(manifest)
+        diagnostic["trigger"] = "regression_signal_only"
+        diagnostic["variants"] = ["candidate"]
+        with self.assertRaisesRegex(core.ManifestError, "baseline then candidate"):
+            core.validate_manifest(manifest)
+
+    def test_graph_replay_early_diagnostic_requires_node_trace(self) -> None:
+        example_path = (
+            SCRIPTS.parent
+            / "examples"
+            / "feature-performance-validation"
+            / "manifest.example.json"
+        )
+        manifest = json.loads(example_path.read_text(encoding="utf-8"))
+        diagnostic = manifest["early_diagnostics"][0]
+        diagnostic["stage"] = "short-graph-decode-smoke"
+        diagnostic["screen_selection"] = {"kind": "fixed", "screen": "default"}
         with self.assertRaisesRegex(core.ManifestError, "requires graph-node tracing"):
             core.validate_manifest(manifest)
 
@@ -473,6 +603,24 @@ class StatisticsTest(unittest.TestCase):
         )
         self.assertEqual(report["decision"], "inconclusive")
 
+    def test_single_pair_screen_has_no_confidence_claim(self) -> None:
+        report = core.single_pair_screen_report(
+            {"pair": 1, "orientation": "BA", "baseline": 100.0, "candidate": 97.0},
+            direction="higher",
+            regression_threshold_percent=2.0,
+        )
+
+        self.assertEqual(report["signal"], "regression_signal")
+        self.assertIsNone(report["confidence_interval"])
+        self.assertEqual(report["confidence_claim"], "none")
+        self.assertEqual(len(report["raw_pairs"]), 1)
+        clear = core.single_pair_screen_report(
+            {"pair": 1, "orientation": "AB", "baseline": 100.0, "candidate": 99.0},
+            direction="higher",
+            regression_threshold_percent=2.0,
+        )
+        self.assertEqual(clear["signal"], "clear_to_continue")
+
     def test_weighted_harmonic_matches_prefill_throughput_geometry(self) -> None:
         value = core.aggregate_screen_values([(100.0, 1.0), (200.0, 3.0)], "weighted_harmonic")
         self.assertAlmostEqual(value, 160.0)
@@ -493,6 +641,48 @@ class StatisticsTest(unittest.TestCase):
 
 
 class ProfilerTest(unittest.TestCase):
+    def test_regression_diagnostic_selects_preregistered_largest_screen(self) -> None:
+        stage = {
+            "id": "spans",
+            "metric": {"direction": "higher"},
+            "screens": [{"id": "low"}, {"id": "mid"}, {"id": "high"}],
+        }
+        report = {
+            "screening_observation": {
+                "signal": "regression_signal",
+                "direction": "higher",
+                "raw_pairs": [
+                    {
+                        "raw_screens": {
+                            "baseline": [
+                                {"screen": "low", "value": 100},
+                                {"screen": "mid", "value": 100},
+                                {"screen": "high", "value": 100},
+                            ],
+                            "candidate": [
+                                {"screen": "low", "value": 99},
+                                {"screen": "mid", "value": 91},
+                                {"screen": "high", "value": 96},
+                            ],
+                        }
+                    }
+                ],
+            }
+        }
+
+        selected = profiler.select_regression_diagnostic(
+            stage, report, {"kind": "largest_observed_regression"}
+        )
+
+        self.assertTrue(selected["triggered"])
+        self.assertEqual(selected["selected_screen"]["screen"], "mid")
+        self.assertEqual(len(selected["all_screen_observations"]), 3)
+        report["screening_observation"]["signal"] = "clear_to_continue"
+        skipped = profiler.select_regression_diagnostic(
+            stage, report, {"kind": "largest_observed_regression"}
+        )
+        self.assertEqual(skipped, {"triggered": False, "reason": "no_regression_signal"})
+
     def test_nsys_explicitly_requests_and_verifies_graph_node_trace(self) -> None:
         config = {
             "applicability": "required",
@@ -586,6 +776,10 @@ class ProfilerTest(unittest.TestCase):
             verified = profiler.verify_ncu_capture(plan, parsed)
             self.assertEqual(verified["status"], "verified")
             self.assertEqual(verified["observed_capture_count"], 2)
+            self.assertEqual(
+                parsed["captures"][0]["metrics"],
+                [{"name": "gpu__time_duration.sum", "unit": None, "value": "10"}],
+            )
 
     def test_ncu_report_count_mismatch_and_missing_columns_do_not_verify(self) -> None:
         plan = {
@@ -607,6 +801,149 @@ class ProfilerTest(unittest.TestCase):
         )
         self.assertEqual(
             profiler.verify_ncu_capture(plan, missing_shapes)["status"], "unverifiable"
+        )
+
+    def test_agent_summary_surfaces_discovery_ncu_metrics_timing_and_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            core.write_json_atomic(
+                root / "ncu-plan.json",
+                {
+                    "stage": "screen",
+                    "variant": "candidate",
+                    "screen": "mid",
+                    "command": {
+                        "selected_launches": [
+                            {
+                                "launch_index": 12,
+                                "name_occurrence": 3,
+                                "graph_node_id": 9,
+                            }
+                        ],
+                        "derivation": {
+                            "kernel_name": "kernel",
+                            "matching_launch_count": 4,
+                            "launch_count": 1,
+                            "discovery_launch_indices": [12],
+                            "name_occurrences": [3],
+                            "expected_shapes": [
+                                {"grid": [2, 1, 1], "block": [32, 1, 1]}
+                            ],
+                        },
+                        "report_path": str(root / "capture.ncu-rep"),
+                    },
+                },
+            )
+            core.write_json_atomic(
+                root / "discovery-inventory.json",
+                {
+                    "launch_count": 20,
+                    "graph_node_trace": {
+                        "launches_with_graph_node": 5,
+                        "distinct_graph_node_ids": ["9"],
+                    },
+                },
+            )
+            core.write_json_atomic(
+                root / "profile-state.json", {"ncu_verification_status": "verified"}
+            )
+            core.write_json_atomic(
+                root / "ncu-verification.json",
+                {
+                    "status": "verified",
+                    "issues": [],
+                    "observed_capture_count": 1,
+                    "parsed_export": {
+                        "captures": [
+                            {
+                                "kernel_name": "kernel",
+                                "metrics": [
+                                    {
+                                        "name": "gpu__time_duration.sum",
+                                        "unit": "nsecond",
+                                        "value": "1234",
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                },
+            )
+            core.write_json_atomic(
+                root / "nsys-result.json",
+                {"timing": {"target_process_seconds": 2.5}},
+            )
+            core.write_json_atomic(
+                root / "ncu-result.json",
+                {"timing": {"target_process_seconds": 3.5}},
+            )
+
+            summary = profiler.agent_profile_summary(root)
+
+        self.assertEqual(summary["status"], "verified")
+        self.assertEqual(summary["nsys"]["selected_kernel"], "kernel")
+        self.assertEqual(summary["nsys"]["selected_graph_node_ids"], ["9"])
+        self.assertEqual(
+            summary["ncu"]["captures"][0]["metrics"][0]["value"], "1234"
+        )
+        self.assertEqual(summary["timing_seconds"]["nsys"]["target_process_seconds"], 2.5)
+        self.assertIn("diagnostic-only", summary["evidence_boundary"].lower())
+
+    def test_agent_comparison_keeps_raw_metrics_without_acceptance_claim(self) -> None:
+        def profile(variant: str, value: str) -> dict[str, object]:
+            return {
+                "variant": variant,
+                "nsys": {
+                    "selected_kernel": "kernel",
+                    "selected_shapes": [{"grid": [1, 1, 1], "block": [32, 1, 1]}],
+                    "total_launch_count": 10,
+                    "matching_launch_count": 2,
+                    "selected_launch_count": 1,
+                },
+                "ncu": {
+                    "captures": [
+                        {
+                            "id": "1",
+                            "kernel_name": "kernel",
+                            "metrics": [{"name": "duration", "value": value}],
+                        }
+                    ]
+                },
+                "timing_seconds": {},
+            }
+
+        comparison = profiler.compare_agent_profiles(
+            profile("baseline", "10"), profile("candidate", "12")
+        )
+
+        self.assertEqual(comparison["status"], "diagnostic_side_by_side_only")
+        self.assertEqual(
+            comparison["raw_ncu_metrics"]["candidate"][0]["metrics"][0]["value"],
+            "12",
+        )
+        self.assertIn("no paired interval", comparison["comparison_boundary"].lower())
+
+    def test_nsys_ncu_template_cast_spelling_normalizes_for_verification(self) -> None:
+        plan = {
+            "command": {
+                "derivation": {
+                    "kernel_name": "kernel<(int)256, (bool)0, (ggml_type)1>",
+                    "launch_count": 1,
+                    "expected_shapes": [{"grid": [1, 1, 1], "block": [32, 1, 1]}],
+                }
+            }
+        }
+        parsed = profiler.parse_ncu_raw_csv(
+            '"ID","Kernel Name","Grid Size","Block Size"\n'
+            '"1","kernel<256, 0, 1>","1 1 1","32 1 1"\n'
+        )
+
+        verified = profiler.verify_ncu_capture(plan, parsed)
+
+        self.assertEqual(verified["status"], "verified")
+        self.assertNotEqual(verified["expected_kernel"], verified["observed_kernel_names"][0])
+        self.assertEqual(
+            verified["canonical_expected_kernel"], verified["canonical_observed_kernel_names"][0]
         )
 
     def test_fake_nsys_sqlite_parses_names_shapes_counts_and_indices(self) -> None:
@@ -660,6 +997,230 @@ class ProfilerTest(unittest.TestCase):
                 ["/tmp/llama-bench", "-C", "0x7", "--cpu-strict", "1"],
                 pathlib.Path(temporary),
             )
+
+    def test_semantic_last_occurrence_is_derived_from_discovery(self) -> None:
+        discovery = {
+            "source": "fake",
+            "launches": [
+                {
+                    "name": "kernel",
+                    "name_occurrence": occurrence,
+                    "launch_index": occurrence * 10,
+                    "graph_node_id": None,
+                    "grid": [1, 1, 1],
+                    "block": [32, 1, 1],
+                }
+                for occurrence in range(1, 4)
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            plan = profiler.build_ncu_plan(
+                discovery,
+                {
+                    "kernel_regex": "kernel",
+                    "graph_only": False,
+                    "occurrence_policy": {"kind": "last"},
+                },
+                ["/tmp/llama-bench", "-C", "0x7", "--cpu-strict", "1"],
+                pathlib.Path(temporary),
+            )
+        derivation = plan["command"]["derivation"]
+        self.assertEqual(derivation["matching_launch_count"], 3)
+        self.assertEqual(derivation["occurrence_policy"], "last")
+        self.assertEqual(derivation["launch_skip"], 2)
+        self.assertEqual(derivation["launch_count"], 1)
+        self.assertEqual(derivation["discovery_launch_indices"], [30])
+
+
+class DiagnosticCliTest(FixtureMixin, unittest.TestCase):
+    def _manifest_with_diagnostic(self, signal: str) -> pathlib.Path:
+        manifest = self.manifest()
+        stage = next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")
+        stage["resource"] = "gpu"
+        del stage["decision_policy"]
+        stage["screening_policy"] = {
+            "kind": "single_pair_fail_fast",
+            "order": "BA",
+            "regression_threshold_percent": 2.0,
+            "confidence_claim": "none",
+        }
+        manifest["early_diagnostics"] = [
+            {
+                "id": "kernel-regression",
+                "trigger": "regression_signal_only",
+                "on_clear": "skip",
+                "evidence_claim": "diagnostic_only",
+                "pattern": "independent_nsys_then_filtered_ncu_per_variant",
+                "profile_repetitions": 1,
+                "stage": stage["id"],
+                "variants": ["baseline", "candidate"],
+                "screen_selection": {"kind": "largest_observed_regression"},
+                "selector": {
+                    "kernel_regex": "kernel",
+                    "graph_only": False,
+                    "occurrence_policy": {"kind": "last"},
+                },
+                "cuda_graph_trace": {
+                    "applicability": "not_applicable",
+                    "reason": "direct fake prefill",
+                },
+                "metrics": ["gpu__time_duration.sum"],
+            }
+        ]
+        manifest_path = self.root / "diagnostic.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        manifest_sha = file_sha256(manifest_path)
+        provenance = core.capture_provenance(manifest, manifest_sha)
+        study_root = pathlib.Path(manifest["artifact_root"]) / (
+            f"{manifest['study']['id']}-{manifest_sha[:12]}"
+        )
+        study_root.mkdir(parents=True)
+        candidate = {"low": 99.0, "mid": 91.0, "high": 96.0}
+        stage_report = {
+            "purpose": "kernel_screen",
+            "execution_status": "completed",
+            "status": "failed" if signal == "regression_signal" else "passed",
+            "screening_observation": {
+                "signal": signal,
+                "direction": "higher",
+                "raw_pairs": [
+                    {
+                        "raw_screens": {
+                            "baseline": [
+                                {"screen": name, "value": 100.0, "weight": 1}
+                                for name in ("low", "mid", "high")
+                            ],
+                            "candidate": [
+                                {"screen": name, "value": candidate[name], "weight": 1}
+                                for name in ("low", "mid", "high")
+                            ],
+                        }
+                    }
+                ],
+            },
+        }
+        core.write_json_atomic(
+            study_root / "state.json",
+            {
+                "schema_version": 1,
+                "manifest_sha256": manifest_sha,
+                "provenance_identity_fingerprint": provenance["identity_fingerprint"],
+                "runs": {},
+                "stages": {stage["id"]: stage_report},
+            },
+        )
+        return manifest_path
+
+    def test_diagnostic_runs_independent_profiles_for_both_variants(self) -> None:
+        manifest_path = self._manifest_with_diagnostic("regression_signal")
+
+        def compact(path: pathlib.Path) -> dict[str, object]:
+            variant = "baseline" if "-baseline-" in path.name else "candidate"
+            return {
+                "status": "verified",
+                "variant": variant,
+                "nsys": {
+                    "selected_kernel": "kernel",
+                    "selected_shapes": [],
+                    "total_launch_count": 1,
+                    "matching_launch_count": 1,
+                    "selected_launch_count": 1,
+                },
+                "ncu": {"captures": []},
+                "timing_seconds": {},
+                "artifacts": {"root": str(path)},
+                "evidence_boundary": "diagnostic only",
+            }
+
+        with mock.patch.object(CLI, "_profile_one") as profile_one, mock.patch.object(
+            CLI.profiler, "agent_profile_summary", side_effect=compact
+        ):
+            report = CLI._diagnose(manifest_path, resume=False)
+
+        self.assertEqual(report["status"], "verified")
+        self.assertEqual(profile_one.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["variant_name"] for call in profile_one.call_args_list],
+            ["baseline", "candidate"],
+        )
+        self.assertTrue(all(call.kwargs["execute_ncu"] for call in profile_one.call_args_list))
+        trigger = report["investigations"][0]["trigger"]
+        self.assertEqual(trigger["selected_screen"]["screen"], "mid")
+        roots = [item["artifacts"]["root"] for item in report["profiles"]]
+        self.assertNotEqual(roots[0], roots[1])
+        self.assertEqual(
+            report["investigations"][0]["agent_comparison"]["status"],
+            "diagnostic_side_by_side_only",
+        )
+
+    def test_clear_screen_skips_all_profiler_work(self) -> None:
+        manifest_path = self._manifest_with_diagnostic("clear_to_continue")
+        with mock.patch.object(CLI, "_profile_one") as profile_one:
+            report = CLI._diagnose(manifest_path, resume=False)
+        self.assertEqual(report["status"], "not_triggered")
+        profile_one.assert_not_called()
+
+    def test_unverifiable_profile_fails_closed_and_is_preserved(self) -> None:
+        manifest_path = self._manifest_with_diagnostic("regression_signal")
+        with mock.patch.object(CLI, "_profile_one"), mock.patch.object(
+            CLI.profiler,
+            "agent_profile_summary",
+            return_value={"status": "unverifiable", "variant": "baseline"},
+        ), self.assertRaisesRegex(core.ValidationError, "unverifiable"):
+            CLI._diagnose(manifest_path, resume=False)
+        manifest_sha = file_sha256(manifest_path)
+        report_path = (
+            self.root
+            / "artifacts"
+            / f"unit-fixture-{manifest_sha[:12]}"
+            / "early-diagnostics"
+            / "agent-diagnostic-report.json"
+        )
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(report["status"], "failed")
+        self.assertEqual(report["investigations"][0]["status"], "failed")
+
+    def test_run_flag_does_not_invoke_diagnostics_after_a_pass(self) -> None:
+        manifest_path = self.root / "passing.json"
+        manifest_path.write_text(json.dumps(self.manifest()), encoding="utf-8")
+        summary = {"status": "early_screen_only_not_production_or_final_acceptance"}
+        with mock.patch.object(StudyRunner, "run", return_value=summary), mock.patch.object(
+            CLI, "_diagnose"
+        ) as diagnose, mock.patch.object(
+            sys,
+            "argv",
+            [
+                "feature-performance-validation.py",
+                "run",
+                str(manifest_path),
+                "--diagnose-regressions",
+            ],
+        ), contextlib.redirect_stdout(io.StringIO()):
+            returncode = CLI.main()
+        self.assertEqual(returncode, 0)
+        diagnose.assert_not_called()
+
+    def test_run_flag_profiles_a_regression_but_preserves_nonzero_status(self) -> None:
+        manifest_path = self.root / "regression.json"
+        manifest_path.write_text(json.dumps(self.manifest()), encoding="utf-8")
+        diagnostic = {"status": "verified", "evidence_boundary": "diagnostic only"}
+        with mock.patch.object(
+            StudyRunner, "run", side_effect=core.ValidationError("screen failed")
+        ), mock.patch.object(
+            CLI, "_diagnose", return_value=diagnostic
+        ) as diagnose, mock.patch.object(
+            sys,
+            "argv",
+            [
+                "feature-performance-validation.py",
+                "run",
+                str(manifest_path),
+                "--diagnose-regressions",
+            ],
+        ), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            returncode = CLI.main()
+        self.assertEqual(returncode, 2)
+        diagnose.assert_called_once_with(manifest_path, resume=False)
 
 
 class TelemetryTest(unittest.TestCase):
@@ -742,6 +1303,36 @@ class TelemetryTest(unittest.TestCase):
 
 
 class RunnerTest(FixtureMixin, unittest.TestCase):
+    def test_single_pair_screen_runs_once_and_fails_on_preregistered_signal(self) -> None:
+        manifest = self.manifest()
+        manifest_path = self.root / "single-pair-screen.json"
+        stage = next(item for item in manifest["stages"] if item["purpose"] == "kernel_screen")
+        del stage["decision_policy"]
+        stage["screening_policy"] = {
+            "kind": "single_pair_fail_fast",
+            "order": "BA",
+            "regression_threshold_percent": 2.0,
+            "confidence_claim": "none",
+        }
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        runner = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+
+        def fake_execute(_stage: dict, scheduled: dict, **_kwargs: object) -> dict:
+            return {
+                "run_id": scheduled["run_id"],
+                "metric_value": 97.0 if scheduled["variant"] == "candidate" else 100.0,
+            }
+
+        with mock.patch.object(runner, "_execute", side_effect=fake_execute) as execute:
+            report = runner._run_performance(stage, retry_failed=False)
+
+        self.assertEqual(execute.call_count, 6)
+        self.assertEqual(report["status"], "failed")
+        observation = report["screening_observation"]
+        self.assertEqual(observation["signal"], "regression_signal")
+        self.assertIsNone(observation["confidence_interval"])
+        self.assertFalse(report["adaptive_repetition"]["applicable"])
+
     def test_final_gate_execution_is_not_acceptance_without_a_pass(self) -> None:
         manifest_path = self.root / "gate-status.json"
         manifest_path.write_text(json.dumps(self.manifest()), encoding="utf-8")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,12 @@ find_package(Python3 COMPONENTS Interpreter QUIET)
 
 if (Python3_Interpreter_FOUND)
     add_test(
+        NAME test-feature-performance-validation
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/test-feature-validation.py)
+    set_property(TEST test-feature-performance-validation PROPERTY LABELS main)
+
+    add_test(
         NAME test-release-workflow-static
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tests/test-release-workflow-static.py)


### PR DESCRIPTION
## Summary

- integrate the generic manifest-driven feature/performance validation toolkit from exact KV base f6341a157
- direct future CPU-KV feature agents to use it for early exactness, performance, resource screening, and opt-in regression diagnostics
- keep long-context, matching-batch PPL/output exactness, clean-process, allocation-lifecycle, and feature-specific acceptance gates mandatory
- exclude compact-causal-specific validation records and machine-local manifests, which remain on tools/feature-performance-validation

## Validation

- `PYTHONWARNINGS=error::ResourceWarning python3 scripts/test-feature-validation.py -v` — 64/64 passed in 9.474s
- fresh CPU-only CMake configure — passed
- registered `test-feature-performance-validation` CTest — 1/1 passed in 9.85s
- Python byte compilation, JSON schema parse, generic manifest structural validation, standard-library import audit, and `git diff --check` — passed
- generic toolkit paths are byte-identical to published toolkit commit 84592036d

## Scope

Three-dot diff from f6341a157 is tooling, docs, tests, one generic schema/example, and optional Python CTest registration only. It adds no production behavior, runtime flag, kernel, model/architecture selection, compile-time dependency, or generated surface. No generation check applies beyond the successful fresh CMake generation because no generated source/document was touched.