### PR TITLE
tools: harden feature validation lifecycle and memory evidence

### DIFF
--- a/docs/feature-performance-validation-validation.md
+++ b/docs/feature-performance-validation-validation.md
@@ -392,3 +392,93 @@ attribution, per-phase device high-water, and allocation backtraces remain
 bounded follow-ups. Persistent `nvidia-smi` process VRAM and `/proc` ordinary
 host memory remain separate telemetry; CUDA events labelled Pinned are not
 relabeled as total process pinned memory and are never inferred from VmLck.
+
+## Parent-interrupt and incomplete-attempt correction
+
+The store-stage-pool validation reproduced two defects in the c2-era toolkit.
+First, the outer runner forwarded SIGINT to the complete `flock` wrapper group.
+Because the direct target intentionally has its own session, the lock holder
+could exit before the internal executor finished terminating that target group;
+a `llama-bench` descendant could therefore survive under PID 1 after the GPU
+lock was released. Second, an interruption after `attempt-01` was created but
+before its result reached `state.json` made retry recompute attempt 1 from the
+state-list length and fail on the existing directory.
+
+The correction keeps the lock wrapper alive during catchable parent SIGINT or
+SIGTERM. The internal executor writes an atomic ownership record before target
+creation, including its PID/start time and then the direct target PGID. The
+outer runner forwards one SIGINT only to that identified executor and absorbs
+further parent signals while cleanup runs. The existing process-group cleanup
+remains authoritative: it waits after SIGTERM, escalates to SIGKILL for a
+remaining descendant, reaps the direct child, stops telemetry, and persists the
+failed result before returning through `flock`. A bounded outer fallback uses
+the same target PGID before it terminates an unresponsive wrapper. The common
+launcher supplies the ownership path, so manifest, NSYS, and NCU locked
+lifecycles share this behavior.
+
+Resume now reconciles disk attempt numbers with state. Every unindexed attempt
+is preserved as failed and non-metric; even an existing child result labelled
+success is retained only as non-counted evidence. A normal recovery writes
+`interrupted-result.json`. An attempt already sealed immediately before state
+persistence instead keeps that seal immutable and binds the recovery through
+`state.json`. The `attempt-evidence.json` seal hashes every preserved artifact
+and binds the inventory to the run/attempt, manifest SHA-256, and provenance
+identity fingerprint. Existing failed attempts receive and verify the same
+seal. A live recorded owner prevents recovery, seal tampering fails closed, and
+retry uses one more than the highest state or disk attempt, preserving repeated
+interruptions without overwrite or reuse.
+
+Focused real-signal and resume validation used:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONWARNINGS=error \
+  python3 scripts/test-feature-validation.py -v \
+  RunnerTest.test_parent_interrupt_holds_wrapper_until_descendant_is_reaped \
+  RunnerTest.test_outer_launcher_real_sigint_persists_state_and_retry_semantics \
+  RunnerTest.test_real_sigint_reaps_target_group_and_preserves_failure \
+  RunnerTest.test_incomplete_attempt_is_sealed_and_retry_uses_next_number \
+  RunnerTest.test_incomplete_attempt_with_live_owner_is_not_recycled \
+  RunnerTest.test_noncanonical_incomplete_attempt_name_fails_closed \
+  RunnerTest.test_repeated_incomplete_attempts_are_preserved_before_attempt_three \
+  RunnerTest.test_preserved_incomplete_attempt_tamper_fails_closed \
+  RunnerTest.test_unindexed_success_result_is_preserved_but_never_counted \
+  RunnerTest.test_unindexed_presealed_failure_recovers_without_mutating_seal
+```
+
+Result: 10 tests passed in 1.845 seconds. The parent-interrupt test sends real
+SIGTERM and SIGINT, launches a real descendant that ignores SIGTERM, observes
+SIGKILL escalation, checks that no target PID remains when the fake lock holder
+records release, and verifies cleanup-state persistence. The fake `flock`
+accepts the exact `LOCK -c COMMAND` form and executes the safely quoted command,
+but does not acquire `/tmp/beellama-single-gpu.lock` or access a GPU.
+
+The complete warning-strict CPU suite used:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONWARNINGS=error \
+  python3 scripts/test-feature-validation.py -v
+```
+
+Result: 103 tests passed in 12.002 seconds. No warning was emitted, and a final
+process inspection found no surviving fake target, descendant, launcher, or
+sampler. Static checks also passed:
+
+```bash
+git diff --check
+PYTHONDONTWRITEBYTECODE=1 PYTHONWARNINGS=error python3 -m py_compile \
+  scripts/feature_validation/*.py \
+  scripts/feature-performance-validation.py \
+  scripts/test-feature-validation.py
+python3 -m json.tool scripts/feature_validation/manifest.schema.json >/dev/null
+for manifest in examples/feature-performance-validation/*.json; do
+  python3 -m json.tool "$manifest" >/dev/null
+done
+```
+
+This was CPU-only toolkit validation: no CUDA build, real GPU command, NSYS/NCU
+capture, or production source change occurred. Userspace cannot guarantee
+cleanup after SIGKILL to the complete wrapper/executor group, kernel failure,
+host reset, or power loss. Resume therefore refuses to recycle a still-live
+owned group; after a parent-only SIGKILL, the separately sessioned lock owner
+continues its finite target lifecycle and the unindexed attempt is later
+recovered conservatively as failed.

--- a/docs/feature-performance-validation-validation.md
+++ b/docs/feature-performance-validation-validation.md
@@ -303,3 +303,92 @@ ctest --test-dir /tmp/beellama-build-provenance-real.CaTwAk/build \
 
 Result: 1/1 passed. No CUDA target, model, GPU process, NSYS, or NCU command ran
 for this tooling-only hardening.
+
+## Artifact/interrupt correction and NSYS memory inventory
+
+The generic artifact/interrupt correction was independently reviewed from
+`1e74eac6c513b7dd9b0445052f3ca999e9a7d28f` against canonical
+`c2ea686d662ef36e0f6dcbef9195309b505cb422`. The imported files are byte-for-
+byte identical to that toolkit source; the attention-staging investigation
+report was not imported. The review accepted the correction because it checks
+the exact artifact directory in every containing variant root, repeats the
+check for actual run/profile/diagnostic directories, retains source-provenance
+identity, tracks the target process-group ID after leader exit, escalates from
+SIGTERM to SIGKILL, reaps the leader and descendants, shuts down telemetry, and
+preserves interrupted attempts as failed for explicit retry.
+
+The profiler follow-up adds an independent standard-library NSYS SQLite memory
+inventory. A configured capture explicitly requests
+`--cuda-memory-usage=true` only after checking the exact tool help. Required
+categories fail closed; optional categories remain visibly incomplete. The
+machine-readable inventory covers CUDA memory events, address-paired
+lifetimes, captured outstanding device-allocation high-water, memcpy/memset,
+CUDA runtime/driver calls, named VMM calls, and standalone NVTX ranges. Missing
+tables/columns/enum meanings are unavailable rather than zero.
+
+Focused warning-as-error checks used:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONWARNINGS=error \
+  python3 scripts/test-feature-validation.py -v \
+  ProfilerTest ArtifactLifecycleTest DiagnosticCliTest
+
+PYTHONDONTWRITEBYTECODE=1 PYTHONWARNINGS=error \
+  python3 scripts/test-feature-validation.py -v \
+  ManifestAndScheduleTest.test_ignored_synthetic_probe_does_not_authorize_unignored_root \
+  ManifestAndScheduleTest.test_ignore_negation_fails_closed_for_exact_artifact_root \
+  ManifestAndScheduleTest.test_nested_variant_roots_must_both_ignore_the_exact_root \
+  ManifestAndScheduleTest.test_distinct_variant_roots_check_only_the_containing_root \
+  ManifestAndScheduleTest.test_ignored_in_source_artifacts_do_not_change_provenance_identity \
+  ArtifactLifecycleTest \
+  RunnerTest.test_cleanup_errors_preserve_result_and_telemetry \
+  RunnerTest.test_exited_leader_does_not_hide_sigterm_ignoring_descendant \
+  RunnerTest.test_real_sigint_reaps_target_group_and_preserves_failure \
+  RunnerTest.test_failed_attempt_is_preserved_and_retry_requires_opt_in
+```
+
+The first focused suite passed 26 tests in 0.580 seconds. The second passed 11
+adversarial artifact/process tests in 3.791 seconds. Synthetic SQLite coverage
+includes current and alternate names, present-but-empty tables, absent tables,
+missing semantic columns, capture-start deallocation, pinned/device separation,
+allocation pairing, copy/memset aggregation, CUDA/VMM API names, and NVTX.
+
+The final warning-as-error suite used:
+
+```sh
+#!/bin/sh
+if [ "$#" -ne 3 ] || [ "$2" != "-c" ]; then exit 64; fi
+exec /bin/sh -c "$3"
+```
+
+```bash
+PATH="$PWD/.feature-validation-test-bin:$PATH" \
+  PYTHONDONTWRITEBYTECODE=1 PYTHONWARNINGS=error \
+  python3 scripts/test-feature-validation.py -v
+```
+
+Result: 95 tests passed in 11.300 seconds. The temporary CPU-test `flock` shim
+accepted only the exact `LOCK -c COMMAND` shape and exec'd `/bin/sh -c COMMAND`;
+it preserved wrapper/target process groups and real signals without competing
+with unrelated long GPU work. It was removed immediately after the run. This
+does not replace the real-flock result: before the memory extension, the exact
+imported correction passed all 89 tests in 11.114 seconds with `/usr/bin/flock`,
+and the post-extension targeted process tests used real signals. JSON
+schema/example parsing and `git diff --check` also passed before commit.
+
+A read-only compatibility check parsed a pre-existing NSYS 2026.1 SQLite
+export twice in 0.04 and 0.05 seconds (28,736 and 28,768 KiB maximum RSS). It found 332 CUDA memory
+events, 3,345 copy/memset events, 25,227 CUDA API events, and 19 named VMM
+events. Those counts validate parser compatibility only; they are not new
+feature-performance or acceptance evidence. The same export had no NVTX table,
+which the inventory correctly labelled unavailable. No GPU command or new
+NSYS/NCU capture was run for this task.
+
+Automated evidence stops at trace capability, event availability, exact raw
+allocation rows, address pairing, captured allocation balances, grouped copy
+and API activity, and requirement enforcement. Human investigation still owns
+the meaning of unmatched live-at-exit allocations. Robust nested-NVTX
+attribution, per-phase device high-water, and allocation backtraces remain
+bounded follow-ups. Persistent `nvidia-smi` process VRAM and `/proc` ordinary
+host memory remain separate telemetry; CUDA events labelled Pinned are not
+relabeled as total process pinned memory and are never inferred from VmLck.

--- a/docs/feature-performance-validation.md
+++ b/docs/feature-performance-validation.md
@@ -338,6 +338,44 @@ selector. Thus `--launch-skip` and `--launch-count` are derived for the current
 binary, hardware, and capture rather than copied between builds. Re-run NSYS
 after any relevant identity changes.
 
+An optional `memory_evidence` block preregisters `mode` (`required` or
+`optional`) and the evidence categories needed from this same discovery. When
+configured, the runner inspects the exact NSYS help and, when supported,
+explicitly passes `--cuda-memory-usage=true`. Required mode fails before launch
+if the option is unsupported, and fails after export if any requested category
+is unavailable or only partial. Optional mode retains the same diagnostics but
+does not turn unavailable evidence into a successful memory claim.
+
+`memory-inventory.json` is schema-tolerant across known NSYS SQLite naming
+variants and separately reports:
+
+- CUDA allocation/deallocation events by memory kind, including device,
+  pinned, pageable, managed, and static kinds when NSYS supplies them, plus
+  captured outstanding-allocation high-water separately for each kind;
+- address-paired lifetimes plus every unmatched allocation/deallocation;
+- captured outstanding device-allocation high-water by process/device, which
+  is not total process VRAM or VMM reservation;
+- memcpy/memset counts, bytes, duration, and memory-kind groupings;
+- aggregated CUDA runtime/driver memory calls and named VMM reserve, create,
+  map, access, unmap, release, and address-free calls; and
+- standalone NVTX ranges when an NVTX table is present.
+
+Each category is `available`, `partial`, or `unavailable`. An available table
+with zero rows is measured zero; a missing table, required column, enum
+meaning, or unresolved identity is never reported as zero. Raw allocation rows
+and lifetimes remain in JSON; raw copy/API rows remain in the SQLite export and
+the JSON aggregates retain their complete counts and byte totals.
+
+The allocation-event balance is deliberately named *captured outstanding
+high-water*. It does not replace the persistent roughly-1-Hz `nvidia-smi`
+process-VRAM series, `/proc/PID/status` VmRSS/VmHWM ordinary-host-memory
+series, or a dedicated pinned-memory audit. CUDA events labelled `Pinned` are
+allocator events only; the toolkit never infers pinned bytes from VmLck or
+process VRAM. Robust nested-NVTX phase attribution, per-phase device high-water,
+and allocation backtraces remain bounded follow-ups because their cross-version
+joins and symbolization would create a substantially larger profiling
+framework.
+
 After the separate NCU process, the runner requires the expected nonempty
 `.ncu-rep`, hashes it, imports its raw CSV with the same NCU binary, and checks
 the observed demangled kernel, unique capture count, and available grid/block
@@ -398,6 +436,8 @@ The deterministic
   same-name occurrences, shapes, and graph-node IDs;
 - verified NCU capture count, raw per-capture requested metric values, and any
   verification issues;
+- memory-category availability, captured allocation high-water, allocation
+  lifecycle counts, copy/memset groups, and CUDA/VMM API groups when requested;
 - NSYS/NCU target and locked-lifecycle timing plus paths to the raw reports,
   inventory, plan, stdout/stderr, and verification record.
 

--- a/docs/feature-performance-validation.md
+++ b/docs/feature-performance-validation.md
@@ -224,14 +224,37 @@ or incomplete attempt is retained and stops the study. It is never dropped or
 overwritten. After correcting an external prerequisite, an explicit
 `--retry-failed` creates the next numbered attempt:
 
-If the user interrupts an active run, the outer launcher forwards the interrupt
-to its isolated wrapper group and waits for the internal executor to persist the
-attempt. The executor tracks the direct target's process-group ID independently
-of its leader, waits for the whole group to disappear, escalates from SIGTERM to
-SIGKILL when descendants remain, always reaps the direct child, and then stops
-telemetry. Cleanup errors are recorded without discarding telemetry or the
-result. The attempt is failed in `state.json` and is never resumable as
-successful evidence; a later attempt still requires `--resume --retry-failed`.
+For every new process, the internal executor atomically records its PID plus
+Linux process start time before telemetry or target creation, then records the
+direct target's process-group ID. The outer launcher installs SIGINT and SIGTERM
+handlers before starting `flock`. On parent interruption it signals only that
+identified executor—not the whole wrapper group—so `flock` continues to hold
+the GPU lock while the executor cleans up. Repeated parent signals are recorded
+but do not interrupt cleanup again. The executor tracks the target group after
+leader exit, escalates from SIGTERM to SIGKILL while descendants remain, reaps
+the direct child, stops telemetry, records the failed result, and only then
+exits the locked lifecycle. A bounded outer fallback uses the same recorded
+target group before terminating an unresponsive wrapper.
+
+On resume, the runner reconciles `state.json` with every numbered attempt
+directory for the scheduled run. A directory with no state entry is never
+reused, even when it contains a child `result.json` reporting success. Once no
+recorded executor or target group remains, the runner records a failed recovery
+with no metric and seals every preserved file in `attempt-evidence.json`.
+Normally the recovery is also written as `interrupted-result.json`. If the
+attempt was already sealed immediately before the parent died, its immutable
+seal is verified and retained while the recovery record lives in `state.json`,
+rather than adding a file that would invalidate that seal. The seal binds the
+file inventory and its SHA-256s to the run/attempt, manifest SHA-256, and
+provenance identity fingerprint. Tampering fails closed. The next retry is
+numbered above the highest attempt in state or on disk, so repeated
+interruptions preserve attempts 1, 2, and so on. If an ownership record still
+identifies a live process, resume refuses to recycle or seal that directory and
+asks the user to retry later.
+
+Cleanup errors are recorded without discarding telemetry or the result. The
+attempt is failed in `state.json` and is never resumable as successful evidence;
+a later attempt still requires `--resume --retry-failed`.
 
 ```bash
 python3 scripts/feature-performance-validation.py run \
@@ -241,6 +264,15 @@ python3 scripts/feature-performance-validation.py run \
 Do not delete a failed attempt to make a report look complete. If the manifest
 or any provenance identity changes, start a new deterministic study rather
 than combining unlike runs.
+
+Catchable parent SIGINT/SIGTERM and normal timeout/error paths have the complete
+ownership contract above. No userspace runner can guarantee cleanup after
+SIGKILL to the entire wrapper/executor group, kernel failure, host reset, or
+power loss. After such an event, resume remains fail-closed while a recorded
+process group is live; inspect it and the GPU lock before retrying. A parent-only
+SIGKILL does not release the separately sessioned wrapper: the lock-owning
+executor continues its finite target lifecycle, and the resulting unindexed
+directory is conservatively recovered as failed afterward.
 
 ## Statistics
 
@@ -507,8 +539,11 @@ and statistics core, clean-process runner, telemetry owner, and profiler
 parser/planner. The merge-readiness pass removed duplicate provenance-spec and
 GPU-lock launch implementations and removed the legacy single-executable
 manifest shape; the JSON schema and runtime now use the same executable-role
-contract. The remaining roughly 3.5k standard-library Python lines are mostly
-fail-closed validation, artifact inventory, lifecycle cleanup, and parsers with
-separate tests. There is no copied CUDA framework or project build dependency.
+contract. The remaining standard-library Python is mostly fail-closed
+validation, artifact inventory, lifecycle cleanup, and parsers with separate
+tests. Interrupt ownership and attempt reconciliation remain in the runner
+because they extend its existing process/state contract and share its cleanup
+and provenance primitives; they do not add a parallel supervisor or artifact
+framework. There is no copied CUDA framework or project build dependency.
 Further code should enter a new module only when it has an independent
 lifecycle or artifact contract, rather than growing another parallel runner.

--- a/docs/feature-performance-validation.md
+++ b/docs/feature-performance-validation.md
@@ -42,8 +42,21 @@ work, CPU KV placement, and future features.
 ## Prepare a manifest
 
 Keep the manifest small and preregister it before collecting measurements.
-Large outputs must go to the absolute `artifact_root`, which the runner rejects
-if it is inside either source repository.
+Large outputs must go to the absolute `artifact_root`. By default the runner
+rejects a root inside either source repository. A worktree-confined study may
+set `artifact_root_policy` to `git_ignored_inside_sources`; this opt-in is
+accepted only when the root is below (and not equal to) every containing source
+root, is outside `.git`, and `git check-ignore --no-index` proves that the exact
+artifact directory itself—not a synthetic child—is ignored by every containing
+variant root. The runner repeats this check on each actual study, attempt,
+diagnostic, and profile directory immediately before a target starts, including
+on resume.
+
+This opt-in deliberately relaxes physical isolation: ignored artifacts can
+share a worktree filesystem with source and may be visible to build scripts or
+other tools that traverse ignored paths. It protects Git source identity and
+accidental commits, but is not equivalent to the default cross-worktree
+boundary. Prefer an outside-source root unless worktree confinement is required.
 
 Register every CMake-built executable after its final build, reconfiguration,
 or copy and before adding it to a manifest:
@@ -210,6 +223,15 @@ A successful run is skipped on `--resume`. A failed, timed-out, contaminated,
 or incomplete attempt is retained and stops the study. It is never dropped or
 overwritten. After correcting an external prerequisite, an explicit
 `--retry-failed` creates the next numbered attempt:
+
+If the user interrupts an active run, the outer launcher forwards the interrupt
+to its isolated wrapper group and waits for the internal executor to persist the
+attempt. The executor tracks the direct target's process-group ID independently
+of its leader, waits for the whole group to disappear, escalates from SIGTERM to
+SIGKILL when descendants remain, always reaps the direct child, and then stops
+telemetry. Cleanup errors are recorded without discarding telemetry or the
+result. The attempt is failed in `state.json` and is never resumable as
+successful evidence; a later attempt still requires `--resume --retry-failed`.
 
 ```bash
 python3 scripts/feature-performance-validation.py run \

--- a/examples/feature-performance-validation/manifest.example.json
+++ b/examples/feature-performance-validation/manifest.example.json
@@ -432,6 +432,17 @@
       "granularity": "node",
       "launch_origin": "host-only"
     },
+    "memory_evidence": {
+      "mode": "required",
+      "categories": [
+        "gpu_memory_events",
+        "allocation_lifetimes",
+        "captured_device_high_water",
+        "copy_activity",
+        "cuda_api",
+        "vmm"
+      ]
+    },
     "selector": {
       "kernel_regex": "replace-with-discovered-production-kernel-regex",
       "graph_only": true

--- a/scripts/feature-performance-validation.py
+++ b/scripts/feature-performance-validation.py
@@ -61,6 +61,7 @@ def _profile_one(
     state_path = profile_root / "profile-state.json"
     plan_path = profile_root / "ncu-plan.json"
     if state_path.exists():
+        core.validate_artifact_directory_isolation(manifest, profile_root)
         state = json.loads(state_path.read_text(encoding="utf-8"))
         if not resume:
             raise core.ValidationError(f"profile artifacts already exist; use --resume: {profile_root}")
@@ -80,6 +81,7 @@ def _profile_one(
         if resume:
             raise core.ValidationError(f"no resumable profile exists at {profile_root}")
         profile_root.mkdir(parents=True, exist_ok=False)
+        core.validate_artifact_directory_isolation(manifest, profile_root)
         state = {
             "schema_version": 1,
             "manifest_sha256": manifest_sha,
@@ -177,6 +179,7 @@ def _profile_one(
             "nvidia_smi": nvidia_smi,
             "host_load_before": core.host_load_snapshot(),
         }
+        core.validate_artifact_directory_isolation(manifest, profile_root)
         result = launch_locked_spec(spec, spec_path, TOOL_SCRIPT)
         if result.get("status") != "success":
             raise core.ValidationError(f"NSYS command failed: {result.get('error')}")
@@ -256,6 +259,7 @@ def _profile_one(
             "nvidia_smi": nvidia_smi,
             "host_load_before": core.host_load_snapshot(),
         }
+        core.validate_artifact_directory_isolation(manifest, profile_root)
         result = launch_locked_spec(spec, spec_path, TOOL_SCRIPT)
         if result.get("status") != "success":
             raise core.ValidationError(f"NCU command failed: {result.get('error')}")
@@ -435,6 +439,7 @@ def _diagnose(manifest_path: pathlib.Path, *, resume: bool) -> dict[str, Any]:
         ),
     }
     diagnostic_root.mkdir(parents=True, exist_ok=True)
+    core.validate_artifact_directory_isolation(manifest, diagnostic_root)
     core.write_json_atomic(report_path, report)
     for config in configs:
         stage = core.stage_by_id(manifest, str(config["stage"]))

--- a/scripts/feature-performance-validation.py
+++ b/scripts/feature-performance-validation.py
@@ -74,9 +74,6 @@ def _profile_one(
                 raise core.ValidationError(
                     "the preserved NCU capture is failed or unverifiable; start a new profile identity"
                 )
-            return json.loads(plan_path.read_text(encoding="utf-8"))
-        if not execute_ncu and state.get("ncu_plan_completed"):
-            return json.loads(plan_path.read_text(encoding="utf-8"))
     else:
         if resume:
             raise core.ValidationError(f"no resumable profile exists at {profile_root}")
@@ -91,6 +88,7 @@ def _profile_one(
             "screen": screen_id,
             "evidence_claim": config.get("evidence_claim", "kernel_investigation_only"),
             "nsys_discovery_completed": False,
+            "memory_evidence_status": "not_evaluated",
             "ncu_plan_completed": False,
             "ncu_executed": False,
             "ncu_verification_status": "not_executed",
@@ -124,6 +122,9 @@ def _profile_one(
     nvidia_smi = nvidia_smi_identity["path"] if nvidia_smi_identity else "nvidia-smi"
 
     sqlite_path = profile_root / "discovery.sqlite"
+    memory_capability_path = profile_root / "nsys-memory-trace-capability.json"
+    memory_config = config.get("memory_evidence")
+    memory_capability: dict[str, Any]
     if not state["nsys_discovery_completed"]:
         nsys_identity = _tool_identity("nsys")
         nsys_help = core.command_capture(
@@ -132,7 +133,10 @@ def _profile_one(
         nsys_version = core.command_capture([nsys_identity["path"], "--version"])
         if (
             nsys_help.get("returncode") != 0
-            and config["cuda_graph_trace"]["applicability"] == "required"
+            and (
+                config["cuda_graph_trace"]["applicability"] == "required"
+                or (memory_config is not None and memory_config["mode"] == "required")
+            )
         ):
             raise core.ValidationError(
                 f"cannot inspect NSYS CUDA tracing support: {nsys_help.get('stderr', nsys_help.get('error'))}"
@@ -150,6 +154,21 @@ def _profile_one(
                 "version_command": nsys_version,
             },
         )
+        memory_capability = profiler.verify_nsys_memory_trace_capability(
+            memory_config,
+            help_text=str(nsys_help.get("stdout", ""))
+            + str(nsys_help.get("stderr", "")),
+            version_text=str(nsys_version.get("stdout", ""))
+            + str(nsys_version.get("stderr", "")),
+        )
+        core.write_json_atomic(
+            memory_capability_path,
+            {
+                **memory_capability,
+                "help_command": nsys_help,
+                "version_command": nsys_version,
+            },
+        )
         identity_files_with_nsys = [*identity_files, nsys_identity]
         prefix = profile_root / "discovery"
         nsys_argv = profiler.nsys_discovery_argv(
@@ -157,6 +176,7 @@ def _profile_one(
             prefix,
             direct_harness,
             cuda_graph_trace=config["cuda_graph_trace"],
+            request_cuda_memory_usage=memory_capability["status"] == "supported",
             nsys_executable=nsys_identity["path"],
         )
         spec_path = profile_root / "nsys-run-spec.json"
@@ -213,12 +233,38 @@ def _profile_one(
             raise core.ValidationError(f"NSYS SQLite export failed: {exported.stderr.strip()}")
         state["nsys_discovery_completed"] = True
         core.write_json_atomic(state_path, state)
+    elif memory_capability_path.is_file():
+        memory_capability = json.loads(
+            memory_capability_path.read_text(encoding="utf-8")
+        )
+    elif memory_config is not None:
+        raise core.ValidationError(
+            "resumed NSYS discovery predates configured memory capability evidence; "
+            "start a new profile identity"
+        )
+    else:
+        memory_capability = {
+            "requested": False,
+            "mode": None,
+            "categories": [],
+            "status": "not_configured",
+        }
 
     discovery = profiler.parse_discovery(sqlite_path)
     discovery["graph_node_verification"] = profiler.verify_graph_node_discovery(
         discovery, config["cuda_graph_trace"]
     )
     core.write_json_atomic(profile_root / "discovery-inventory.json", discovery)
+    memory_inventory = profiler.parse_memory_inventory(sqlite_path)
+    memory_assessment = profiler.assess_memory_evidence(
+        memory_inventory, memory_config, memory_capability
+    )
+    memory_inventory["request"] = memory_capability
+    memory_inventory["assessment"] = memory_assessment
+    core.write_json_atomic(profile_root / "memory-inventory.json", memory_inventory)
+    state["memory_evidence_status"] = memory_assessment["status"]
+    core.write_json_atomic(state_path, state)
+    profiler.enforce_memory_evidence(memory_assessment)
     plan = profiler.build_ncu_plan(
         discovery,
         config["selector"],

--- a/scripts/feature-performance-validation.py
+++ b/scripts/feature-performance-validation.py
@@ -184,6 +184,10 @@ def _profile_one(
             "schema_version": 1,
             "run_id": f"profile--{stage['id']}--nsys-discovery",
             "attempt": 1,
+            "study_identity": {
+                "manifest_sha256": manifest_sha,
+                "provenance_identity_fingerprint": provenance["identity_fingerprint"],
+            },
             "resource": "gpu",
             "argv": nsys_argv,
             "environment": environment,
@@ -290,6 +294,10 @@ def _profile_one(
             "schema_version": 1,
             "run_id": f"profile--{stage['id']}--filtered-ncu",
             "attempt": 1,
+            "study_identity": {
+                "manifest_sha256": manifest_sha,
+                "provenance_identity_fingerprint": provenance["identity_fingerprint"],
+            },
             "resource": "gpu",
             "argv": command,
             "environment": environment,

--- a/scripts/feature_validation/core.py
+++ b/scripts/feature_validation/core.py
@@ -34,6 +34,15 @@ PURPOSE_ORDER = {
     "long_context_acceptance": 4,
 }
 PROFILE_TOOLS = {"nsys", "ncu"}
+MEMORY_EVIDENCE_CATEGORIES = {
+    "gpu_memory_events",
+    "allocation_lifetimes",
+    "captured_device_high_water",
+    "copy_activity",
+    "cuda_api",
+    "vmm",
+    "nvtx_ranges",
+}
 FORBIDDEN_TOKENS = {"taskset"}
 OPAQUE_WRAPPERS = {
     "bash",
@@ -588,6 +597,31 @@ def _validate_profiler_details(
     else:
         if set(graph_trace) != {"applicability", "reason"} or not graph_trace.get("reason"):
             raise ManifestError("not-applicable CUDA graph tracing requires exactly a reason")
+    memory_evidence = config.get("memory_evidence")
+    if memory_evidence is not None:
+        if not isinstance(memory_evidence, dict) or set(memory_evidence) != {
+            "mode",
+            "categories",
+        }:
+            raise ManifestError(
+                f"{label}.memory_evidence requires exactly mode and categories"
+            )
+        if memory_evidence.get("mode") not in {"required", "optional"}:
+            raise ManifestError(
+                f"{label}.memory_evidence.mode must be required or optional"
+            )
+        categories = memory_evidence.get("categories")
+        if (
+            not isinstance(categories, list)
+            or not categories
+            or any(not isinstance(item, str) for item in categories)
+            or len(set(categories)) != len(categories)
+            or not set(categories).issubset(MEMORY_EVIDENCE_CATEGORIES)
+        ):
+            raise ManifestError(
+                f"{label}.memory_evidence.categories must be a non-empty unique subset of "
+                f"{sorted(MEMORY_EVIDENCE_CATEGORIES)}"
+            )
     metrics = config.get("metrics", [])
     if not isinstance(metrics, list) or any(
         not isinstance(value, str) or not value for value in metrics
@@ -1001,6 +1035,7 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             "timeout_seconds",
             "selector",
             "cuda_graph_trace",
+            "memory_evidence",
             "metrics",
         }
         profiler_required = {
@@ -1051,7 +1086,11 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
             "selector",
             "cuda_graph_trace",
         }
-        diagnostic_keys = diagnostic_required | {"timeout_seconds", "metrics"}
+        diagnostic_keys = diagnostic_required | {
+            "timeout_seconds",
+            "memory_evidence",
+            "metrics",
+        }
         if diagnostic_required - set(config) or set(config) - diagnostic_keys:
             raise ManifestError("early diagnostic has unknown or missing fields")
         diagnostic_id = safe_slug(str(config.get("id", "")))

--- a/scripts/feature_validation/core.py
+++ b/scripts/feature_validation/core.py
@@ -616,6 +616,74 @@ def variant_executables(variant: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return executables
 
 
+def validate_artifact_directory_isolation(
+    manifest: dict[str, Any], directory: pathlib.Path
+) -> None:
+    """Fail closed unless one exact artifact directory satisfies source isolation.
+
+    The default policy keeps artifacts physically outside every declared source
+    worktree.  The opt-in policy permits an in-source directory only when Git
+    reports that directory itself ignored from every variant source root that
+    contains it.  Checking the exact path is intentional: an ignored synthetic
+    child says nothing about whether real files directly below the directory
+    would be untracked.
+    """
+    artifact_root = pathlib.Path(str(manifest["artifact_root"])).expanduser().resolve()
+    resolved_directory = directory.expanduser().resolve()
+    try:
+        resolved_directory.relative_to(artifact_root)
+    except ValueError as error:
+        raise ManifestError(
+            f"artifact directory must remain below artifact_root: {resolved_directory}"
+        ) from error
+
+    policy = str(manifest.get("artifact_root_policy", "outside_sources"))
+    seen_roots: set[pathlib.Path] = set()
+    for variant in manifest["variants"].values():
+        source_root = pathlib.Path(str(variant["source_root"])).expanduser().resolve()
+        if source_root in seen_roots:
+            continue
+        seen_roots.add(source_root)
+        try:
+            relative = resolved_directory.relative_to(source_root)
+        except ValueError:
+            continue
+        if policy != "git_ignored_inside_sources":
+            raise ManifestError(
+                "artifact_root must be outside every variant source repository unless "
+                "artifact_root_policy=git_ignored_inside_sources"
+            )
+        if not relative.parts or ".git" in relative.parts:
+            raise ManifestError("an in-source artifact directory cannot be the source root or .git")
+        ignored = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(source_root),
+                "check-ignore",
+                "--quiet",
+                "--no-index",
+                "--",
+                f"{resolved_directory}{os.sep}",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if ignored.returncode == 1:
+            raise ManifestError(
+                "artifact_root_policy=git_ignored_inside_sources requires the exact "
+                f"artifact directory to be Git-ignored by every containing variant "
+                f"source repository: {resolved_directory} is not ignored by {source_root}"
+            )
+        if ignored.returncode != 0:
+            detail = ignored.stderr.strip() or f"exit status {ignored.returncode}"
+            raise ManifestError(
+                f"cannot verify Git-ignore isolation for {resolved_directory} in "
+                f"{source_root}: {detail}"
+            )
+
+
 def validate_manifest(manifest: dict[str, Any]) -> None:
     if manifest.get("schema_version") != SCHEMA_VERSION:
         raise ManifestError(f"schema_version must be {SCHEMA_VERSION}")
@@ -628,7 +696,12 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
         raise ManifestError("study must state the 30-90 second early-decision target")
     artifact_root = manifest.get("artifact_root")
     if not isinstance(artifact_root, str) or not pathlib.Path(artifact_root).is_absolute():
-        raise ManifestError("artifact_root must be an absolute path outside the repository")
+        raise ManifestError("artifact_root must be an absolute path")
+    artifact_root_policy = manifest.get("artifact_root_policy", "outside_sources")
+    if artifact_root_policy not in {"outside_sources", "git_ignored_inside_sources"}:
+        raise ManifestError(
+            "artifact_root_policy must be outside_sources or git_ignored_inside_sources"
+        )
 
     variants = manifest.get("variants")
     if not isinstance(variants, dict) or set(variants) != {"baseline", "candidate"}:
@@ -683,12 +756,7 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
                         f"variant {name} executable role {role} provenance_sidecar path must be absolute"
                     )
                 validate_sha256(sidecar["sha256"], f"variant {name}/{role} provenance_sidecar sha256")
-        try:
-            pathlib.Path(artifact_root).resolve().relative_to(pathlib.Path(variant["source_root"]).resolve())
-        except ValueError:
-            pass
-        else:
-            raise ManifestError("artifact_root must be outside every variant source repository")
+    validate_artifact_directory_isolation(manifest, pathlib.Path(artifact_root))
 
     inputs = manifest.get("inputs", [])
     if not isinstance(inputs, list):

--- a/scripts/feature_validation/manifest.schema.json
+++ b/scripts/feature_validation/manifest.schema.json
@@ -98,6 +98,7 @@
         "timeout_seconds": { "type": "number", "exclusiveMinimum": 0, "maximum": 86400 },
         "selector": { "$ref": "#/$defs/profilerSelector" },
         "cuda_graph_trace": { "$ref": "#/$defs/cudaGraphTrace" },
+        "memory_evidence": { "$ref": "#/$defs/memoryEvidence" },
         "metrics": {
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
@@ -155,6 +156,7 @@
           "timeout_seconds": { "type": "number", "exclusiveMinimum": 0, "maximum": 86400 },
           "selector": { "$ref": "#/$defs/profilerSelector" },
           "cuda_graph_trace": { "$ref": "#/$defs/cudaGraphTrace" },
+          "memory_evidence": { "$ref": "#/$defs/memoryEvidence" },
           "metrics": {
             "type": "array",
             "items": { "type": "string", "minLength": 1 }
@@ -463,6 +465,30 @@
           }
         }
       ]
+    },
+    "memoryEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "categories"],
+      "properties": {
+        "mode": { "enum": ["required", "optional"] },
+        "categories": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "gpu_memory_events",
+              "allocation_lifetimes",
+              "captured_device_high_water",
+              "copy_activity",
+              "cuda_api",
+              "vmm",
+              "nvtx_ranges"
+            ]
+          }
+        }
+      }
     },
     "stage": {
       "type": "object",

--- a/scripts/feature_validation/manifest.schema.json
+++ b/scripts/feature_validation/manifest.schema.json
@@ -34,6 +34,9 @@
       }
     },
     "artifact_root": { "type": "string", "pattern": "^/" },
+    "artifact_root_policy": {
+      "enum": ["outside_sources", "git_ignored_inside_sources"]
+    },
     "variants": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/feature_validation/nsys_memory.py
+++ b/scripts/feature_validation/nsys_memory.py
@@ -1,0 +1,697 @@
+"""Schema-tolerant, evidence-bounded NSYS CUDA memory inventory."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sqlite3
+from collections import defaultdict
+from contextlib import closing
+from typing import Any
+
+from .core import ValidationError
+
+
+def _identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _normalized(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _column(columns: list[str], *aliases: str) -> str | None:
+    by_name = {_normalized(item): item for item in columns}
+    return next((by_name[_normalized(item)] for item in aliases if _normalized(item) in by_name), None)
+
+
+def _tables(connection: sqlite3.Connection) -> list[str]:
+    return [
+        str(row[0])
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    ]
+
+
+def _table(
+    tables: list[str], *, exact: tuple[str, ...] = (), contains: tuple[str, ...] = ()
+) -> str | None:
+    exact_normalized = {_normalized(item) for item in exact}
+    for name in tables:
+        if _normalized(name) in exact_normalized:
+            return name
+    for name in tables:
+        lowered = name.lower()
+        if contains and all(item.lower() in lowered for item in contains):
+            return name
+    return None
+
+
+def _columns(connection: sqlite3.Connection, table: str) -> list[str]:
+    return [
+        str(row[1])
+        for row in connection.execute(f"PRAGMA table_info({_identifier(table)})")
+    ]
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _enum_lookup(
+    connection: sqlite3.Connection, tables: list[str], *table_names: str
+) -> dict[int, str]:
+    table = _table(tables, exact=tuple(table_names))
+    if table is None:
+        return {}
+    columns = _columns(connection, table)
+    id_column = _column(columns, "id", "value")
+    label_column = _column(columns, "label", "name")
+    if id_column is None or label_column is None:
+        return {}
+    result: dict[int, str] = {}
+    query = (
+        f"SELECT {_identifier(id_column)}, {_identifier(label_column)} "
+        f"FROM {_identifier(table)}"
+    )
+    for key, label in connection.execute(query):
+        if key is not None and label is not None:
+            result[int(key)] = str(label)
+    return result
+
+
+def _label(value: Any, lookup: dict[int, str]) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, int) and value in lookup:
+        return lookup[value]
+    return str(value)
+
+
+def _operation(value: str | None) -> str | None:
+    lowered = (value or "").lower()
+    if "dealloc" in lowered or "free" in lowered or "release" in lowered:
+        return "deallocation"
+    if "alloc" in lowered or "create" in lowered or lowered in {"allocate", "allocation"}:
+        return "allocation"
+    return None
+
+
+def _unavailable(reason: str) -> dict[str, Any]:
+    return {"status": "unavailable", "reason": reason, "event_count": None}
+
+
+def _memory_categories(
+    connection: sqlite3.Connection, tables: list[str]
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    table = _table(
+        tables,
+        exact=("CUDA_GPU_MEMORY_USAGE_EVENTS", "CUDA_MEMORY_USAGE_EVENTS"),
+        contains=("memory", "usage", "event"),
+    )
+    if table is None:
+        reason = "NSYS export contains no CUDA GPU memory-usage event table"
+        return _unavailable(reason), _unavailable(reason), _unavailable(reason)
+    columns = _columns(connection, table)
+    selected = {
+        "start": _column(columns, "start", "timestamp", "time"),
+        "process": _column(columns, "globalPid", "processId", "pid"),
+        "device": _column(columns, "deviceId", "device"),
+        "context": _column(columns, "contextId", "context"),
+        "address": _column(columns, "address", "virtualAddress", "ptr"),
+        "bytes": _column(columns, "bytes", "size", "allocationSize"),
+        "kind": _column(columns, "memKind", "memoryKind", "memoryKindId"),
+        "operation": _column(
+            columns, "memoryOperationType", "operationType", "operation", "op"
+        ),
+        "name": _column(columns, "name", "variableName"),
+        "correlation": _column(columns, "correlationId", "correlation"),
+    }
+    required = {"start", "bytes", "kind", "operation"}
+    missing = sorted(key for key in required if selected[key] is None)
+    if missing:
+        reason = f"memory-usage table {table!r} lacks required columns {missing}"
+        return _unavailable(reason), _unavailable(reason), _unavailable(reason)
+    query_columns = list(dict.fromkeys(item for item in selected.values() if item is not None))
+    query = (
+        "SELECT "
+        + ", ".join(_identifier(item) for item in query_columns)
+        + f" FROM {_identifier(table)} ORDER BY {_identifier(selected['start'])}"
+    )
+    indexes = {name: offset for offset, name in enumerate(query_columns)}
+    operation_names = _enum_lookup(
+        connection, tables, "ENUM_CUDA_DEV_MEM_EVENT_OPER", "ENUM_CUDA_MEMORY_OPERATION"
+    )
+    kind_names = _enum_lookup(connection, tables, "ENUM_CUDA_MEM_KIND", "ENUM_CUDA_MEMORY_KIND")
+
+    def value(row: tuple[Any, ...], key: str) -> Any:
+        column = selected[key]
+        return row[indexes[column]] if column is not None else None
+
+    events: list[dict[str, Any]] = []
+    unknown_operations = 0
+    unknown_kinds = 0
+    for row in connection.execute(query):
+        raw_operation = _label(value(row, "operation"), operation_names)
+        operation = _operation(raw_operation)
+        kind = _label(value(row, "kind"), kind_names)
+        unknown_operations += operation is None
+        unknown_kinds += kind is None or (not kind_names and str(kind).isdigit())
+        events.append(
+            {
+                "start_ns": _as_int(value(row, "start")),
+                "process_id": _as_int(value(row, "process")),
+                "device_id": _as_int(value(row, "device")),
+                "context_id": _as_int(value(row, "context")),
+                "address": _as_int(value(row, "address")),
+                "bytes": _as_int(value(row, "bytes")),
+                "memory_kind": kind,
+                "operation": operation,
+                "raw_operation": raw_operation,
+                "name": value(row, "name"),
+                "correlation_id": _as_int(value(row, "correlation")),
+            }
+        )
+
+    semantic_problem = bool(events and (unknown_operations or unknown_kinds))
+    if not events and (not operation_names or not kind_names):
+        semantic_problem = True
+    memory_status = "partial" if semantic_problem else "available"
+    memory_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for event in events:
+        key = (event["memory_kind"], event["operation"])
+        group = memory_groups.setdefault(
+            key,
+            {
+                "memory_kind": event["memory_kind"],
+                "operation": event["operation"],
+                "event_count": 0,
+                "total_bytes": 0,
+                "maximum_bytes": 0,
+            },
+        )
+        group["event_count"] += 1
+        if event["bytes"] is not None:
+            group["total_bytes"] += event["bytes"]
+            group["maximum_bytes"] = max(group["maximum_bytes"], event["bytes"])
+    memory = {
+        "status": memory_status,
+        "reason": (
+            "operation or memory-kind enum semantics are unavailable for some rows"
+            if semantic_problem
+            else None
+        ),
+        "table": table,
+        "columns": selected,
+        "event_count": len(events),
+        "unknown_operation_count": unknown_operations,
+        "unknown_memory_kind_count": unknown_kinds,
+        "groups": sorted(
+            memory_groups.values(),
+            key=lambda item: (str(item["memory_kind"]), str(item["operation"])),
+        ),
+        "events": events,
+    }
+
+    if selected["address"] is None or semantic_problem:
+        lifetime = _unavailable(
+            "allocation lifetimes require address plus resolved allocation/deallocation semantics"
+        )
+    else:
+        active: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+        lifetimes: list[dict[str, Any]] = []
+        unmatched_deallocations: list[dict[str, Any]] = []
+        for event in events:
+            key = (
+                event["process_id"],
+                event["device_id"],
+                event["memory_kind"],
+                event["address"],
+            )
+            if event["operation"] == "allocation":
+                active[key].append(event)
+            elif active[key]:
+                allocated = active[key].pop()
+                lifetimes.append(
+                    {
+                        "process_id": event["process_id"],
+                        "device_id": event["device_id"],
+                        "memory_kind": event["memory_kind"],
+                        "address": event["address"],
+                        "bytes": allocated["bytes"],
+                        "allocation_start_ns": allocated["start_ns"],
+                        "deallocation_start_ns": event["start_ns"],
+                        "lifetime_ns": (
+                            event["start_ns"] - allocated["start_ns"]
+                            if event["start_ns"] is not None
+                            and allocated["start_ns"] is not None
+                            else None
+                        ),
+                    }
+                )
+            else:
+                unmatched_deallocations.append(event)
+        unmatched_allocations = [event for pending in active.values() for event in pending]
+        lifetime = {
+            "status": "available",
+            "reason": None,
+            "event_count": len(events),
+            "paired_lifetime_count": len(lifetimes),
+            "lifetimes": lifetimes,
+            "unmatched_allocation_count": len(unmatched_allocations),
+            "unmatched_allocations": unmatched_allocations,
+            "unmatched_deallocation_count": len(unmatched_deallocations),
+            "unmatched_deallocations": unmatched_deallocations,
+            "interpretation": (
+                "Unmatched allocations can be intentionally live at capture end; this inventory "
+                "does not infer a leak."
+            ),
+        }
+
+    if semantic_problem or any(event["bytes"] is None for event in events):
+        high_water = _unavailable(
+            "captured high-water requires resolved operations, memory kinds, and byte counts"
+        )
+    else:
+        outstanding: dict[tuple[Any, ...], int] = defaultdict(int)
+        peaks: dict[tuple[Any, ...], int] = defaultdict(int)
+        minima: dict[tuple[Any, ...], int] = defaultdict(int)
+        combined_outstanding: dict[tuple[Any, ...], int] = defaultdict(int)
+        combined_peaks: dict[tuple[Any, ...], int] = defaultdict(int)
+        combined_minima: dict[tuple[Any, ...], int] = defaultdict(int)
+        for event in events:
+            kind = str(event["memory_kind"] or "unknown")
+            key = (event["process_id"], event["device_id"], kind)
+            delta = int(event["bytes"] or 0)
+            signed = delta if event["operation"] == "allocation" else -delta
+            outstanding[key] += signed
+            peaks[key] = max(peaks[key], outstanding[key])
+            minima[key] = min(minima[key], outstanding[key])
+            if "device" not in kind.lower() and "array" not in kind.lower():
+                continue
+            combined_key = (event["process_id"], event["device_id"])
+            combined_outstanding[combined_key] += signed
+            combined_peaks[combined_key] = max(
+                combined_peaks[combined_key], combined_outstanding[combined_key]
+            )
+            combined_minima[combined_key] = min(
+                combined_minima[combined_key], combined_outstanding[combined_key]
+            )
+        kind_rows = [
+            {
+                "process_id": key[0],
+                "device_id": key[1],
+                "memory_kind": key[2],
+                "captured_outstanding_high_water_bytes": peaks[key],
+                "captured_final_outstanding_bytes": outstanding[key],
+                "minimum_running_balance_bytes": minima[key],
+            }
+            for key in sorted(peaks, key=lambda item: tuple(str(value) for value in item))
+        ]
+        memory["captured_outstanding_by_process_device_kind"] = kind_rows
+        combined_rows = [
+            {
+                "process_id": key[0],
+                "device_id": key[1],
+                "captured_outstanding_high_water_bytes": combined_peaks[key],
+                "captured_final_outstanding_bytes": combined_outstanding[key],
+                "minimum_running_balance_bytes": combined_minima[key],
+            }
+            for key in sorted(
+                combined_peaks, key=lambda item: tuple(str(value) for value in item)
+            )
+        ]
+        negative = any(
+            row["minimum_running_balance_bytes"] < 0 for row in combined_rows
+        )
+        high_water = {
+            "status": "partial" if negative else "available",
+            "reason": (
+                "a negative running balance proves that capture-start allocations were missing"
+                if negative
+                else None
+            ),
+            "event_count": sum(
+                1
+                for event in events
+                if "device" in str(event["memory_kind"]).lower()
+                or "array" in str(event["memory_kind"]).lower()
+            ),
+            "by_process_device": combined_rows,
+            "by_process_device_kind": [
+                row
+                for row in kind_rows
+                if "device" in row["memory_kind"].lower()
+                or "array" in row["memory_kind"].lower()
+            ],
+            "interpretation": (
+                "Captured allocation-event balance only; not nvidia-smi process VRAM, VMM virtual "
+                "reservation, or a whole-system device-memory high-water."
+            ),
+        }
+    return memory, lifetime, high_water
+
+
+def _copy_category(connection: sqlite3.Connection, tables: list[str]) -> dict[str, Any]:
+    def activity_table(kind: str) -> str | None:
+        exact = _table(tables, exact=(f"CUPTI_ACTIVITY_KIND_{kind.upper()}",))
+        if exact is not None:
+            return exact
+        return next(
+            (
+                name
+                for name in tables
+                if kind in name.lower()
+                and "activity" in name.lower()
+                and not name.lower().startswith("enum")
+            ),
+            None,
+        )
+
+    definitions = (
+        ("memcpy", activity_table("memcpy")),
+        ("memset", activity_table("memset")),
+    )
+    missing_tables = [kind for kind, table in definitions if table is None]
+    if missing_tables:
+        return _unavailable(f"NSYS export lacks activity tables for {missing_tables}")
+    copy_kinds = _enum_lookup(connection, tables, "ENUM_CUDA_MEMCPY_OPER")
+    memory_kinds = _enum_lookup(connection, tables, "ENUM_CUDA_MEM_KIND")
+    summaries: list[dict[str, Any]] = []
+    total_events = 0
+    for activity, table in definitions:
+        assert table is not None
+        columns = _columns(connection, table)
+        start = _column(columns, "start", "timestamp")
+        end = _column(columns, "end", "stop")
+        size = _column(columns, "bytes", "size")
+        if start is None or size is None:
+            return _unavailable(f"{activity} table {table!r} lacks start/bytes columns")
+        kind = _column(columns, "copyKind", "operation", "kind")
+        src = _column(columns, "srcKind", "sourceKind")
+        dst = _column(columns, "dstKind", "destinationKind")
+        mem = _column(columns, "memKind", "memoryKind")
+        selected = list(dict.fromkeys(item for item in (start, end, size, kind, src, dst, mem) if item))
+        indexes = {name: offset for offset, name in enumerate(selected)}
+        query = "SELECT " + ", ".join(_identifier(item) for item in selected) + f" FROM {_identifier(table)}"
+        grouped: dict[tuple[Any, ...], dict[str, Any]] = {}
+        for row in connection.execute(query):
+            def raw(column: str | None) -> Any:
+                return row[indexes[column]] if column is not None else None
+
+            key = (
+                activity,
+                _label(raw(kind), copy_kinds),
+                _label(raw(src), memory_kinds),
+                _label(raw(dst), memory_kinds),
+                _label(raw(mem), memory_kinds),
+            )
+            summary = grouped.setdefault(
+                key,
+                {
+                    "activity": activity,
+                    "operation": key[1],
+                    "source_memory_kind": key[2],
+                    "destination_memory_kind": key[3],
+                    "memory_kind": key[4],
+                    "event_count": 0,
+                    "total_bytes": 0,
+                    "total_duration_ns": 0,
+                    "maximum_bytes": 0,
+                },
+            )
+            row_bytes = int(raw(size))
+            summary["event_count"] += 1
+            summary["total_bytes"] += row_bytes
+            summary["maximum_bytes"] = max(summary["maximum_bytes"], row_bytes)
+            if end is not None and raw(end) is not None:
+                summary["total_duration_ns"] += int(raw(end)) - int(raw(start))
+            total_events += 1
+        summaries.extend(grouped.values())
+    return {
+        "status": "available",
+        "reason": None,
+        "event_count": total_events,
+        "groups": sorted(summaries, key=lambda item: tuple(str(value) for value in item.values())),
+        "raw_rows": "retained in the NSYS SQLite export; this JSON preserves complete counts and byte totals grouped by observed operation and memory kind",
+    }
+
+
+def _api_categories(
+    connection: sqlite3.Connection, tables: list[str], strings: dict[int, str]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    api_tables = [
+        name
+        for name in tables
+        if "cupti_activity_kind_runtime" in name.lower()
+        or "cupti_activity_kind_driver" in name.lower()
+    ]
+    if not api_tables:
+        reason = "NSYS export contains no CUDA runtime/driver API activity table"
+        return _unavailable(reason), _unavailable(reason)
+    summaries: dict[str, dict[str, Any]] = {}
+    unresolved_names = 0
+    total_events = 0
+    for table in api_tables:
+        columns = _columns(connection, table)
+        start = _column(columns, "start", "timestamp")
+        end = _column(columns, "end", "stop")
+        name = _column(columns, "name", "functionName", "apiName")
+        name_id = _column(columns, "nameId", "stringId")
+        if start is None or (name is None and name_id is None):
+            reason = f"CUDA API table {table!r} lacks start and name/nameId columns"
+            return _unavailable(reason), _unavailable(reason)
+        selected = list(dict.fromkeys(item for item in (start, end, name, name_id) if item))
+        indexes = {column: offset for offset, column in enumerate(selected)}
+        query = "SELECT " + ", ".join(_identifier(item) for item in selected) + f" FROM {_identifier(table)}"
+        for row in connection.execute(query):
+            if name is not None:
+                api_name = str(row[indexes[name]])
+            else:
+                raw_id = _as_int(row[indexes[name_id]])
+                api_name = strings.get(raw_id, "") if raw_id is not None else ""
+            if not api_name:
+                unresolved_names += 1
+                api_name = "<unresolved>"
+            summary = summaries.setdefault(
+                api_name,
+                {"name": api_name, "event_count": 0, "total_duration_ns": 0},
+            )
+            summary["event_count"] += 1
+            if end is not None and row[indexes[end]] is not None:
+                summary["total_duration_ns"] += int(row[indexes[end]]) - int(row[indexes[start]])
+            total_events += 1
+    status = "partial" if unresolved_names else "available"
+    all_summaries = sorted(summaries.values(), key=lambda item: item["name"])
+    memory_api = [
+        item
+        for item in all_summaries
+        if any(token in item["name"].lower() for token in ("mem", "malloc", "alloc", "free"))
+    ]
+    vmm_pattern = re.compile(
+        r"(?:cu|cuda)mem(?:addressreserve|addressfree|create|release|map|unmap|setaccess)",
+        re.IGNORECASE,
+    )
+    vmm_events = [item for item in all_summaries if vmm_pattern.search(item["name"])]
+    common = {
+        "status": status,
+        "reason": "some CUDA API names could not be resolved" if unresolved_names else None,
+        "table_count": len(api_tables),
+        "tables": api_tables,
+        "event_count": total_events,
+        "unresolved_name_count": unresolved_names,
+    }
+    return (
+        {**common, "all_api_groups": all_summaries, "memory_api_groups": memory_api},
+        {
+            **common,
+            "event_count": sum(item["event_count"] for item in vmm_events),
+            "groups": vmm_events,
+            "interpretation": (
+                "A zero count is evidence of no named VMM calls only when CUDA API status is "
+                "available; an absent API table is unavailable, not zero."
+            ),
+        },
+    )
+
+
+def _string_lookup(connection: sqlite3.Connection, tables: list[str]) -> dict[int, str]:
+    table = _table(tables, exact=("StringIds", "StringId"))
+    if table is None:
+        return {}
+    columns = _columns(connection, table)
+    key = _column(columns, "id")
+    value = _column(columns, "value", "string", "text")
+    if key is None or value is None:
+        return {}
+    query = f"SELECT {_identifier(key)}, {_identifier(value)} FROM {_identifier(table)}"
+    return {int(row[0]): str(row[1]) for row in connection.execute(query)}
+
+
+def _nvtx_category(
+    connection: sqlite3.Connection, tables: list[str], strings: dict[int, str]
+) -> dict[str, Any]:
+    table = next(
+        (
+            name
+            for name in tables
+            if "nvtx" in name.lower()
+            and ("event" in name.lower() or "range" in name.lower())
+            and not name.lower().startswith("enum")
+        ),
+        None,
+    )
+    if table is None:
+        return _unavailable("NSYS export contains no NVTX event/range table")
+    columns = _columns(connection, table)
+    start = _column(columns, "start", "startTimestamp", "timestamp")
+    end = _column(columns, "end", "endTimestamp", "stop")
+    text = _column(columns, "text", "message", "name")
+    text_id = _column(columns, "textId", "nameId", "stringId")
+    if start is None or (text is None and text_id is None):
+        return _unavailable(f"NVTX table {table!r} lacks start and text/textId columns")
+    selected = list(dict.fromkeys(item for item in (start, end, text, text_id) if item))
+    indexes = {column: offset for offset, column in enumerate(selected)}
+    query = (
+        "SELECT "
+        + ", ".join(_identifier(item) for item in selected)
+        + f" FROM {_identifier(table)} ORDER BY {_identifier(start)}"
+    )
+    ranges: list[dict[str, Any]] = []
+    unresolved = 0
+    for row in connection.execute(query):
+        if text is not None and row[indexes[text]] is not None:
+            label = str(row[indexes[text]])
+        else:
+            raw_id = _as_int(row[indexes[text_id]]) if text_id is not None else None
+            label = strings.get(raw_id, "") if raw_id is not None else ""
+        if not label:
+            unresolved += 1
+            label = "<unresolved>"
+        start_ns = int(row[indexes[start]])
+        end_ns = int(row[indexes[end]]) if end is not None and row[indexes[end]] is not None else None
+        ranges.append(
+            {
+                "text": label,
+                "start_ns": start_ns,
+                "end_ns": end_ns,
+                "duration_ns": end_ns - start_ns if end_ns is not None else None,
+            }
+        )
+    return {
+        "status": "partial" if unresolved else "available",
+        "reason": "some NVTX labels could not be resolved" if unresolved else None,
+        "table": table,
+        "event_count": len(ranges),
+        "unresolved_label_count": unresolved,
+        "ranges": ranges,
+        "phase_attribution": {
+            "status": "not_implemented",
+            "reason": (
+                "Robust allocation-to-nested-range attribution across NSYS schemas is a bounded "
+                "follow-up; ranges and allocation timestamps are preserved separately."
+            ),
+        },
+    }
+
+
+def parse_memory_inventory(path: pathlib.Path) -> dict[str, Any]:
+    """Inventory memory evidence without interpreting missing evidence as zero."""
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise ValidationError(f"NSYS memory inventory input is missing: {resolved}")
+    with closing(sqlite3.connect(f"file:{resolved}?mode=ro", uri=True)) as connection:
+        tables = _tables(connection)
+        strings = _string_lookup(connection, tables)
+        memory, lifetimes, high_water = _memory_categories(connection, tables)
+        copies = _copy_category(connection, tables)
+        cuda_api, vmm = _api_categories(connection, tables, strings)
+        nvtx = _nvtx_category(connection, tables, strings)
+    return {
+        "schema_version": 1,
+        "source": str(resolved),
+        "categories": {
+            "gpu_memory_events": memory,
+            "allocation_lifetimes": lifetimes,
+            "captured_device_high_water": high_water,
+            "copy_activity": copies,
+            "cuda_api": cuda_api,
+            "vmm": vmm,
+            "nvtx_ranges": nvtx,
+        },
+        "memory_boundaries": {
+            "process_vram": (
+                "Measured separately by persistent nvidia-smi telemetry; never inferred from "
+                "allocation events."
+            ),
+            "pinned_host_memory": (
+                "CUDA memory events labelled Pinned are captured allocator events, not a proof "
+                "of total process pinned bytes and never inferred from VmLck or process VRAM."
+            ),
+            "ordinary_host_memory": (
+                "Measured separately from /proc/PID/status VmRSS/VmHWM; pageable CUDA events do "
+                "not replace process host-memory telemetry."
+            ),
+            "per_phase_device_high_water": (
+                "Unavailable automatically: robust NVTX attribution is a bounded follow-up."
+            ),
+            "allocation_backtraces": (
+                "Unavailable automatically: backtrace collection and symbolization are a bounded "
+                "follow-up."
+            ),
+        },
+    }
+
+
+def assess_memory_evidence(
+    inventory: dict[str, Any],
+    config: dict[str, Any] | None,
+    capability: dict[str, Any],
+) -> dict[str, Any]:
+    """Evaluate preregistered availability; zero events remain valid available evidence."""
+    if config is None:
+        return {
+            "status": "not_requested",
+            "mode": None,
+            "required_categories": [],
+            "issues": [],
+        }
+    categories = [str(item) for item in config["categories"]]
+    issues: list[str] = []
+    if capability.get("status") != "supported":
+        issues.append("NSYS did not advertise --cuda-memory-usage support")
+    available = inventory.get("categories", {})
+    for category in categories:
+        status = available.get(category, {}).get("status", "unavailable")
+        if status != "available":
+            issues.append(f"{category} evidence is {status}, not available")
+    required = config["mode"] == "required"
+    return {
+        "status": (
+            "failed"
+            if required and issues
+            else "satisfied"
+            if not issues
+            else "optional_incomplete"
+        ),
+        "mode": config["mode"],
+        "required_categories": categories if required else [],
+        "requested_categories": categories,
+        "issues": issues,
+        "zero_is_evidence": (
+            "A zero event count satisfies availability only when the category table and required "
+            "columns/semantics were present."
+        ),
+    }
+
+
+def enforce_memory_evidence(assessment: dict[str, Any]) -> None:
+    """Fail closed only after the caller has persisted the assessment."""
+    if assessment.get("status") == "failed":
+        raise ValidationError(
+            f"required NSYS memory evidence is unavailable: {assessment.get('issues', [])}"
+        )

--- a/scripts/feature_validation/profiler.py
+++ b/scripts/feature_validation/profiler.py
@@ -19,6 +19,11 @@ from .core import (
     reject_forbidden_tokens,
     validate_direct_target,
 )
+from .nsys_memory import (
+    assess_memory_evidence,
+    enforce_memory_evidence,
+    parse_memory_inventory,
+)
 
 
 def _column(columns: list[str], *candidates: str) -> str | None:
@@ -239,6 +244,7 @@ def nsys_discovery_argv(
     direct_harness: dict[str, Any] | None = None,
     *,
     cuda_graph_trace: dict[str, Any] | None = None,
+    request_cuda_memory_usage: bool = False,
     nsys_executable: str = "nsys",
 ) -> list[str]:
     validate_native_affinity(target_argv, direct_harness)
@@ -257,6 +263,8 @@ def nsys_discovery_argv(
             "--cuda-graph-trace="
             f"{cuda_graph_trace['granularity']}:{cuda_graph_trace['launch_origin']}"
         )
+    if request_cuda_memory_usage:
+        argv.append("--cuda-memory-usage=true")
     return [*argv, *target_argv]
 
 
@@ -285,6 +293,39 @@ def verify_nsys_graph_trace_capability(
             "this NSYS version does not advertise required --cuda-graph-trace node support"
         )
     evidence["status"] = "supported" if required else "not_applicable"
+    return evidence
+
+
+def verify_nsys_memory_trace_capability(
+    config: dict[str, Any] | None,
+    *,
+    help_text: str,
+    version_text: str,
+) -> dict[str, Any]:
+    """Verify the exact NSYS binary before requesting CUDA memory events."""
+    if config is None:
+        return {
+            "requested": False,
+            "mode": None,
+            "categories": [],
+            "nsys_version": version_text.strip(),
+            "help_mentions_cuda_memory_usage": "--cuda-memory-usage" in help_text,
+            "status": "not_configured",
+        }
+    supported = "--cuda-memory-usage" in help_text
+    evidence = {
+        "requested": True,
+        "mode": config["mode"],
+        "categories": list(config["categories"]),
+        "nsys_version": version_text.strip(),
+        "help_mentions_cuda_memory_usage": supported,
+        "requested_option": "--cuda-memory-usage=true" if supported else None,
+        "status": "supported" if supported else "unsupported",
+    }
+    if config["mode"] == "required" and not supported:
+        raise ValidationError(
+            "this NSYS version does not advertise required --cuda-memory-usage support"
+        )
     return evidence
 
 
@@ -633,6 +674,7 @@ def agent_profile_summary(profile_root: pathlib.Path) -> dict[str, Any]:
     plan = read_json("ncu-plan.json")
     discovery = read_json("discovery-inventory.json")
     verification = read_json("ncu-verification.json")
+    memory_inventory = read_json("memory-inventory.json")
     state = read_json("profile-state.json")
     if plan is None or discovery is None or state is None:
         raise ValidationError(f"profiler artifacts are incomplete: {root}")
@@ -653,6 +695,49 @@ def agent_profile_summary(profile_root: pathlib.Path) -> dict[str, Any]:
         if verification is not None
         else []
     )
+    memory_summary: dict[str, Any] = {
+        "assessment_status": "legacy_unavailable",
+        "categories": {},
+    }
+    if memory_inventory is not None:
+        memory_categories = memory_inventory.get("categories", {})
+        memory_summary = {
+            "assessment_status": memory_inventory.get("assessment", {}).get(
+                "status", "not_evaluated"
+            ),
+            "issues": memory_inventory.get("assessment", {}).get("issues", []),
+            "categories": {
+                name: {
+                    "status": details.get("status", "unavailable"),
+                    "reason": details.get("reason"),
+                    "event_count": details.get("event_count"),
+                }
+                for name, details in memory_categories.items()
+            },
+            "allocation_groups": memory_categories.get("gpu_memory_events", {}).get(
+                "groups", []
+            ),
+            "captured_outstanding_by_memory_kind": memory_categories.get(
+                "gpu_memory_events", {}
+            ).get("captured_outstanding_by_process_device_kind", []),
+            "allocation_lifetime_counts": {
+                key: memory_categories.get("allocation_lifetimes", {}).get(key)
+                for key in (
+                    "paired_lifetime_count",
+                    "unmatched_allocation_count",
+                    "unmatched_deallocation_count",
+                )
+            },
+            "captured_device_high_water": memory_categories.get(
+                "captured_device_high_water", {}
+            ).get("by_process_device", []),
+            "copy_groups": memory_categories.get("copy_activity", {}).get("groups", []),
+            "memory_api_groups": memory_categories.get("cuda_api", {}).get(
+                "memory_api_groups", []
+            ),
+            "vmm_groups": memory_categories.get("vmm", {}).get("groups", []),
+            "memory_boundaries": memory_inventory.get("memory_boundaries", {}),
+        }
     return {
         "status": (
             "verified"
@@ -689,10 +774,15 @@ def agent_profile_summary(profile_root: pathlib.Path) -> dict[str, Any]:
             ),
             "captures": captures,
         },
+        "memory": memory_summary,
         "timing_seconds": timings,
         "artifacts": {
             "root": str(root),
             "discovery_inventory": str(root / "discovery-inventory.json"),
+            "memory_inventory": str(root / "memory-inventory.json"),
+            "memory_trace_capability": str(
+                root / "nsys-memory-trace-capability.json"
+            ),
             "nsys_report": str(root / "discovery.nsys-rep"),
             "nsys_stdout": str(root / "nsys-stdout.log"),
             "nsys_stderr": str(root / "nsys-stderr.log"),
@@ -745,6 +835,10 @@ def compare_agent_profiles(
         "raw_ncu_metrics": {
             "baseline": metric_inventory(baseline),
             "candidate": metric_inventory(candidate),
+        },
+        "memory_inventory": {
+            "baseline": baseline.get("memory", {}),
+            "candidate": candidate.get("memory", {}),
         },
         "timing_seconds": {
             "baseline": baseline.get("timing_seconds", {}),

--- a/scripts/feature_validation/runner.py
+++ b/scripts/feature_validation/runner.py
@@ -28,23 +28,119 @@ def _environment_command(environment: dict[str, str], argv: list[str]) -> list[s
     return ["env", "-i", *[f"{key}={environment[key]}" for key in sorted(environment)], *argv]
 
 
-def _kill_group(process: subprocess.Popen[Any]) -> None:
-    if process.poll() is not None:
-        return
+def _process_group_exists(pgid: int) -> bool:
     try:
-        os.killpg(process.pid, signal.SIGTERM)
-    except (ProcessLookupError, PermissionError):
-        process.terminate()
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_for_group_disappearance(
+    process: subprocess.Popen[Any], pgid: int, timeout: float
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        # poll() also reaps an exited direct child so its zombie cannot keep the
+        # process group observable while descendants are being checked.
+        process.poll()
+        if not _process_group_exists(pgid):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.02)
+
+
+def _cleanup_process_group(
+    process: subprocess.Popen[Any],
+    pgid: int,
+    *,
+    term_timeout: float = 3.0,
+    kill_timeout: float = 3.0,
+) -> dict[str, Any]:
+    """Terminate an entire tracked group and always reap its direct leader.
+
+    A leader may exit while descendants keep its process group alive.  Group
+    existence, rather than leader status, therefore controls TERM/KILL
+    escalation.  Cleanup failures are returned as evidence instead of raised so
+    callers can still stop telemetry and serialize the attempt result.
+    """
+    report: dict[str, Any] = {
+        "pgid": pgid,
+        "term_sent": False,
+        "kill_sent": False,
+        "group_gone": False,
+        "leader_reaped": False,
+        "errors": [],
+    }
+    if pgid == os.getpgrp():
+        report["errors"].append("refusing to signal the executor's own process group")
+    else:
+        try:
+            group_exists = _process_group_exists(pgid)
+        except (Exception, KeyboardInterrupt) as caught:
+            group_exists = True
+            report["errors"].append(
+                f"process-group existence check: {type(caught).__name__}: {caught}"
+            )
+        if group_exists:
+            try:
+                os.killpg(pgid, signal.SIGTERM)
+                report["term_sent"] = True
+            except ProcessLookupError:
+                pass
+            except (Exception, KeyboardInterrupt) as caught:
+                report["errors"].append(
+                    f"process-group SIGTERM: {type(caught).__name__}: {caught}"
+                )
+            try:
+                report["group_gone"] = _wait_for_group_disappearance(
+                    process, pgid, term_timeout
+                )
+            except (Exception, KeyboardInterrupt) as caught:
+                report["errors"].append(
+                    f"process-group TERM wait: {type(caught).__name__}: {caught}"
+                )
+        else:
+            report["group_gone"] = True
+        if not report["group_gone"]:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+                report["kill_sent"] = True
+            except ProcessLookupError:
+                pass
+            except (Exception, KeyboardInterrupt) as caught:
+                report["errors"].append(
+                    f"process-group SIGKILL: {type(caught).__name__}: {caught}"
+                )
+            try:
+                report["group_gone"] = _wait_for_group_disappearance(
+                    process, pgid, kill_timeout
+                )
+            except (Exception, KeyboardInterrupt) as caught:
+                report["errors"].append(
+                    f"process-group KILL wait: {type(caught).__name__}: {caught}"
+                )
+        if not report["group_gone"]:
+            report["errors"].append(f"process group {pgid} remained after SIGKILL")
+
     try:
-        process.wait(timeout=3.0)
-        return
-    except subprocess.TimeoutExpired:
-        pass
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError):
-        process.kill()
-    process.wait(timeout=3.0)
+        if process.poll() is None:
+            process.wait(timeout=max(0.1, kill_timeout))
+        else:
+            process.wait(timeout=0)
+        report["leader_reaped"] = True
+    except (Exception, KeyboardInterrupt) as caught:
+        report["errors"].append(f"leader reap: {type(caught).__name__}: {caught}")
+    return report
+
+
+def _append_error(error: str | None, label: str, caught: BaseException | str) -> str:
+    detail = caught if isinstance(caught, str) else f"{type(caught).__name__}: {caught}"
+    addition = f"{label}: {detail}"
+    return f"{error}; {addition}" if error else addition
 
 
 def _drain(stream: Any, chunks: list[bytes], label: str, output_lock: threading.Lock) -> None:
@@ -113,6 +209,8 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
     target_started: float | None = None
     target_finished: float | None = None
     cleanup_seconds: float | None = None
+    process_group_id: int | None = None
+    process_group_cleanup: dict[str, Any] | None = None
     try:
         phase_start = time.monotonic()
         _verify_spec_identity(spec)
@@ -131,6 +229,9 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
             stderr=subprocess.PIPE,
             start_new_session=True,
         )
+        # start_new_session makes the direct target the leader of a new process
+        # group.  Keep this identity even if that leader exits before cleanup.
+        process_group_id = process.pid
         telemetry.attach(process.pid)
         print(
             f"[feature-validation] started run={spec['run_id']} pid={process.pid} "
@@ -159,7 +260,6 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
             elapsed = time.monotonic() - start_monotonic
             if elapsed > timeout:
                 timed_out = True
-                _kill_group(process)
                 break
             if time.monotonic() >= next_heartbeat:
                 print(
@@ -168,29 +268,56 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
                 )
                 next_heartbeat += 5.0
             time.sleep(0.05)
-        returncode = process.wait()
+        returncode = process.poll()
         target_finished = time.monotonic()
-    except Exception as caught:  # the result must preserve every failed attempt
+    except (Exception, KeyboardInterrupt) as caught:  # preserve failures and reap on user interrupt
         if target_started is not None and target_finished is None:
             target_finished = time.monotonic()
         error = f"{type(caught).__name__}: {caught}"
-        if process is not None:
-            _kill_group(process)
-            returncode = process.poll()
     finally:
         cleanup_started = time.monotonic()
+        if process is not None and process_group_id is not None:
+            try:
+                process_group_cleanup = _cleanup_process_group(
+                    process,
+                    process_group_id,
+                    term_timeout=float(spec.get("cleanup_term_timeout_seconds", 3.0)),
+                    kill_timeout=float(spec.get("cleanup_kill_timeout_seconds", 3.0)),
+                )
+                returncode = process.returncode
+                for cleanup_error in process_group_cleanup["errors"]:
+                    error = _append_error(error, "process cleanup", cleanup_error)
+            except (Exception, KeyboardInterrupt) as caught:
+                # The cleanup primitive is intended to report rather than raise,
+                # but preserve the result even if an unforeseen cleanup failure
+                # escapes it.
+                error = _append_error(error, "process cleanup", caught)
+                try:
+                    returncode = process.poll()
+                except (Exception, KeyboardInterrupt) as poll_error:
+                    error = _append_error(error, "process status", poll_error)
         for thread in threads:
-            thread.join(timeout=3.0)
+            try:
+                thread.join(timeout=3.0)
+                if thread.is_alive():
+                    error = _append_error(error, "output cleanup", "drain thread did not stop")
+            except (Exception, KeyboardInterrupt) as caught:
+                error = _append_error(error, "output cleanup", caught)
         if process is not None:
             if process.stdout is not None:
-                process.stdout.close()
+                try:
+                    process.stdout.close()
+                except (Exception, KeyboardInterrupt) as caught:
+                    error = _append_error(error, "stdout cleanup", caught)
             if process.stderr is not None:
-                process.stderr.close()
+                try:
+                    process.stderr.close()
+                except (Exception, KeyboardInterrupt) as caught:
+                    error = _append_error(error, "stderr cleanup", caught)
         try:
             telemetry_report = telemetry.stop()
-        except Exception as caught:
-            telemetry_error = f"{type(caught).__name__}: {caught}"
-            error = f"{error}; telemetry cleanup: {telemetry_error}" if error else telemetry_error
+        except (Exception, KeyboardInterrupt) as caught:
+            error = _append_error(error, "telemetry cleanup", caught)
         cleanup_seconds = time.monotonic() - cleanup_started
     stdout = b"".join(stdout_chunks)
     stderr = b"".join(stderr_chunks)
@@ -232,6 +359,8 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
             ),
         },
         "pid": process.pid if process is not None else None,
+        "process_group_id": process_group_id,
+        "process_group_cleanup": process_group_cleanup,
         "returncode": returncode,
         "timed_out": timed_out,
         "error": error,
@@ -286,6 +415,66 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _run_launcher_with_interrupt_forwarding(
+    wrapper: list[str], spec: dict[str, Any]
+) -> tuple[int | None, bool, dict[str, Any] | None, list[str]]:
+    """Run an isolated wrapper and forward outer SIGINT to its whole group."""
+    process = subprocess.Popen(wrapper, start_new_session=True)
+    pgid = process.pid
+    interrupted = False
+    errors: list[str] = []
+    while process.poll() is None:
+        try:
+            process.wait(timeout=0.1)
+        except subprocess.TimeoutExpired:
+            continue
+        except KeyboardInterrupt:
+            interrupted = True
+            try:
+                os.killpg(pgid, signal.SIGINT)
+            except ProcessLookupError:
+                pass
+            except Exception as caught:
+                errors.append(f"SIGINT forward: {type(caught).__name__}: {caught}")
+
+    cleanup: dict[str, Any] | None = None
+    if interrupted:
+        # flock may exit before the internal executor finishes recording its
+        # interrupted target.  Give that executor its own TERM/KILL cleanup
+        # window, then force down any remaining launcher descendants.
+        grace = (
+            float(spec.get("cleanup_term_timeout_seconds", 3.0))
+            + float(spec.get("cleanup_kill_timeout_seconds", 3.0))
+            + 2.0
+        )
+        try:
+            group_gone = _wait_for_group_disappearance(process, pgid, grace)
+        except KeyboardInterrupt:
+            try:
+                os.killpg(pgid, signal.SIGINT)
+            except ProcessLookupError:
+                pass
+            except Exception as caught:
+                errors.append(f"repeated SIGINT forward: {type(caught).__name__}: {caught}")
+            group_gone = False
+        except Exception as caught:
+            errors.append(f"launcher group wait: {type(caught).__name__}: {caught}")
+            group_gone = False
+        if not group_gone:
+            cleanup = _cleanup_process_group(
+                process,
+                pgid,
+                term_timeout=float(spec.get("cleanup_term_timeout_seconds", 3.0)),
+                kill_timeout=float(spec.get("cleanup_kill_timeout_seconds", 3.0)),
+            )
+            errors.extend(str(item) for item in cleanup["errors"])
+    try:
+        process.wait(timeout=0)
+    except Exception as caught:
+        errors.append(f"launcher reap: {type(caught).__name__}: {caught}")
+    return process.returncode, interrupted, cleanup, errors
+
+
 def launch_locked_spec(
     spec: dict[str, Any], spec_path: pathlib.Path, tool_script: pathlib.Path
 ) -> dict[str, Any]:
@@ -306,7 +495,9 @@ def launch_locked_spec(
     spec["launcher_requested_monotonic"] = time.monotonic()
     core.write_json_atomic(spec_path, spec)
     print(f"[feature-validation] launch {core.quote_argv(wrapper)}", flush=True)
-    completed = subprocess.run(wrapper, check=False)
+    returncode, interrupted, launcher_cleanup, launcher_errors = (
+        _run_launcher_with_interrupt_forwarding(wrapper, spec)
+    )
     if result_path.is_file():
         result = json.loads(result_path.read_text(encoding="utf-8"))
         launcher_seconds = time.monotonic() - spec["launcher_requested_monotonic"]
@@ -315,14 +506,40 @@ def launch_locked_spec(
             0.0,
             launcher_seconds - float(result["timing"].get("target_process_seconds", 0.0)),
         )
+        result["launcher"] = {
+            "returncode": returncode,
+            "interrupted": interrupted,
+            "process_group_cleanup": launcher_cleanup,
+            "errors": launcher_errors,
+        }
+        if interrupted:
+            result["status"] = "failed"
+            result["error"] = _append_error(
+                result.get("error"), "outer launcher", "KeyboardInterrupt"
+            )
+        for launcher_error in launcher_errors:
+            result["status"] = "failed"
+            result["error"] = _append_error(
+                result.get("error"), "launcher cleanup", launcher_error
+            )
         core.write_json_atomic(result_path, result)
         return result
     result = {
         "run_id": spec["run_id"],
         "attempt": spec["attempt"],
         "status": "failed",
-        "error": f"flock/internal executor returned {completed.returncode} without result",
+        "error": (
+            "outer launcher KeyboardInterrupt produced no internal result"
+            if interrupted
+            else f"flock/internal executor returned {returncode} without result"
+        ),
         "gpu_lock": spec["gpu_lock"],
+        "launcher": {
+            "returncode": returncode,
+            "interrupted": interrupted,
+            "process_group_cleanup": launcher_cleanup,
+            "errors": launcher_errors,
+        },
     }
     core.write_json_atomic(result_path, result)
     return result
@@ -344,6 +561,8 @@ class StudyRunner:
         self.resume_mode = False
 
     def prepare(self, *, resume: bool) -> None:
+        if self.study_root.exists():
+            core.validate_artifact_directory_isolation(self.manifest, self.study_root)
         provenance = core.capture_provenance(self.manifest, self.manifest_sha256)
         if self.state_path.exists():
             if not resume:
@@ -360,6 +579,7 @@ class StudyRunner:
             if resume:
                 raise core.ValidationError(f"no resumable study exists at {self.study_root}")
             self.study_root.mkdir(parents=True, exist_ok=False)
+            core.validate_artifact_directory_isolation(self.manifest, self.study_root)
             core.write_json_atomic(self.study_root / "manifest.snapshot.json", self.manifest)
             core.write_json_atomic(self.study_root / "provenance.json", provenance)
             self.state = {
@@ -400,6 +620,7 @@ class StudyRunner:
         attempt = len(prior) + 1
         run_root = self.study_root / "runs" / stage["id"] / scheduled["run_id"] / f"attempt-{attempt:02d}"
         run_root.mkdir(parents=True, exist_ok=False)
+        core.validate_artifact_directory_isolation(self.manifest, run_root)
         argv, environment = core.command_for_run(self.manifest, stage, scheduled)
         context = {
             "artifact_dir": run_root,
@@ -450,10 +671,12 @@ class StudyRunner:
             "host_load_before": core.host_load_snapshot(),
         }
         if stage["resource"] == "gpu":
+            core.validate_artifact_directory_isolation(self.manifest, run_root)
             result = launch_locked_spec(spec, spec_path, self.tool_script)
         else:
             spec["gpu_lock"] = None
             core.write_json_atomic(spec_path, spec)
+            core.validate_artifact_directory_isolation(self.manifest, run_root)
             result = execute_run_spec(spec)
         prior.append(result)
         self.state["runs"][run_id] = prior

--- a/scripts/feature_validation/runner.py
+++ b/scripts/feature_validation/runner.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import pathlib
+import re
 import signal
 import subprocess
 import sys
@@ -39,18 +40,89 @@ def _process_group_exists(pgid: int) -> bool:
 
 
 def _wait_for_group_disappearance(
-    process: subprocess.Popen[Any], pgid: int, timeout: float
+    pgid: int,
+    timeout: float,
+    process: subprocess.Popen[Any] | None = None,
 ) -> bool:
     deadline = time.monotonic() + timeout
     while True:
         # poll() also reaps an exited direct child so its zombie cannot keep the
         # process group observable while descendants are being checked.
-        process.poll()
+        if process is not None:
+            process.poll()
         if not _process_group_exists(pgid):
             return True
         if time.monotonic() >= deadline:
             return False
         time.sleep(0.02)
+
+
+def _terminate_process_group(
+    pgid: int,
+    *,
+    process: subprocess.Popen[Any] | None = None,
+    term_timeout: float = 3.0,
+    kill_timeout: float = 3.0,
+) -> dict[str, Any]:
+    """Terminate an entire tracked group, including descendants after leader exit."""
+    report: dict[str, Any] = {
+        "pgid": pgid,
+        "term_sent": False,
+        "kill_sent": False,
+        "group_gone": False,
+        "errors": [],
+    }
+    if pgid == os.getpgrp():
+        report["errors"].append("refusing to signal the executor's own process group")
+        return report
+    try:
+        group_exists = _process_group_exists(pgid)
+    except (Exception, KeyboardInterrupt) as caught:
+        group_exists = True
+        report["errors"].append(
+            f"process-group existence check: {type(caught).__name__}: {caught}"
+        )
+    if group_exists:
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+            report["term_sent"] = True
+        except ProcessLookupError:
+            pass
+        except (Exception, KeyboardInterrupt) as caught:
+            report["errors"].append(
+                f"process-group SIGTERM: {type(caught).__name__}: {caught}"
+            )
+        try:
+            report["group_gone"] = _wait_for_group_disappearance(
+                pgid, term_timeout, process
+            )
+        except (Exception, KeyboardInterrupt) as caught:
+            report["errors"].append(
+                f"process-group TERM wait: {type(caught).__name__}: {caught}"
+            )
+    else:
+        report["group_gone"] = True
+    if not report["group_gone"]:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+            report["kill_sent"] = True
+        except ProcessLookupError:
+            pass
+        except (Exception, KeyboardInterrupt) as caught:
+            report["errors"].append(
+                f"process-group SIGKILL: {type(caught).__name__}: {caught}"
+            )
+        try:
+            report["group_gone"] = _wait_for_group_disappearance(
+                pgid, kill_timeout, process
+            )
+        except (Exception, KeyboardInterrupt) as caught:
+            report["errors"].append(
+                f"process-group KILL wait: {type(caught).__name__}: {caught}"
+            )
+    if not report["group_gone"]:
+        report["errors"].append(f"process group {pgid} remained after SIGKILL")
+    return report
 
 
 def _cleanup_process_group(
@@ -67,64 +139,13 @@ def _cleanup_process_group(
     escalation.  Cleanup failures are returned as evidence instead of raised so
     callers can still stop telemetry and serialize the attempt result.
     """
-    report: dict[str, Any] = {
-        "pgid": pgid,
-        "term_sent": False,
-        "kill_sent": False,
-        "group_gone": False,
-        "leader_reaped": False,
-        "errors": [],
-    }
-    if pgid == os.getpgrp():
-        report["errors"].append("refusing to signal the executor's own process group")
-    else:
-        try:
-            group_exists = _process_group_exists(pgid)
-        except (Exception, KeyboardInterrupt) as caught:
-            group_exists = True
-            report["errors"].append(
-                f"process-group existence check: {type(caught).__name__}: {caught}"
-            )
-        if group_exists:
-            try:
-                os.killpg(pgid, signal.SIGTERM)
-                report["term_sent"] = True
-            except ProcessLookupError:
-                pass
-            except (Exception, KeyboardInterrupt) as caught:
-                report["errors"].append(
-                    f"process-group SIGTERM: {type(caught).__name__}: {caught}"
-                )
-            try:
-                report["group_gone"] = _wait_for_group_disappearance(
-                    process, pgid, term_timeout
-                )
-            except (Exception, KeyboardInterrupt) as caught:
-                report["errors"].append(
-                    f"process-group TERM wait: {type(caught).__name__}: {caught}"
-                )
-        else:
-            report["group_gone"] = True
-        if not report["group_gone"]:
-            try:
-                os.killpg(pgid, signal.SIGKILL)
-                report["kill_sent"] = True
-            except ProcessLookupError:
-                pass
-            except (Exception, KeyboardInterrupt) as caught:
-                report["errors"].append(
-                    f"process-group SIGKILL: {type(caught).__name__}: {caught}"
-                )
-            try:
-                report["group_gone"] = _wait_for_group_disappearance(
-                    process, pgid, kill_timeout
-                )
-            except (Exception, KeyboardInterrupt) as caught:
-                report["errors"].append(
-                    f"process-group KILL wait: {type(caught).__name__}: {caught}"
-                )
-        if not report["group_gone"]:
-            report["errors"].append(f"process group {pgid} remained after SIGKILL")
+    report = _terminate_process_group(
+        pgid,
+        process=process,
+        term_timeout=term_timeout,
+        kill_timeout=kill_timeout,
+    )
+    report["leader_reaped"] = False
 
     try:
         if process.poll() is None:
@@ -135,6 +156,65 @@ def _cleanup_process_group(
     except (Exception, KeyboardInterrupt) as caught:
         report["errors"].append(f"leader reap: {type(caught).__name__}: {caught}")
     return report
+
+
+def _process_identity(pid: int) -> dict[str, int | None]:
+    """Return a PID plus Linux start ticks so stale ownership cannot hit PID reuse."""
+    start_ticks: int | None = None
+    stat_path = pathlib.Path(f"/proc/{pid}/stat")
+    try:
+        raw = stat_path.read_text(encoding="utf-8")
+        closing = raw.rfind(")")
+        fields = raw[closing + 2 :].split()
+        start_ticks = int(fields[19])
+    except (OSError, ValueError, IndexError):
+        pass
+    return {"pid": pid, "start_time_ticks": start_ticks}
+
+
+def _process_identity_is_live(identity: dict[str, Any] | None) -> bool:
+    if not identity:
+        return False
+    pid = int(identity["pid"])
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        pass
+    expected = identity.get("start_time_ticks")
+    return expected is None or _process_identity(pid).get("start_time_ticks") == expected
+
+
+def _lifecycle_path(spec: dict[str, Any]) -> pathlib.Path | None:
+    value = spec.get("lifecycle_path")
+    if value is None:
+        return None
+    path = pathlib.Path(str(value)).resolve()
+    result_parent = pathlib.Path(spec["result_path"]).resolve().parent
+    if path.parent != result_parent:
+        raise core.ValidationError("lifecycle ownership record must stay in the attempt directory")
+    return path
+
+
+def _write_lifecycle(path: pathlib.Path | None, lifecycle: dict[str, Any]) -> None:
+    if path is None:
+        return
+    lifecycle["updated_utc"] = core.utc_now()
+    core.write_json_atomic(path, lifecycle)
+
+
+def _read_lifecycle(spec: dict[str, Any]) -> dict[str, Any] | None:
+    path = _lifecycle_path(spec)
+    if path is None or not path.is_file():
+        return None
+    lifecycle = json.loads(path.read_text(encoding="utf-8"))
+    if lifecycle.get("run_id") != spec["run_id"] or lifecycle.get("attempt") != spec["attempt"]:
+        raise core.ValidationError("lifecycle ownership record does not match this attempt")
+    expected_identity = spec.get("study_identity")
+    if expected_identity is not None and lifecycle.get("study_identity") != expected_identity:
+        raise core.ProvenanceError("lifecycle ownership provenance does not match this study")
+    return lifecycle
 
 
 def _append_error(error: str | None, label: str, caught: BaseException | str) -> str:
@@ -211,7 +291,20 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
     cleanup_seconds: float | None = None
     process_group_id: int | None = None
     process_group_cleanup: dict[str, Any] | None = None
+    lifecycle_path: pathlib.Path | None = None
+    lifecycle: dict[str, Any] = {
+        "schema_version": 1,
+        "run_id": spec["run_id"],
+        "attempt": spec["attempt"],
+        "study_identity": spec.get("study_identity"),
+        "executor": _process_identity(os.getpid()),
+        "target": None,
+        "state": "executor_started",
+        "created_utc": core.utc_now(),
+    }
     try:
+        lifecycle_path = _lifecycle_path(spec)
+        _write_lifecycle(lifecycle_path, lifecycle)
         phase_start = time.monotonic()
         _verify_spec_identity(spec)
         identity_seconds = time.monotonic() - phase_start
@@ -232,6 +325,12 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
         # start_new_session makes the direct target the leader of a new process
         # group.  Keep this identity even if that leader exits before cleanup.
         process_group_id = process.pid
+        lifecycle["target"] = {
+            **_process_identity(process.pid),
+            "process_group_id": process_group_id,
+        }
+        lifecycle["state"] = "target_running"
+        _write_lifecycle(lifecycle_path, lifecycle)
         telemetry.attach(process.pid)
         print(
             f"[feature-validation] started run={spec['run_id']} pid={process.pid} "
@@ -318,6 +417,13 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
             telemetry_report = telemetry.stop()
         except (Exception, KeyboardInterrupt) as caught:
             error = _append_error(error, "telemetry cleanup", caught)
+        lifecycle["state"] = "cleanup_complete"
+        lifecycle["process_group_cleanup"] = process_group_cleanup
+        lifecycle["telemetry_stopped"] = telemetry_report is not None
+        try:
+            _write_lifecycle(lifecycle_path, lifecycle)
+        except (Exception, KeyboardInterrupt) as caught:
+            error = _append_error(error, "lifecycle cleanup record", caught)
         cleanup_seconds = time.monotonic() - cleanup_started
     stdout = b"".join(stdout_chunks)
     stderr = b"".join(stderr_chunks)
@@ -342,6 +448,7 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
         "run_id": spec["run_id"],
         "status": status,
         "attempt": spec["attempt"],
+        "study_identity": spec.get("study_identity"),
         "schedule": spec.get("schedule"),
         "started_utc": started,
         "finished_utc": core.utc_now(),
@@ -417,62 +524,142 @@ def execute_run_spec(spec: dict[str, Any]) -> dict[str, Any]:
 
 def _run_launcher_with_interrupt_forwarding(
     wrapper: list[str], spec: dict[str, Any]
-) -> tuple[int | None, bool, dict[str, Any] | None, list[str]]:
-    """Run an isolated wrapper and forward outer SIGINT to its whole group."""
-    process = subprocess.Popen(wrapper, start_new_session=True)
-    pgid = process.pid
+) -> tuple[
+    int | None,
+    bool,
+    dict[str, Any] | None,
+    dict[str, Any] | None,
+    list[str],
+    list[str],
+]:
+    """Keep flock alive while an identified executor cleans its target group."""
     interrupted = False
+    forwarded = False
     errors: list[str] = []
-    while process.poll() is None:
-        try:
-            process.wait(timeout=0.1)
-        except subprocess.TimeoutExpired:
-            continue
-        except KeyboardInterrupt:
-            interrupted = True
-            try:
-                os.killpg(pgid, signal.SIGINT)
-            except ProcessLookupError:
-                pass
-            except Exception as caught:
-                errors.append(f"SIGINT forward: {type(caught).__name__}: {caught}")
+    interrupt_signals: list[str] = []
+    pending_signals: list[int] = []
+    old_handlers: dict[int, Any] = {}
+    can_install_handlers = threading.current_thread() is threading.main_thread()
+
+    def capture_interrupt(signum: int, _frame: Any) -> None:
+        pending_signals.append(signum)
+
+    if can_install_handlers:
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            old_handlers[signum] = signal.getsignal(signum)
+            signal.signal(signum, capture_interrupt)
+
+    try:
+        process = subprocess.Popen(wrapper, start_new_session=True)
+    except BaseException:
+        if can_install_handlers:
+            for signum, handler in old_handlers.items():
+                signal.signal(signum, handler)
+        raise
+    pgid = process.pid
 
     cleanup: dict[str, Any] | None = None
-    if interrupted:
-        # flock may exit before the internal executor finishes recording its
-        # interrupted target.  Give that executor its own TERM/KILL cleanup
-        # window, then force down any remaining launcher descendants.
-        grace = (
-            float(spec.get("cleanup_term_timeout_seconds", 3.0))
-            + float(spec.get("cleanup_kill_timeout_seconds", 3.0))
-            + 2.0
-        )
-        try:
-            group_gone = _wait_for_group_disappearance(process, pgid, grace)
-        except KeyboardInterrupt:
+    owned_target_cleanup: dict[str, Any] | None = None
+    interruption_deadline: float | None = None
+    try:
+        while process.poll() is None:
             try:
-                os.killpg(pgid, signal.SIGINT)
-            except ProcessLookupError:
+                process.wait(timeout=0.1)
+            except subprocess.TimeoutExpired:
                 pass
-            except Exception as caught:
-                errors.append(f"repeated SIGINT forward: {type(caught).__name__}: {caught}")
-            group_gone = False
-        except Exception as caught:
-            errors.append(f"launcher group wait: {type(caught).__name__}: {caught}")
-            group_gone = False
-        if not group_gone:
-            cleanup = _cleanup_process_group(
-                process,
-                pgid,
-                term_timeout=float(spec.get("cleanup_term_timeout_seconds", 3.0)),
-                kill_timeout=float(spec.get("cleanup_kill_timeout_seconds", 3.0)),
-            )
-            errors.extend(str(item) for item in cleanup["errors"])
+            except KeyboardInterrupt:
+                pending_signals.append(signal.SIGINT)
+
+            if pending_signals:
+                interrupted = True
+                interrupt_signals.extend(signal.Signals(item).name for item in pending_signals)
+                pending_signals.clear()
+            if interrupted and not forwarded:
+                # The lifecycle record is written before telemetry or target
+                # creation.  Wait briefly for an executor that has just crossed
+                # the flock boundary; if no record appears, the wrapper is only
+                # waiting for the lock and is safe to cancel as a group.
+                owner_deadline = time.monotonic() + 0.5
+                lifecycle = _read_lifecycle(spec)
+                while lifecycle is None and process.poll() is None and time.monotonic() < owner_deadline:
+                    time.sleep(0.02)
+                    lifecycle = _read_lifecycle(spec)
+                if lifecycle is None:
+                    cleanup = _cleanup_process_group(
+                        process,
+                        pgid,
+                        term_timeout=float(spec.get("cleanup_term_timeout_seconds", 3.0)),
+                        kill_timeout=float(spec.get("cleanup_kill_timeout_seconds", 3.0)),
+                    )
+                    errors.extend(str(item) for item in cleanup["errors"])
+                else:
+                    executor = lifecycle.get("executor")
+                    if not _process_identity_is_live(executor):
+                        errors.append("owned executor disappeared before interrupt forwarding")
+                    else:
+                        try:
+                            os.kill(int(executor["pid"]), signal.SIGINT)
+                        except ProcessLookupError:
+                            errors.append("owned executor disappeared during interrupt forwarding")
+                        except Exception as caught:
+                            errors.append(
+                                f"executor SIGINT forward: {type(caught).__name__}: {caught}"
+                            )
+                forwarded = True
+                interruption_deadline = time.monotonic() + (
+                    float(spec.get("cleanup_term_timeout_seconds", 3.0))
+                    + float(spec.get("cleanup_kill_timeout_seconds", 3.0))
+                    + 5.0
+                )
+            if (
+                interrupted
+                and process.poll() is None
+                and interruption_deadline is not None
+                and time.monotonic() >= interruption_deadline
+            ):
+                # The normal path leaves the lock-owning wrapper untouched until
+                # the executor has reaped its target.  If that executor stalls,
+                # use its provenance-bound target PGID as the final fallback,
+                # then tear down the wrapper only after the target group is gone.
+                lifecycle = _read_lifecycle(spec)
+                target = lifecycle.get("target") if lifecycle else None
+                if target and target.get("process_group_id") is not None:
+                    owned_target_cleanup = _terminate_process_group(
+                        int(target["process_group_id"]),
+                        term_timeout=float(spec.get("cleanup_term_timeout_seconds", 3.0)),
+                        kill_timeout=float(spec.get("cleanup_kill_timeout_seconds", 3.0)),
+                    )
+                    errors.extend(
+                        f"owned target cleanup: {item}"
+                        for item in owned_target_cleanup["errors"]
+                    )
+                cleanup = _cleanup_process_group(
+                    process,
+                    pgid,
+                    term_timeout=float(spec.get("cleanup_term_timeout_seconds", 3.0)),
+                    kill_timeout=float(spec.get("cleanup_kill_timeout_seconds", 3.0)),
+                )
+                errors.extend(str(item) for item in cleanup["errors"])
+    finally:
+        if pending_signals:
+            interrupted = True
+            interrupt_signals.extend(signal.Signals(item).name for item in pending_signals)
+            pending_signals.clear()
+        if can_install_handlers:
+            for signum, handler in old_handlers.items():
+                signal.signal(signum, handler)
     try:
         process.wait(timeout=0)
     except Exception as caught:
         errors.append(f"launcher reap: {type(caught).__name__}: {caught}")
-    return process.returncode, interrupted, cleanup, errors
+    return (
+        process.returncode,
+        interrupted,
+        cleanup,
+        owned_target_cleanup,
+        errors,
+        interrupt_signals,
+    )
 
 
 def launch_locked_spec(
@@ -480,6 +667,10 @@ def launch_locked_spec(
 ) -> dict[str, Any]:
     """Launch one internal lifecycle under the required whole-command GPU lock."""
     result_path = pathlib.Path(spec["result_path"])
+    spec.setdefault(
+        "lifecycle_path",
+        str(result_path.with_name(f"{result_path.stem}-lifecycle-owner.json")),
+    )
     if spec_path.exists() or result_path.exists():
         raise core.ValidationError(
             f"refusing to overwrite an existing attempt: {spec_path} / {result_path}"
@@ -495,7 +686,14 @@ def launch_locked_spec(
     spec["launcher_requested_monotonic"] = time.monotonic()
     core.write_json_atomic(spec_path, spec)
     print(f"[feature-validation] launch {core.quote_argv(wrapper)}", flush=True)
-    returncode, interrupted, launcher_cleanup, launcher_errors = (
+    (
+        returncode,
+        interrupted,
+        launcher_cleanup,
+        owned_target_cleanup,
+        launcher_errors,
+        interrupt_signals,
+    ) = (
         _run_launcher_with_interrupt_forwarding(wrapper, spec)
     )
     if result_path.is_file():
@@ -509,13 +707,17 @@ def launch_locked_spec(
         result["launcher"] = {
             "returncode": returncode,
             "interrupted": interrupted,
+            "interrupt_signals": interrupt_signals,
             "process_group_cleanup": launcher_cleanup,
+            "owned_target_fallback_cleanup": owned_target_cleanup,
             "errors": launcher_errors,
         }
         if interrupted:
             result["status"] = "failed"
             result["error"] = _append_error(
-                result.get("error"), "outer launcher", "KeyboardInterrupt"
+                result.get("error"),
+                "outer launcher",
+                "parent interruption (" + ", ".join(interrupt_signals or ["SIGINT"]) + ")",
             )
         for launcher_error in launcher_errors:
             result["status"] = "failed"
@@ -529,7 +731,7 @@ def launch_locked_spec(
         "attempt": spec["attempt"],
         "status": "failed",
         "error": (
-            "outer launcher KeyboardInterrupt produced no internal result"
+            "outer launcher parent interruption produced no internal result"
             if interrupted
             else f"flock/internal executor returned {returncode} without result"
         ),
@@ -537,12 +739,66 @@ def launch_locked_spec(
         "launcher": {
             "returncode": returncode,
             "interrupted": interrupted,
+            "interrupt_signals": interrupt_signals,
             "process_group_cleanup": launcher_cleanup,
+            "owned_target_fallback_cleanup": owned_target_cleanup,
             "errors": launcher_errors,
         },
     }
     core.write_json_atomic(result_path, result)
     return result
+
+
+_ATTEMPT_DIRECTORY = re.compile(r"attempt-([0-9]+)")
+_ATTEMPT_EVIDENCE_NAME = "attempt-evidence.json"
+_RECOVERED_RESULT_NAME = "interrupted-result.json"
+
+
+def _attempt_file_inventory(attempt_root: pathlib.Path) -> list[dict[str, Any]]:
+    """Hash every preserved attempt artifact except the self-referential seal."""
+    inventory: list[dict[str, Any]] = []
+    for path in sorted(
+        attempt_root.rglob("*"), key=lambda item: str(item.relative_to(attempt_root))
+    ):
+        relative = str(path.relative_to(attempt_root))
+        if relative == _ATTEMPT_EVIDENCE_NAME or path.is_dir():
+            continue
+        if path.is_symlink():
+            target = os.fsencode(os.readlink(path))
+            inventory.append(
+                {
+                    "path": relative,
+                    "kind": "symlink",
+                    "sha256": hashlib.sha256(target).hexdigest(),
+                }
+            )
+            continue
+        if not path.is_file():
+            raise core.ValidationError(
+                f"attempt evidence contains unsupported non-file artifact: {path}"
+            )
+        before = core.stat_identity(path)
+        digest = core.sha256_file(path)
+        after = core.stat_identity(path)
+        if before != after:
+            raise core.ValidationError(f"attempt artifact changed while being sealed: {path}")
+        inventory.append(
+            {
+                "path": relative,
+                "kind": "file",
+                "sha256": digest,
+                **after,
+            }
+        )
+    return inventory
+
+
+def _attempt_evidence_reference(path: pathlib.Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "sha256": core.sha256_file(path),
+        "kind": "failed_or_interrupted_attempt_seal",
+    }
 
 
 class StudyRunner:
@@ -600,6 +856,246 @@ class StudyRunner:
         self.state["updated_utc"] = core.utc_now()
         core.write_json_atomic(self.state_path, self.state)
 
+    def _study_identity(self) -> dict[str, str]:
+        assert self.provenance is not None
+        return {
+            "manifest_sha256": self.manifest_sha256,
+            "provenance_identity_fingerprint": self.provenance["identity_fingerprint"],
+        }
+
+    def _seal_failed_attempt(
+        self,
+        run_root: pathlib.Path,
+        run_id: str,
+        attempt: int,
+    ) -> dict[str, Any]:
+        evidence_path = run_root / _ATTEMPT_EVIDENCE_NAME
+        if evidence_path.exists():
+            evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+            if (
+                evidence.get("run_id") != run_id
+                or evidence.get("attempt") != attempt
+                or evidence.get("study_identity") != self._study_identity()
+                or pathlib.Path(str(evidence.get("artifact_directory", ""))).resolve()
+                != run_root.resolve()
+            ):
+                raise core.ProvenanceError(
+                    f"failed-attempt evidence identity mismatch: {evidence_path}"
+                )
+            observed_inventory = _attempt_file_inventory(run_root)
+            if (
+                evidence.get("inventory_sha256")
+                != core.canonical_sha256(observed_inventory)
+                or evidence.get("files") != observed_inventory
+            ):
+                raise core.ProvenanceError(
+                    f"preserved failed-attempt evidence changed: {run_root}"
+                )
+            return _attempt_evidence_reference(evidence_path)
+
+        inventory = _attempt_file_inventory(run_root)
+        evidence = {
+            "schema_version": 1,
+            "kind": "failed_or_interrupted_attempt_evidence",
+            "run_id": run_id,
+            "attempt": attempt,
+            "artifact_directory": str(run_root.resolve()),
+            "study_identity": self._study_identity(),
+            "sealed_utc": core.utc_now(),
+            "files": inventory,
+            "inventory_sha256": core.canonical_sha256(inventory),
+        }
+        core.write_json_atomic(evidence_path, evidence)
+        return _attempt_evidence_reference(evidence_path)
+
+    def _assert_incomplete_attempt_inactive(self, run_root: pathlib.Path) -> None:
+        lifecycle_path = run_root / "lifecycle-owner.json"
+        if not lifecycle_path.is_file():
+            return
+        try:
+            lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise core.ProvenanceError(
+                f"cannot establish ownership of incomplete attempt {run_root}: {error}"
+            ) from error
+        identity = lifecycle.get("study_identity")
+        if identity is not None and identity != self._study_identity():
+            raise core.ProvenanceError(
+                f"incomplete attempt lifecycle provenance mismatch: {lifecycle_path}"
+            )
+        if _process_identity_is_live(lifecycle.get("executor")):
+            raise core.ValidationError(
+                f"incomplete attempt still has a live owned executor; retry later: {run_root}"
+            )
+        target = lifecycle.get("target")
+        if target and _process_group_exists(int(target["process_group_id"])):
+            raise core.ValidationError(
+                f"incomplete attempt still has a live owned target group; retry later: {run_root}"
+            )
+
+    def _recover_incomplete_attempt(
+        self,
+        run_root: pathlib.Path,
+        run_id: str,
+        attempt: int,
+        scheduled: dict[str, Any],
+    ) -> dict[str, Any]:
+        self._assert_incomplete_attempt_inactive(run_root)
+        preexisting_evidence: dict[str, Any] | None = None
+        if (run_root / _ATTEMPT_EVIDENCE_NAME).is_file():
+            preexisting_evidence = self._seal_failed_attempt(
+                run_root, run_id, attempt
+            )
+        spec_path = run_root / "run-spec.json"
+        preserved_spec: dict[str, Any] | None = None
+        if spec_path.is_file():
+            spec = json.loads(spec_path.read_text(encoding="utf-8"))
+            if spec.get("run_id") != run_id or spec.get("attempt") != attempt:
+                raise core.ProvenanceError(
+                    f"incomplete run spec does not match its deterministic directory: {spec_path}"
+                )
+            spec_identity = spec.get("study_identity")
+            if spec_identity is not None and spec_identity != self._study_identity():
+                raise core.ProvenanceError(
+                    f"incomplete run spec provenance mismatch: {spec_path}"
+                )
+            preserved_spec = {
+                "path": str(spec_path),
+                "sha256": core.sha256_file(spec_path),
+                "study_identity_present": spec_identity is not None,
+            }
+
+        child_result_path = run_root / "result.json"
+        preserved_child_result: dict[str, Any] | None = None
+        if child_result_path.is_file():
+            child_result = json.loads(child_result_path.read_text(encoding="utf-8"))
+            if (
+                child_result.get("run_id") != run_id
+                or child_result.get("attempt") != attempt
+            ):
+                raise core.ProvenanceError(
+                    "unindexed child result does not match its deterministic directory: "
+                    f"{child_result_path}"
+                )
+            preserved_child_result = {
+                "path": str(child_result_path),
+                "sha256": core.sha256_file(child_result_path),
+                "reported_status": child_result.get("status"),
+                "metric_disposition": "preserved_not_counted",
+            }
+
+        recovered_path = run_root / _RECOVERED_RESULT_NAME
+        if recovered_path.exists():
+            recovered = json.loads(recovered_path.read_text(encoding="utf-8"))
+            if (
+                recovered.get("run_id") != run_id
+                or recovered.get("attempt") != attempt
+                or recovered.get("study_identity") != self._study_identity()
+                or recovered.get("status") != "failed"
+            ):
+                raise core.ProvenanceError(
+                    f"recovered interruption record identity mismatch: {recovered_path}"
+                )
+        else:
+            recovered = {
+                "schema_version": 1,
+                "run_id": run_id,
+                "attempt": attempt,
+                "schedule": scheduled,
+                "status": "failed",
+                "error": (
+                    "recovered an unindexed attempt directory after parent interruption; "
+                    "all artifacts are preserved and no metric is counted"
+                ),
+                "recovered_utc": core.utc_now(),
+                "study_identity": self._study_identity(),
+                "artifact_directory": str(run_root.resolve()),
+                "preserved_run_spec": preserved_spec,
+                "preserved_child_result": preserved_child_result,
+                "metric_disposition": "not_counted_interrupted_attempt",
+            }
+            if preexisting_evidence is None:
+                core.write_json_atomic(recovered_path, recovered)
+            else:
+                recovered["recovery_record"] = (
+                    "state_only_to_preserve_preexisting_immutable_attempt_seal"
+                )
+        recovered["attempt_evidence"] = (
+            preexisting_evidence
+            or self._seal_failed_attempt(run_root, run_id, attempt)
+        )
+        return recovered
+
+    def _reconcile_attempts(
+        self,
+        stage: dict[str, Any],
+        scheduled: dict[str, Any],
+        run_id: str,
+    ) -> tuple[list[dict[str, Any]], int]:
+        assert self.state is not None
+        run_base = self.study_root / "runs" / stage["id"] / scheduled["run_id"]
+        prior = self.state["runs"].get(run_id, [])
+        state_changed = False
+        by_attempt: dict[int, dict[str, Any]] = {}
+        for record in prior:
+            attempt = int(record.get("attempt", 0))
+            if attempt <= 0 or attempt in by_attempt:
+                raise core.ProvenanceError(f"invalid or duplicate attempt number for {run_id}")
+            by_attempt[attempt] = record
+
+        disk_attempts: dict[int, pathlib.Path] = {}
+        if run_base.is_dir():
+            for child in run_base.iterdir():
+                if not child.is_dir() or not child.name.startswith("attempt-"):
+                    continue
+                match = _ATTEMPT_DIRECTORY.fullmatch(child.name)
+                if match is None:
+                    raise core.ProvenanceError(
+                        f"unrecognized attempt directory cannot be reused: {child}"
+                    )
+                number = int(match.group(1))
+                if child.name != f"attempt-{number:02d}":
+                    raise core.ProvenanceError(
+                        f"noncanonical attempt directory cannot be reused: {child}"
+                    )
+                if number <= 0 or number in disk_attempts:
+                    raise core.ProvenanceError(f"invalid duplicate attempt directory: {child}")
+                disk_attempts[number] = child
+
+        for attempt, record in sorted(by_attempt.items()):
+            run_root = run_base / f"attempt-{attempt:02d}"
+            if disk_attempts.get(attempt) != run_root:
+                raise core.ProvenanceError(
+                    f"state references a missing deterministic attempt directory: {run_root}"
+                )
+            if record.get("status") != "success":
+                reference = self._seal_failed_attempt(run_root, run_id, attempt)
+                existing = record.get("attempt_evidence")
+                if existing is not None and existing != reference:
+                    raise core.ProvenanceError(
+                        f"state failed-attempt evidence reference mismatch: {run_root}"
+                    )
+                if existing is None:
+                    state_changed = True
+                record["attempt_evidence"] = reference
+
+        recovered_any = False
+        for attempt, run_root in sorted(disk_attempts.items()):
+            if attempt in by_attempt:
+                continue
+            recovered = self._recover_incomplete_attempt(
+                run_root, run_id, attempt, scheduled
+            )
+            by_attempt[attempt] = recovered
+            recovered_any = True
+
+        ordered = [by_attempt[number] for number in sorted(by_attempt)]
+        if recovered_any or state_changed or ordered != prior:
+            self.state["runs"][run_id] = ordered
+            self._save_state()
+        highest = max({0, *by_attempt, *disk_attempts})
+        return ordered, highest + 1
+
     def _execute(
         self,
         stage: dict[str, Any],
@@ -609,7 +1105,7 @@ class StudyRunner:
     ) -> dict[str, Any]:
         assert self.state is not None
         run_id = f"{stage['id']}--{scheduled['run_id']}"
-        prior = self.state["runs"].get(run_id, [])
+        prior, attempt = self._reconcile_attempts(stage, scheduled, run_id)
         if prior and prior[-1]["status"] == "success":
             print(f"[feature-validation] resume skip successful run={run_id}", flush=True)
             return prior[-1]
@@ -617,7 +1113,6 @@ class StudyRunner:
             raise core.ValidationError(
                 f"run {run_id} has a preserved failed attempt; use --retry-failed explicitly"
             )
-        attempt = len(prior) + 1
         run_root = self.study_root / "runs" / stage["id"] / scheduled["run_id"] / f"attempt-{attempt:02d}"
         run_root.mkdir(parents=True, exist_ok=False)
         core.validate_artifact_directory_isolation(self.manifest, run_root)
@@ -648,6 +1143,7 @@ class StudyRunner:
             "schema_version": 1,
             "run_id": run_id,
             "attempt": attempt,
+            "study_identity": self._study_identity(),
             "schedule": scheduled,
             "resource": stage["resource"],
             "argv": argv,
@@ -656,6 +1152,7 @@ class StudyRunner:
             "timeout_seconds": float(stage["timeout_seconds"]),
             "progress": stage["progress"],
             "result_path": str(result_path),
+            "lifecycle_path": str(run_root / "lifecycle-owner.json"),
             "stdout_path": str(run_root / "stdout.log"),
             "stderr_path": str(run_root / "stderr.log"),
             "metric": stage.get("metric"),
@@ -682,6 +1179,10 @@ class StudyRunner:
         self.state["runs"][run_id] = prior
         self._save_state()
         if result["status"] != "success":
+            result["attempt_evidence"] = self._seal_failed_attempt(
+                run_root, run_id, attempt
+            )
+            self._save_state()
             raise core.ValidationError(
                 f"run {run_id} attempt {attempt} failed; preserved at {result_path}: {result.get('error')}"
             )

--- a/scripts/test-feature-validation.py
+++ b/scripts/test-feature-validation.py
@@ -1100,6 +1100,27 @@ class StatisticsTest(unittest.TestCase):
 
 
 class ProfilerTest(unittest.TestCase):
+    def test_memory_manifest_categories_are_explicit_and_schema_bounded(self) -> None:
+        stage = {
+            "resource": "gpu",
+            "selection": {"execution_mode": "direct_process"},
+        }
+        config = {
+            "selector": {"kernel_regex": "kernel"},
+            "cuda_graph_trace": {
+                "applicability": "not_applicable",
+                "reason": "direct launch",
+            },
+            "memory_evidence": {
+                "mode": "required",
+                "categories": ["gpu_memory_events", "vmm"],
+            },
+        }
+        core._validate_profiler_details(config, stage, label="profiler")
+        config["memory_evidence"]["categories"] = ["architecture_specific_bytes"]
+        with self.assertRaisesRegex(core.ManifestError, "non-empty unique subset"):
+            core._validate_profiler_details(config, stage, label="profiler")
+
     def test_regression_diagnostic_selects_preregistered_largest_screen(self) -> None:
         stage = {
             "id": "spans",
@@ -1177,6 +1198,274 @@ class ProfilerTest(unittest.TestCase):
             profiler.verify_graph_node_discovery(
                 {"graph_node_trace": {"launches_with_graph_node": 0}}, config
             )
+
+    def test_nsys_memory_trace_is_explicit_and_required_support_fails_closed(self) -> None:
+        config = {
+            "mode": "required",
+            "categories": ["gpu_memory_events", "captured_device_high_water"],
+        }
+        evidence = profiler.verify_nsys_memory_trace_capability(
+            config,
+            help_text="--cuda-memory-usage= true|false",
+            version_text="Nsight Systems 2026.1",
+        )
+        self.assertEqual(evidence["status"], "supported")
+        argv = profiler.nsys_discovery_argv(
+            ["/tmp/llama-bench", "-C", "0x7", "--cpu-strict", "1"],
+            pathlib.Path("/tmp/discovery"),
+            request_cuda_memory_usage=True,
+        )
+        self.assertIn("--cuda-memory-usage=true", argv)
+        with self.assertRaisesRegex(core.ValidationError, "does not advertise required"):
+            profiler.verify_nsys_memory_trace_capability(
+                config,
+                help_text="older CUDA tracing help",
+                version_text="Nsight Systems old",
+            )
+        optional = profiler.verify_nsys_memory_trace_capability(
+            {**config, "mode": "optional"},
+            help_text="older CUDA tracing help",
+            version_text="Nsight Systems old",
+        )
+        self.assertEqual(optional["status"], "unsupported")
+
+    def test_memory_inventory_parses_allocations_copies_api_vmm_and_nvtx(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = pathlib.Path(temporary) / "memory.sqlite"
+            import sqlite3
+
+            with contextlib.closing(sqlite3.connect(path)) as connection:
+                connection.executescript(
+                    """
+                    CREATE TABLE ENUM_CUDA_DEV_MEM_EVENT_OPER (id INTEGER, label TEXT);
+                    INSERT INTO ENUM_CUDA_DEV_MEM_EVENT_OPER VALUES (0, 'Allocation');
+                    INSERT INTO ENUM_CUDA_DEV_MEM_EVENT_OPER VALUES (1, 'Deallocation');
+                    CREATE TABLE ENUM_CUDA_MEM_KIND (id INTEGER, label TEXT);
+                    INSERT INTO ENUM_CUDA_MEM_KIND VALUES (1, 'Pinned');
+                    INSERT INTO ENUM_CUDA_MEM_KIND VALUES (2, 'Device');
+                    CREATE TABLE ENUM_CUDA_MEMCPY_OPER (id INTEGER, label TEXT);
+                    INSERT INTO ENUM_CUDA_MEMCPY_OPER VALUES (1, 'Host to Device');
+                    CREATE TABLE CUDA_GPU_MEMORY_USAGE_EVENTS (
+                        start INTEGER, globalPid INTEGER, deviceId INTEGER,
+                        contextId INTEGER, address INTEGER, bytes INTEGER,
+                        memKind INTEGER, memoryOperationType INTEGER,
+                        name TEXT, correlationId INTEGER
+                    );
+                    INSERT INTO CUDA_GPU_MEMORY_USAGE_EVENTS
+                        VALUES (10, 7, 0, 3, 100, 1024, 2, 0, 'device-a', 11);
+                    INSERT INTO CUDA_GPU_MEMORY_USAGE_EVENTS
+                        VALUES (15, 7, 0, 3, 200, 512, 1, 0, 'pinned-a', 12);
+                    INSERT INTO CUDA_GPU_MEMORY_USAGE_EVENTS
+                        VALUES (30, 7, 0, 3, 100, 1024, 2, 1, 'device-a', 13);
+                    CREATE TABLE CUPTI_ACTIVITY_KIND_MEMCPY (
+                        start INTEGER, end INTEGER, bytes INTEGER,
+                        copyKind INTEGER, srcKind INTEGER, dstKind INTEGER
+                    );
+                    INSERT INTO CUPTI_ACTIVITY_KIND_MEMCPY VALUES (16, 20, 512, 1, 1, 2);
+                    CREATE TABLE CUPTI_ACTIVITY_KIND_MEMSET (
+                        start INTEGER, end INTEGER, bytes INTEGER, memKind INTEGER
+                    );
+                    INSERT INTO CUPTI_ACTIVITY_KIND_MEMSET VALUES (21, 23, 256, 2);
+                    CREATE TABLE StringIds (id INTEGER, value TEXT);
+                    INSERT INTO StringIds VALUES (1, 'cuMemMap');
+                    INSERT INTO StringIds VALUES (2, 'cudaMallocHost_v3020');
+                    CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+                        start INTEGER, end INTEGER, nameId INTEGER
+                    );
+                    INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (5, 6, 1);
+                    INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (7, 9, 2);
+                    CREATE TABLE NVTX_EVENTS (start INTEGER, end INTEGER, text TEXT);
+                    INSERT INTO NVTX_EVENTS VALUES (4, 40, 'prefill');
+                    """
+                )
+                connection.commit()
+
+            inventory = profiler.parse_memory_inventory(path)
+
+        categories = inventory["categories"]
+        self.assertEqual(categories["gpu_memory_events"]["status"], "available")
+        self.assertEqual(categories["gpu_memory_events"]["event_count"], 3)
+        self.assertTrue(
+            any(
+                item["memory_kind"] == "Pinned"
+                for item in categories["gpu_memory_events"]["groups"]
+            )
+        )
+        pinned_balance = next(
+            item
+            for item in categories["gpu_memory_events"][
+                "captured_outstanding_by_process_device_kind"
+            ]
+            if item["memory_kind"] == "Pinned"
+        )
+        self.assertEqual(pinned_balance["captured_outstanding_high_water_bytes"], 512)
+        self.assertEqual(categories["allocation_lifetimes"]["paired_lifetime_count"], 1)
+        self.assertEqual(categories["allocation_lifetimes"]["unmatched_allocation_count"], 1)
+        self.assertEqual(
+            categories["captured_device_high_water"]["by_process_device"][0][
+                "captured_outstanding_high_water_bytes"
+            ],
+            1024,
+        )
+        self.assertEqual(categories["copy_activity"]["event_count"], 2)
+        self.assertEqual(categories["vmm"]["event_count"], 1)
+        self.assertEqual(categories["nvtx_ranges"]["ranges"][0]["text"], "prefill")
+        assessment = profiler.assess_memory_evidence(
+            inventory,
+            {
+                "mode": "required",
+                "categories": [
+                    "gpu_memory_events",
+                    "allocation_lifetimes",
+                    "captured_device_high_water",
+                    "copy_activity",
+                    "cuda_api",
+                    "vmm",
+                    "nvtx_ranges",
+                ],
+            },
+            {"status": "supported"},
+        )
+        self.assertEqual(assessment["status"], "satisfied")
+        profiler.enforce_memory_evidence(assessment)
+        self.assertIn("never inferred from VmLck", inventory["memory_boundaries"]["pinned_host_memory"])
+
+    def test_memory_inventory_distinguishes_zero_from_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            zero_path = root / "zero.sqlite"
+            missing_path = root / "missing.sqlite"
+            import sqlite3
+
+            with contextlib.closing(sqlite3.connect(zero_path)) as connection:
+                connection.executescript(
+                    """
+                    CREATE TABLE ENUM_CUDA_DEV_MEM_EVENT_OPER (id INTEGER, label TEXT);
+                    INSERT INTO ENUM_CUDA_DEV_MEM_EVENT_OPER VALUES (0, 'Allocation');
+                    INSERT INTO ENUM_CUDA_DEV_MEM_EVENT_OPER VALUES (1, 'Deallocation');
+                    CREATE TABLE ENUM_CUDA_MEM_KIND (id INTEGER, label TEXT);
+                    INSERT INTO ENUM_CUDA_MEM_KIND VALUES (2, 'Device');
+                    CREATE TABLE CUDA_GPU_MEMORY_USAGE_EVENTS (
+                        start INTEGER, globalPid INTEGER, deviceId INTEGER,
+                        address INTEGER, bytes INTEGER, memKind INTEGER,
+                        memoryOperationType INTEGER
+                    );
+                    CREATE TABLE CUPTI_ACTIVITY_KIND_MEMCPY (
+                        start INTEGER, end INTEGER, bytes INTEGER
+                    );
+                    CREATE TABLE CUPTI_ACTIVITY_KIND_MEMSET (
+                        start INTEGER, end INTEGER, bytes INTEGER
+                    );
+                    CREATE TABLE StringIds (id INTEGER, value TEXT);
+                    CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+                        start INTEGER, end INTEGER, nameId INTEGER
+                    );
+                    """
+                )
+                connection.commit()
+            with contextlib.closing(sqlite3.connect(missing_path)) as connection:
+                connection.execute("CREATE TABLE unrelated (value INTEGER)")
+                connection.commit()
+
+            zero = profiler.parse_memory_inventory(zero_path)
+            missing = profiler.parse_memory_inventory(missing_path)
+
+        for category in (
+            "gpu_memory_events",
+            "allocation_lifetimes",
+            "captured_device_high_water",
+            "copy_activity",
+            "cuda_api",
+            "vmm",
+        ):
+            self.assertEqual(zero["categories"][category]["status"], "available")
+            self.assertEqual(zero["categories"][category]["event_count"], 0)
+            self.assertEqual(missing["categories"][category]["status"], "unavailable")
+            self.assertIsNone(missing["categories"][category]["event_count"])
+        required = {
+            "mode": "required",
+            "categories": ["gpu_memory_events", "copy_activity", "vmm"],
+        }
+        failed = profiler.assess_memory_evidence(
+            missing, required, {"status": "supported"}
+        )
+        self.assertEqual(failed["status"], "failed")
+        with self.assertRaisesRegex(core.ValidationError, "required NSYS memory evidence"):
+            profiler.enforce_memory_evidence(failed)
+        optional = profiler.assess_memory_evidence(
+            missing, {**required, "mode": "optional"}, {"status": "unsupported"}
+        )
+        self.assertEqual(optional["status"], "optional_incomplete")
+        profiler.enforce_memory_evidence(optional)
+
+    def test_memory_inventory_accepts_named_variant_columns_and_rejects_missing_semantics(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            variant = root / "variant.sqlite"
+            invalid = root / "invalid.sqlite"
+            import sqlite3
+
+            with contextlib.closing(sqlite3.connect(variant)) as connection:
+                connection.execute(
+                    "CREATE TABLE CUDA_MEMORY_USAGE_EVENTS ("
+                    "timestamp INTEGER, processId INTEGER, device INTEGER, ptr INTEGER, "
+                    "size INTEGER, memoryKind TEXT, operation TEXT)"
+                )
+                connection.execute(
+                    "INSERT INTO CUDA_MEMORY_USAGE_EVENTS VALUES "
+                    "(1, 2, 0, 4096, 64, 'Device', 'Allocation')"
+                )
+                connection.commit()
+            with contextlib.closing(sqlite3.connect(invalid)) as connection:
+                connection.execute(
+                    "CREATE TABLE CUDA_MEMORY_USAGE_EVENTS ("
+                    "timestamp INTEGER, address INTEGER, size INTEGER, memoryKind TEXT)"
+                )
+                connection.commit()
+
+            parsed = profiler.parse_memory_inventory(variant)
+            rejected = profiler.parse_memory_inventory(invalid)
+
+        self.assertEqual(parsed["categories"]["gpu_memory_events"]["status"], "available")
+        self.assertEqual(
+            parsed["categories"]["captured_device_high_water"]["by_process_device"][0][
+                "captured_outstanding_high_water_bytes"
+            ],
+            64,
+        )
+        self.assertEqual(rejected["categories"]["gpu_memory_events"]["status"], "unavailable")
+
+    def test_capture_start_deallocation_marks_high_water_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = pathlib.Path(temporary) / "partial.sqlite"
+            import sqlite3
+
+            with contextlib.closing(sqlite3.connect(path)) as connection:
+                connection.execute(
+                    "CREATE TABLE CUDA_MEMORY_USAGE_EVENTS ("
+                    "timestamp INTEGER, processId INTEGER, device INTEGER, ptr INTEGER, "
+                    "size INTEGER, memoryKind TEXT, operation TEXT)"
+                )
+                connection.execute(
+                    "INSERT INTO CUDA_MEMORY_USAGE_EVENTS VALUES "
+                    "(1, 2, 0, 4096, 64, 'Device', 'Deallocation')"
+                )
+                connection.commit()
+
+            inventory = profiler.parse_memory_inventory(path)
+
+        categories = inventory["categories"]
+        self.assertEqual(categories["gpu_memory_events"]["status"], "available")
+        self.assertEqual(
+            categories["allocation_lifetimes"]["unmatched_deallocation_count"], 1
+        )
+        self.assertEqual(categories["captured_device_high_water"]["status"], "partial")
+        assessment = profiler.assess_memory_evidence(
+            inventory,
+            {"mode": "required", "categories": ["captured_device_high_water"]},
+            {"status": "supported"},
+        )
+        self.assertEqual(assessment["status"], "failed")
 
     def test_jsonl_discovery_and_one_filtered_ncu_plan(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1329,6 +1618,48 @@ class ProfilerTest(unittest.TestCase):
                 },
             )
             core.write_json_atomic(
+                root / "memory-inventory.json",
+                {
+                    "assessment": {"status": "satisfied", "issues": []},
+                    "categories": {
+                        "gpu_memory_events": {
+                            "status": "available",
+                            "reason": None,
+                            "event_count": 2,
+                            "groups": [
+                                {
+                                    "memory_kind": "Device",
+                                    "operation": "allocation",
+                                    "event_count": 1,
+                                    "total_bytes": 4096,
+                                }
+                            ],
+                        },
+                        "allocation_lifetimes": {
+                            "status": "available",
+                            "reason": None,
+                            "event_count": 2,
+                            "paired_lifetime_count": 1,
+                            "unmatched_allocation_count": 0,
+                            "unmatched_deallocation_count": 0,
+                        },
+                        "captured_device_high_water": {
+                            "status": "available",
+                            "reason": None,
+                            "event_count": 2,
+                            "by_process_device": [
+                                {
+                                    "process_id": 1,
+                                    "device_id": 0,
+                                    "captured_outstanding_high_water_bytes": 4096,
+                                }
+                            ],
+                        },
+                    },
+                    "memory_boundaries": {"process_vram": "separate telemetry"},
+                },
+            )
+            core.write_json_atomic(
                 root / "nsys-result.json",
                 {"timing": {"target_process_seconds": 2.5}},
             )
@@ -1346,6 +1677,13 @@ class ProfilerTest(unittest.TestCase):
             summary["ncu"]["captures"][0]["metrics"][0]["value"], "1234"
         )
         self.assertEqual(summary["timing_seconds"]["nsys"]["target_process_seconds"], 2.5)
+        self.assertEqual(summary["memory"]["assessment_status"], "satisfied")
+        self.assertEqual(
+            summary["memory"]["captured_device_high_water"][0][
+                "captured_outstanding_high_water_bytes"
+            ],
+            4096,
+        )
         self.assertIn("diagnostic-only", summary["evidence_boundary"].lower())
 
     def test_agent_comparison_keeps_raw_metrics_without_acceptance_claim(self) -> None:
@@ -1368,6 +1706,12 @@ class ProfilerTest(unittest.TestCase):
                         }
                     ]
                 },
+                "memory": {
+                    "assessment_status": "satisfied",
+                    "captured_device_high_water": [
+                        {"captured_outstanding_high_water_bytes": int(value)}
+                    ],
+                },
                 "timing_seconds": {},
             }
 
@@ -1379,6 +1723,12 @@ class ProfilerTest(unittest.TestCase):
         self.assertEqual(
             comparison["raw_ncu_metrics"]["candidate"][0]["metrics"][0]["value"],
             "12",
+        )
+        self.assertEqual(
+            comparison["memory_inventory"]["candidate"][
+                "captured_device_high_water"
+            ][0]["captured_outstanding_high_water_bytes"],
+            12,
         )
         self.assertIn("no paired interval", comparison["comparison_boundary"].lower())
 

--- a/scripts/test-feature-validation.py
+++ b/scripts/test-feature-validation.py
@@ -10,12 +10,15 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 import pathlib
+import signal
 import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from unittest import mock
@@ -24,8 +27,13 @@ from unittest import mock
 SCRIPTS = pathlib.Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS))
 
-from feature_validation import core, profiler, telemetry  # noqa: E402
-from feature_validation.runner import StudyRunner, _verify_spec_identity  # noqa: E402
+from feature_validation import core, profiler, runner as validation_runner, telemetry  # noqa: E402
+from feature_validation.runner import (  # noqa: E402
+    StudyRunner,
+    _verify_spec_identity,
+    execute_run_spec,
+    launch_locked_spec,
+)
 
 
 CLI_SPEC = importlib.util.spec_from_file_location(
@@ -306,6 +314,96 @@ class FixtureMixin:
         return manifest, built_executable, cache, sidecar
 
 
+class ArtifactLifecycleTest(FixtureMixin, unittest.TestCase):
+    def _in_source_manifest(self) -> tuple[dict, pathlib.Path]:
+        manifest = self.manifest()
+        artifact_root = self.repo / "build-validation-artifacts"
+        manifest["artifact_root"] = str(artifact_root)
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+        (self.repo / ".git" / "info" / "exclude").write_text(
+            "/build-validation-artifacts/\n", encoding="utf-8"
+        )
+        manifest_path = self.root / "in-source.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        return manifest, manifest_path
+
+    def test_run_and_resume_recheck_actual_ignored_directories(self) -> None:
+        _manifest, manifest_path = self._in_source_manifest()
+        runner = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        runner.prepare(resume=False)
+        stage = core.stage_by_id(runner.manifest, "exactness")
+        scheduled = core.build_schedule(runner.manifest, stage)[0]
+
+        result = runner._execute(stage, scheduled, retry_failed=False)
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(result["process_group_cleanup"]["leader_reaped"])
+        core.validate_artifact_directory_isolation(
+            runner.manifest, pathlib.Path(result["stdout"]["path"]).parent
+        )
+
+        (self.repo / ".git" / "info" / "exclude").write_text("", encoding="utf-8")
+        with self.assertRaisesRegex(core.ManifestError, "exact artifact directory"):
+            runner.prepare(resume=True)
+
+    def test_profile_rechecks_created_directory_immediately_before_target(self) -> None:
+        manifest, manifest_path = self._in_source_manifest()
+        stage = core.stage_by_id(manifest, "production")
+        stage["resource"] = "gpu"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        config = {
+            "stage": "production",
+            "selector": {
+                "kernel_regex": "kernel",
+                "graph_only": False,
+                "occurrence_policy": {"kind": "last"},
+            },
+            "cuda_graph_trace": {
+                "applicability": "not_applicable",
+                "reason": "CPU-only isolation test",
+            },
+            "metrics": ["gpu__time_duration.sum"],
+        }
+        manifest_sha = file_sha256(manifest_path)
+        provenance = core.capture_provenance(manifest, manifest_sha)
+        profile_base = pathlib.Path(manifest["artifact_root"]) / "profiles"
+
+        def tool_identity(_name: str) -> dict[str, object]:
+            (self.repo / ".git" / "info" / "exclude").write_text("", encoding="utf-8")
+            return {"path": "/bin/true", "sha256": file_sha256(pathlib.Path("/bin/true"))}
+
+        with mock.patch.object(
+            CLI.profiler, "validate_native_affinity"
+        ), mock.patch.object(
+            CLI, "_tool_identity", side_effect=tool_identity
+        ), mock.patch.object(
+            CLI.core,
+            "command_capture",
+            return_value={"returncode": 0, "stdout": "", "stderr": ""},
+        ), mock.patch.object(
+            CLI.profiler,
+            "verify_nsys_graph_trace_capability",
+            return_value={"status": "not_applicable"},
+        ), mock.patch.object(
+            CLI.profiler, "nsys_discovery_argv", return_value=["/bin/true"]
+        ), mock.patch.object(
+            CLI, "launch_locked_spec"
+        ) as launch, self.assertRaisesRegex(
+            core.ManifestError, "exact artifact directory"
+        ):
+            CLI._profile_one(
+                manifest,
+                manifest_sha,
+                provenance,
+                config,
+                variant_name="baseline",
+                screen_id="default",
+                profile_base=profile_base,
+                resume=False,
+                execute_ncu=False,
+            )
+        launch.assert_not_called()
+
+
 class QuotingAndArityTest(unittest.TestCase):
     def test_safe_quoting_round_trips_spaces_quotes_and_metacharacters(self) -> None:
         argv = ["/tmp/a b", "single'quote", 'double"quote', "$(do-not-run)", "semi;colon"]
@@ -364,6 +462,25 @@ class QuotingAndArityTest(unittest.TestCase):
 
 
 class ManifestAndScheduleTest(FixtureMixin, unittest.TestCase):
+    @staticmethod
+    def _set_exclude(repo: pathlib.Path, contents: str) -> None:
+        (repo / ".git" / "info" / "exclude").write_text(contents, encoding="utf-8")
+
+    def _new_repo(self, name: str) -> pathlib.Path:
+        repo = self.root / name
+        repo.mkdir()
+        (repo / "tracked").write_text("fixture\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "tests@example.invalid"], cwd=repo, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Feature Tests"], cwd=repo, check=True
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=repo, check=True)
+        return repo
+
     def test_checked_in_example_is_structurally_valid_and_schema_is_json(self) -> None:
         schema_path = SCRIPTS / "feature_validation" / "manifest.schema.json"
         example_path = SCRIPTS.parent / "examples" / "feature-performance-validation" / "manifest.example.json"
@@ -386,6 +503,133 @@ class ManifestAndScheduleTest(FixtureMixin, unittest.TestCase):
             orientations.append(pair_runs[0]["orientation"])
             self.assertEqual(len({item["variant"] for item in pair_runs}), 2)
         self.assertEqual(orientations, ["AB", "BA", "AB", "BA", "AB"])
+
+    def test_in_source_artifacts_require_explicit_git_ignored_policy(self) -> None:
+        manifest = self.manifest()
+        artifact_root = self.repo / "build-validation-artifacts"
+        manifest["artifact_root"] = str(artifact_root)
+
+        with self.assertRaisesRegex(core.ManifestError, "outside every variant source"):
+            core.validate_manifest(manifest)
+
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+        with self.assertRaisesRegex(core.ManifestError, "Git-ignored"):
+            core.validate_manifest(manifest)
+
+        exclude = self.repo / ".git" / "info" / "exclude"
+        exclude.write_text(
+            exclude.read_text(encoding="utf-8") + "\n/build-validation-artifacts/\n",
+            encoding="utf-8",
+        )
+        core.validate_manifest(manifest)
+
+    def test_ignored_synthetic_probe_does_not_authorize_unignored_root(self) -> None:
+        manifest = self.manifest()
+        manifest["artifact_root"] = str(self.repo / "build-validation-artifacts")
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+        self._set_exclude(
+            self.repo,
+            "/build-validation-artifacts/.feature-validation-artifact-root-probe\n",
+        )
+
+        with self.assertRaisesRegex(core.ManifestError, "exact artifact directory"):
+            core.validate_manifest(manifest)
+
+    def test_ignore_negation_fails_closed_for_exact_artifact_root(self) -> None:
+        manifest = self.manifest()
+        artifact_root = self.repo / "build-validation-artifacts"
+        artifact_root.mkdir()
+        manifest["artifact_root"] = str(artifact_root)
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+        self._set_exclude(
+            self.repo,
+            "/build-validation-artifacts/\n!/build-validation-artifacts/\n",
+        )
+
+        with self.assertRaisesRegex(core.ManifestError, "exact artifact directory"):
+            core.validate_manifest(manifest)
+
+    def test_distinct_variant_roots_check_only_the_containing_root(self) -> None:
+        other = self._new_repo("other source")
+        manifest = self.manifest()
+        artifact_root = self.repo / "build-validation-artifacts"
+        manifest["artifact_root"] = str(artifact_root)
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+        self._set_exclude(self.repo, "/build-validation-artifacts/\n")
+        candidate = manifest["variants"]["candidate"]
+        candidate["source_root"] = str(other)
+        candidate["expected_commit"] = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=other,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        core.validate_manifest(manifest)
+
+    def test_nested_variant_roots_must_both_ignore_the_exact_root(self) -> None:
+        nested = self.repo / "nested-source"
+        nested.mkdir()
+        (nested / "tracked").write_text("fixture\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=nested, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "tests@example.invalid"], cwd=nested, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Feature Tests"], cwd=nested, check=True
+        )
+        subprocess.run(["git", "add", "."], cwd=nested, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=nested, check=True)
+        artifact_root = nested / "build-validation-artifacts"
+        manifest = self.manifest()
+        manifest["artifact_root"] = str(artifact_root)
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+        candidate = manifest["variants"]["candidate"]
+        candidate["source_root"] = str(nested)
+        candidate["expected_commit"] = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=nested,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self._set_exclude(
+            self.repo, "/nested-source/\n!/nested-source/\n/nested-source/build-validation-artifacts/\n"
+        )
+        self._set_exclude(nested, "")
+
+        with self.assertRaisesRegex(core.ManifestError, str(nested)):
+            core.validate_manifest(manifest)
+
+        self._set_exclude(nested, "/build-validation-artifacts/\n")
+        core.validate_manifest(manifest)
+
+    def test_ignored_in_source_artifacts_do_not_change_provenance_identity(self) -> None:
+        manifest = self.manifest()
+        artifact_root = self.repo / "build-validation-artifacts"
+        manifest["artifact_root"] = str(artifact_root)
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+        self._set_exclude(self.repo, "/build-validation-artifacts/\n")
+        manifest_path = self.root / "provenance.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        manifest_sha = file_sha256(manifest_path)
+        before = core.capture_provenance(manifest, manifest_sha)
+        artifact_root.mkdir()
+        (artifact_root / "raw-profile.sqlite").write_text("ignored\n", encoding="utf-8")
+        core.validate_artifact_directory_isolation(manifest, artifact_root)
+        after = core.capture_provenance(manifest, manifest_sha)
+
+        self.assertEqual(before["identity_fingerprint"], after["identity_fingerprint"])
+        self.assertEqual(before["variants"], after["variants"])
+
+    def test_in_source_artifacts_never_allow_git_metadata(self) -> None:
+        manifest = self.manifest()
+        manifest["artifact_root"] = str(self.repo / ".git" / "validation-artifacts")
+        manifest["artifact_root_policy"] = "git_ignored_inside_sources"
+
+        with self.assertRaisesRegex(core.ManifestError, "cannot be the source root or .git"):
+            core.validate_manifest(manifest)
 
     def test_single_pair_screening_is_explicit_and_limited_to_early_stages(self) -> None:
         manifest = self.manifest()
@@ -1518,6 +1762,213 @@ class TelemetryTest(unittest.TestCase):
 
 
 class RunnerTest(FixtureMixin, unittest.TestCase):
+    def _spec(self, attempt: pathlib.Path, argv: list[str], run_id: str) -> dict:
+        return {
+            "schema_version": 1,
+            "run_id": run_id,
+            "attempt": 1,
+            "resource": "cpu",
+            "argv": argv,
+            "environment": {},
+            "cwd": str(attempt),
+            "timeout_seconds": 60.0,
+            "progress": "CPU-only real-signal lifecycle test",
+            "result_path": str(attempt / "result.json"),
+            "stdout_path": str(attempt / "stdout.log"),
+            "stderr_path": str(attempt / "stderr.log"),
+            "identity_files": [],
+            "source_identities": [],
+            "host_load_before": {},
+            "cleanup_term_timeout_seconds": 0.2,
+            "cleanup_kill_timeout_seconds": 1.0,
+        }
+
+    def test_exited_leader_does_not_hide_sigterm_ignoring_descendant(self) -> None:
+        attempt = self.root / "leader-exited"
+        attempt.mkdir()
+        descendant_pid_path = attempt / "descendant.pid"
+        target = attempt / "spawn-descendant.py"
+        descendant_code = (
+            "import os, pathlib, signal, time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            f"pathlib.Path({str(descendant_pid_path)!r}).write_text(str(os.getpid())); "
+            "time.sleep(30)"
+        )
+        target.write_text(
+            "#!/usr/bin/python3\n"
+            "import pathlib, subprocess, sys, time\n"
+            f"ready = pathlib.Path({str(descendant_pid_path)!r})\n"
+            f"subprocess.Popen([sys.executable, '-c', {descendant_code!r}], "
+            "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n"
+            "for _ in range(200):\n"
+            "    if ready.is_file():\n"
+            "        break\n"
+            "    time.sleep(.01)\n",
+            encoding="utf-8",
+        )
+        target.chmod(0o755)
+
+        result = execute_run_spec(self._spec(attempt, [str(target)], "leader-exited"))
+
+        descendant_pid = int(descendant_pid_path.read_text(encoding="utf-8"))
+        self.assertEqual(result["status"], "success")
+        cleanup = result["process_group_cleanup"]
+        self.assertTrue(cleanup["term_sent"])
+        self.assertTrue(cleanup["kill_sent"])
+        self.assertTrue(cleanup["group_gone"])
+        self.assertTrue(cleanup["leader_reaped"])
+        with self.assertRaises(ProcessLookupError):
+            os.kill(descendant_pid, 0)
+
+    def test_real_sigint_reaps_target_group_and_preserves_failure(self) -> None:
+        attempt = self.root / "interrupted-attempt"
+        attempt.mkdir()
+        descendant_pid_path = attempt / "descendant.pid"
+        ready_path = attempt / "target-ready.json"
+        target = attempt / "interrupt-target.py"
+        descendant_code = (
+            "import os, pathlib, signal, time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            f"pathlib.Path({str(descendant_pid_path)!r}).write_text(str(os.getpid())); "
+            "time.sleep(30)"
+        )
+        target.write_text(
+            "#!/usr/bin/python3\n"
+            "import json, os, pathlib, subprocess, sys, time\n"
+            f"child = subprocess.Popen([sys.executable, '-c', {descendant_code!r}], "
+            "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n"
+            f"descendant = pathlib.Path({str(descendant_pid_path)!r})\n"
+            "for _ in range(200):\n"
+            "    if descendant.is_file():\n"
+            "        break\n"
+            "    time.sleep(.01)\n"
+            f"pathlib.Path({str(ready_path)!r}).write_text(json.dumps([os.getpid(), child.pid]))\n"
+            "time.sleep(30)\n",
+            encoding="utf-8",
+        )
+        target.chmod(0o755)
+        spec = self._spec(attempt, [str(target)], "interrupt-cleanup")
+        spec_path = attempt / "spec.json"
+        spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+        with subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPTS / "feature-performance-validation.py"),
+                "_execute-run",
+                str(spec_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ) as executor:
+            deadline = time.monotonic() + 5.0
+            while not ready_path.is_file() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(ready_path.is_file())
+            os.kill(executor.pid, signal.SIGINT)
+            self.assertEqual(executor.wait(timeout=5.0), 1)
+
+        target_pid, descendant_pid = json.loads(ready_path.read_text(encoding="utf-8"))
+        result = json.loads(pathlib.Path(spec["result_path"]).read_text(encoding="utf-8"))
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("KeyboardInterrupt", result["error"])
+        self.assertEqual(result["process_group_id"], target_pid)
+        self.assertTrue(result["process_group_cleanup"]["kill_sent"])
+        self.assertTrue(result["process_group_cleanup"]["group_gone"])
+        self.assertTrue(result["process_group_cleanup"]["leader_reaped"])
+        for pid in (target_pid, descendant_pid):
+            with self.assertRaises(ProcessLookupError):
+                os.kill(pid, 0)
+
+    def test_cleanup_errors_preserve_result_and_telemetry(self) -> None:
+        attempt = self.root / "cleanup-error"
+        attempt.mkdir()
+        spec = self._spec(attempt, ["/bin/true"], "cleanup-error")
+        original_cleanup = validation_runner._cleanup_process_group
+
+        def cleanup_with_error(*args: object, **kwargs: object) -> dict[str, object]:
+            report = original_cleanup(*args, **kwargs)
+            report["errors"].append("injected cleanup failure")
+            return report
+
+        with mock.patch.object(
+            validation_runner, "_cleanup_process_group", side_effect=cleanup_with_error
+        ):
+            result = execute_run_spec(spec)
+
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("injected cleanup failure", result["error"])
+        self.assertIsNotNone(result["telemetry"])
+        self.assertTrue(pathlib.Path(spec["result_path"]).is_file())
+
+    def test_outer_launcher_real_sigint_persists_state_and_retry_semantics(self) -> None:
+        ready = self.root / "outer-ready"
+        allow = self.root / "outer-allow"
+        self.executable.write_text(
+            f"#!{sys.executable}\n"
+            "import pathlib, time\n"
+            f"ready = pathlib.Path({str(ready)!r})\n"
+            f"allow = pathlib.Path({str(allow)!r})\n"
+            "if allow.is_file():\n"
+            "    print('metric=100.0')\n"
+            "else:\n"
+            "    ready.write_text('ready')\n"
+            "    time.sleep(30)\n",
+            encoding="utf-8",
+        )
+        self.executable.chmod(0o755)
+        subprocess.run(["git", "add", "."], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "interrupt fixture"], cwd=self.repo, check=True
+        )
+        manifest_path = self.root / "outer-interrupt.json"
+        manifest_path.write_text(json.dumps(self.manifest()), encoding="utf-8")
+        runner = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        runner.prepare(resume=False)
+        stage = core.stage_by_id(runner.manifest, "exactness")
+        stage["resource"] = "gpu"
+        scheduled = core.build_schedule(runner.manifest, stage)[0]
+
+        def cpu_locked(spec: dict, spec_path: pathlib.Path, tool_script: pathlib.Path) -> dict:
+            spec["resource"] = "cpu"
+            spec["cleanup_term_timeout_seconds"] = 0.2
+            spec["cleanup_kill_timeout_seconds"] = 1.0
+            return launch_locked_spec(spec, spec_path, tool_script)
+
+        def interrupt_when_ready() -> None:
+            deadline = time.monotonic() + 5.0
+            while not ready.is_file() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            if ready.is_file():
+                os.kill(os.getpid(), signal.SIGINT)
+
+        interrupter = threading.Thread(target=interrupt_when_ready)
+        interrupter.start()
+        with mock.patch.object(
+            validation_runner, "launch_locked_spec", side_effect=cpu_locked
+        ), self.assertRaisesRegex(core.ValidationError, "preserved"):
+            runner._execute(stage, scheduled, retry_failed=False)
+        interrupter.join(timeout=5.0)
+        self.assertFalse(interrupter.is_alive())
+
+        run_id = f"{stage['id']}--{scheduled['run_id']}"
+        attempts = runner.state["runs"][run_id]
+        self.assertEqual([item["status"] for item in attempts], ["failed"])
+        self.assertTrue(attempts[0]["launcher"]["interrupted"])
+        with self.assertRaisesRegex(core.ValidationError, "--retry-failed"):
+            runner._execute(stage, scheduled, retry_failed=False)
+
+        allow.write_text("go", encoding="utf-8")
+        with mock.patch.object(
+            validation_runner, "launch_locked_spec", side_effect=cpu_locked
+        ):
+            retried = runner._execute(stage, scheduled, retry_failed=True)
+        self.assertEqual(retried["status"], "success")
+        self.assertEqual(
+            [item["status"] for item in runner.state["runs"][run_id]],
+            ["failed", "success"],
+        )
+
     def test_single_pair_screen_runs_once_and_fails_on_preregistered_signal(self) -> None:
         manifest = self.manifest()
         manifest_path = self.root / "single-pair-screen.json"

--- a/scripts/test-feature-validation.py
+++ b/scripts/test-feature-validation.py
@@ -2133,6 +2133,288 @@ class RunnerTest(FixtureMixin, unittest.TestCase):
             "cleanup_kill_timeout_seconds": 1.0,
         }
 
+    def _fake_flock(self, target_pids_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+        fake_bin = self.root / "fake-flock-bin"
+        fake_bin.mkdir()
+        held_path = self.root / "fake-lock-held"
+        released_path = self.root / "fake-lock-released.json"
+        fake = fake_bin / "flock"
+        fake.write_text(
+            f"#!{sys.executable}\n"
+            "import json, os, pathlib, subprocess, sys, time\n"
+            "if len(sys.argv) != 4 or sys.argv[2] != '-c':\n"
+            "    raise SystemExit(64)\n"
+            f"held = pathlib.Path({str(held_path)!r})\n"
+            f"released = pathlib.Path({str(released_path)!r})\n"
+            f"target_pids = pathlib.Path({str(target_pids_path)!r})\n"
+            "held.write_text(str(time.monotonic()))\n"
+            "result = subprocess.run(['/bin/sh', '-c', sys.argv[3]], check=False)\n"
+            "pids = json.loads(target_pids.read_text()) if target_pids.is_file() else []\n"
+            "deadline = time.monotonic() + 2.0\n"
+            "alive = []\n"
+            "while True:\n"
+            "    alive = []\n"
+            "    for pid in pids:\n"
+            "        try:\n"
+            "            os.kill(pid, 0)\n"
+            "        except ProcessLookupError:\n"
+            "            continue\n"
+            "        alive.append(pid)\n"
+            "    if not alive or time.monotonic() >= deadline:\n"
+            "        break\n"
+            "    time.sleep(.02)\n"
+            "released.write_text(json.dumps({'alive_at_release': alive, "
+            "'released_monotonic': time.monotonic(), 'inner_returncode': result.returncode}))\n"
+            "raise SystemExit(result.returncode)\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        return fake_bin, released_path
+
+    def _prepared_first_run(
+        self, manifest_name: str
+    ) -> tuple[StudyRunner, dict, dict, str, pathlib.Path]:
+        manifest_path = self.root / manifest_name
+        manifest_path.write_text(json.dumps(self.manifest()), encoding="utf-8")
+        study = StudyRunner(manifest_path, SCRIPTS / "feature-performance-validation.py")
+        study.prepare(resume=False)
+        stage = core.stage_by_id(study.manifest, "exactness")
+        scheduled = core.build_schedule(study.manifest, stage)[0]
+        run_id = f"{stage['id']}--{scheduled['run_id']}"
+        run_base = study.study_root / "runs" / stage["id"] / scheduled["run_id"]
+        return study, stage, scheduled, run_id, run_base
+
+    def test_parent_interrupt_holds_wrapper_until_descendant_is_reaped(self) -> None:
+        attempt = self.root / "parent-interrupted"
+        attempt.mkdir()
+        target_pids_path = attempt / "target-pids.json"
+        ready_path = attempt / "target-ready"
+        target = attempt / "parent-interrupt-target.py"
+        descendant_code = (
+            "import signal, time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "time.sleep(30)"
+        )
+        target.write_text(
+            f"#!{sys.executable}\n"
+            "import json, os, pathlib, subprocess, sys, time\n"
+            f"child = subprocess.Popen([sys.executable, '-c', {descendant_code!r}], "
+            "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n"
+            f"pathlib.Path({str(target_pids_path)!r}).write_text(json.dumps([os.getpid(), child.pid]))\n"
+            f"pathlib.Path({str(ready_path)!r}).write_text('ready')\n"
+            "time.sleep(30)\n",
+            encoding="utf-8",
+        )
+        target.chmod(0o755)
+        fake_bin, released_path = self._fake_flock(target_pids_path)
+        spec = self._spec(attempt, [str(target)], "parent-interrupt-cleanup")
+        spec["lifecycle_path"] = str(attempt / "lifecycle-owner.json")
+        spec_path = attempt / "run-spec.json"
+
+        def interrupt_twice() -> None:
+            deadline = time.monotonic() + 5.0
+            while not ready_path.is_file() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            if ready_path.is_file():
+                os.kill(os.getpid(), signal.SIGTERM)
+                time.sleep(0.05)
+                os.kill(os.getpid(), signal.SIGINT)
+
+        interrupter = threading.Thread(target=interrupt_twice)
+        interrupter.start()
+        result: dict | None = None
+        try:
+            with mock.patch.dict(
+                os.environ,
+                {"PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"},
+            ):
+                result = launch_locked_spec(
+                    spec, spec_path, SCRIPTS / "feature-performance-validation.py"
+                )
+        finally:
+            interrupter.join(timeout=5.0)
+            if target_pids_path.is_file():
+                target_pids = json.loads(target_pids_path.read_text(encoding="utf-8"))
+                for pid in target_pids:
+                    try:
+                        os.kill(pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["status"], "failed")
+        self.assertTrue(result["launcher"]["interrupted"])
+        self.assertEqual(result["launcher"]["interrupt_signals"], ["SIGTERM", "SIGINT"])
+        self.assertIsNone(result["launcher"]["owned_target_fallback_cleanup"])
+        self.assertTrue(result["process_group_cleanup"]["kill_sent"])
+        self.assertTrue(result["process_group_cleanup"]["group_gone"])
+        self.assertTrue(result["process_group_cleanup"]["leader_reaped"])
+        self.assertIsNotNone(result["telemetry"])
+        release = json.loads(released_path.read_text(encoding="utf-8"))
+        self.assertEqual(release["alive_at_release"], [])
+        lifecycle = json.loads(
+            pathlib.Path(spec["lifecycle_path"]).read_text(encoding="utf-8")
+        )
+        self.assertEqual(lifecycle["state"], "cleanup_complete")
+        self.assertTrue(lifecycle["telemetry_stopped"])
+
+    def test_incomplete_attempt_is_sealed_and_retry_uses_next_number(self) -> None:
+        study, stage, scheduled, run_id, run_base = self._prepared_first_run(
+            "incomplete-attempt.json"
+        )
+        first = run_base / "attempt-01"
+        first.mkdir(parents=True)
+        sentinel = first / "partial.log"
+        sentinel.write_text("interrupted output\n", encoding="utf-8")
+        resumed = StudyRunner(
+            study.manifest_path, SCRIPTS / "feature-performance-validation.py"
+        )
+        resumed.prepare(resume=True)
+
+        with self.assertRaisesRegex(core.ValidationError, "--retry-failed"):
+            resumed._execute(stage, scheduled, retry_failed=False)
+        recovered = resumed.state["runs"][run_id][0]
+        self.assertEqual(recovered["status"], "failed")
+        self.assertNotIn("metric_value", recovered)
+        self.assertEqual(recovered["metric_disposition"], "not_counted_interrupted_attempt")
+        evidence_path = pathlib.Path(recovered["attempt_evidence"]["path"])
+        self.assertEqual(
+            recovered["attempt_evidence"]["sha256"], file_sha256(evidence_path)
+        )
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        self.assertEqual(evidence["study_identity"], resumed._study_identity())
+        self.assertIn("partial.log", [item["path"] for item in evidence["files"]])
+
+        result = resumed._execute(stage, scheduled, retry_failed=True)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["attempt"], 2)
+        self.assertEqual(sentinel.read_text(encoding="utf-8"), "interrupted output\n")
+        self.assertTrue((run_base / "attempt-02" / "result.json").is_file())
+        self.assertEqual(
+            [item["status"] for item in resumed.state["runs"][run_id]],
+            ["failed", "success"],
+        )
+
+    def test_incomplete_attempt_with_live_owner_is_not_recycled(self) -> None:
+        study, stage, scheduled, run_id, run_base = self._prepared_first_run(
+            "live-owner-incomplete.json"
+        )
+        first = run_base / "attempt-01"
+        first.mkdir(parents=True)
+        core.write_json_atomic(
+            first / "lifecycle-owner.json",
+            {
+                "run_id": run_id,
+                "attempt": 1,
+                "study_identity": study._study_identity(),
+                "executor": validation_runner._process_identity(os.getpid()),
+                "target": None,
+                "state": "executor_started",
+            },
+        )
+
+        with self.assertRaisesRegex(core.ValidationError, "live owned executor"):
+            study._execute(stage, scheduled, retry_failed=True)
+        self.assertNotIn(run_id, study.state["runs"])
+        self.assertFalse((first / "attempt-evidence.json").exists())
+
+    def test_noncanonical_incomplete_attempt_name_fails_closed(self) -> None:
+        study, stage, scheduled, run_id, run_base = self._prepared_first_run(
+            "noncanonical-incomplete.json"
+        )
+        (run_base / "attempt-1").mkdir(parents=True)
+
+        with self.assertRaisesRegex(core.ProvenanceError, "noncanonical"):
+            study._execute(stage, scheduled, retry_failed=True)
+        self.assertNotIn(run_id, study.state["runs"])
+
+    def test_repeated_incomplete_attempts_are_preserved_before_attempt_three(self) -> None:
+        study, stage, scheduled, run_id, run_base = self._prepared_first_run(
+            "repeated-incomplete.json"
+        )
+        for attempt in (1, 2):
+            directory = run_base / f"attempt-{attempt:02d}"
+            directory.mkdir(parents=True)
+            (directory / "partial.log").write_text(
+                f"interruption {attempt}\n", encoding="utf-8"
+            )
+
+        result = study._execute(stage, scheduled, retry_failed=True)
+
+        self.assertEqual(result["attempt"], 3)
+        records = study.state["runs"][run_id]
+        self.assertEqual([item["status"] for item in records], ["failed", "failed", "success"])
+        self.assertEqual([item["attempt"] for item in records], [1, 2, 3])
+        for attempt in (1, 2):
+            self.assertTrue((run_base / f"attempt-{attempt:02d}" / "attempt-evidence.json").is_file())
+
+    def test_preserved_incomplete_attempt_tamper_fails_closed(self) -> None:
+        study, stage, scheduled, _run_id, run_base = self._prepared_first_run(
+            "tampered-incomplete.json"
+        )
+        first = run_base / "attempt-01"
+        first.mkdir(parents=True)
+        sentinel = first / "partial.log"
+        sentinel.write_text("original\n", encoding="utf-8")
+        with self.assertRaisesRegex(core.ValidationError, "--retry-failed"):
+            study._execute(stage, scheduled, retry_failed=False)
+        sentinel.write_text("changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(core.ProvenanceError, "evidence changed"):
+            study._execute(stage, scheduled, retry_failed=True)
+
+    def test_unindexed_success_result_is_preserved_but_never_counted(self) -> None:
+        study, stage, scheduled, run_id, run_base = self._prepared_first_run(
+            "unindexed-success.json"
+        )
+        first = run_base / "attempt-01"
+        first.mkdir(parents=True)
+        core.write_json_atomic(
+            first / "result.json",
+            {
+                "run_id": run_id,
+                "attempt": 1,
+                "status": "success",
+                "metric_value": 999999,
+            },
+        )
+
+        result = study._execute(stage, scheduled, retry_failed=True)
+
+        recovered = study.state["runs"][run_id][0]
+        self.assertEqual(recovered["status"], "failed")
+        self.assertNotIn("metric_value", recovered)
+        self.assertEqual(
+            recovered["preserved_child_result"]["metric_disposition"],
+            "preserved_not_counted",
+        )
+        self.assertEqual(result["attempt"], 2)
+
+    def test_unindexed_presealed_failure_recovers_without_mutating_seal(self) -> None:
+        study, stage, scheduled, run_id, run_base = self._prepared_first_run(
+            "unindexed-presealed.json"
+        )
+        first = run_base / "attempt-01"
+        first.mkdir(parents=True)
+        core.write_json_atomic(
+            first / "result.json",
+            {"run_id": run_id, "attempt": 1, "status": "failed", "error": "stopped"},
+        )
+        reference = study._seal_failed_attempt(first, run_id, 1)
+        evidence_path = pathlib.Path(reference["path"])
+        evidence_before = evidence_path.read_bytes()
+
+        result = study._execute(stage, scheduled, retry_failed=True)
+
+        recovered = study.state["runs"][run_id][0]
+        self.assertEqual(
+            recovered["recovery_record"],
+            "state_only_to_preserve_preexisting_immutable_attempt_seal",
+        )
+        self.assertEqual(recovered["attempt_evidence"], reference)
+        self.assertEqual(evidence_path.read_bytes(), evidence_before)
+        self.assertFalse((first / "interrupted-result.json").exists())
+        self.assertEqual(result["attempt"], 2)
+
     def test_exited_leader_does_not_hide_sigterm_ignoring_descendant(self) -> None:
         attempt = self.root / "leader-exited"
         attempt.mkdir()
@@ -2278,6 +2560,8 @@ class RunnerTest(FixtureMixin, unittest.TestCase):
         stage = core.stage_by_id(runner.manifest, "exactness")
         stage["resource"] = "gpu"
         scheduled = core.build_schedule(runner.manifest, stage)[0]
+        fake_bin, _released_path = self._fake_flock(self.root / "no-target-pids")
+        fake_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
 
         def cpu_locked(spec: dict, spec_path: pathlib.Path, tool_script: pathlib.Path) -> dict:
             spec["resource"] = "cpu"
@@ -2294,7 +2578,7 @@ class RunnerTest(FixtureMixin, unittest.TestCase):
 
         interrupter = threading.Thread(target=interrupt_when_ready)
         interrupter.start()
-        with mock.patch.object(
+        with mock.patch.dict(os.environ, {"PATH": fake_path}), mock.patch.object(
             validation_runner, "launch_locked_spec", side_effect=cpu_locked
         ), self.assertRaisesRegex(core.ValidationError, "preserved"):
             runner._execute(stage, scheduled, retry_failed=False)
@@ -2305,11 +2589,15 @@ class RunnerTest(FixtureMixin, unittest.TestCase):
         attempts = runner.state["runs"][run_id]
         self.assertEqual([item["status"] for item in attempts], ["failed"])
         self.assertTrue(attempts[0]["launcher"]["interrupted"])
+        self.assertEqual(
+            attempts[0]["attempt_evidence"]["sha256"],
+            file_sha256(pathlib.Path(attempts[0]["attempt_evidence"]["path"])),
+        )
         with self.assertRaisesRegex(core.ValidationError, "--retry-failed"):
             runner._execute(stage, scheduled, retry_failed=False)
 
         allow.write_text("go", encoding="utf-8")
-        with mock.patch.object(
+        with mock.patch.dict(os.environ, {"PATH": fake_path}), mock.patch.object(
             validation_runner, "launch_locked_spec", side_effect=cpu_locked
         ):
             retried = runner._execute(stage, scheduled, retry_failed=True)


### PR DESCRIPTION
## Summary

- harden exact artifact isolation and direct-process interrupt cleanup
- add schema-tolerant NSYS CUDA memory, copy, API, VMM, and lifetime inventory
- keep the GPU lock held until complete descendant cleanup and telemetry shutdown
- preserve and provenance-seal interrupted attempts with safe deterministic retry numbering

## Validation

- warning-strict CPU suite: 103 tests passed in 12.002 seconds
- focused interruption/resume suite: 10 tests passed in 1.845 seconds
- profiler and diagnostic CPU suite: 24 tests passed in 0.423 seconds
- Python compilation, JSON schema/example parsing, and git diff checks passed

## Scope

Tooling, tests, schema/example, and current toolkit documentation only. No production source, CMake/build dependency, runtime flag, architecture/model selection, CUDA build, GPU command, or Nsight capture.