### PR TITLE
recurrent: use consolidated snapshot mode

### DIFF
--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -1570,14 +1570,6 @@ int32_t llama_memory_recurrent_context::s_copy(int i) const {
     return (int32_t)(idx * mem->size) + src0;
 }
 
-bool llama_memory_recurrent_context::has_sparse_snapshots() const {
-    return snapshot_mode.sparse;
-}
-
-int32_t llama_memory_recurrent_context::get_selected_snapshot_token() const {
-    return snapshot_mode.selected_token;
-}
-
 const llama_recurrent_snapshot_mode & llama_memory_recurrent_context::get_snapshot_mode() const {
     return snapshot_mode;
 }

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -203,8 +203,6 @@ public:
 
     int32_t s_copy(int i) const;
 
-    bool has_sparse_snapshots() const;
-    int32_t get_selected_snapshot_token() const;
     const llama_recurrent_snapshot_mode & get_snapshot_mode() const;
 
 private:

--- a/src/models/delta-net-base.cpp
+++ b/src/models/delta-net-base.cpp
@@ -515,8 +515,9 @@ ggml_tensor * llm_build_delta_net_base::build_conv_state(
         //   the same ubatch, which `split_equal()` guarantees via its n_keep_tail argument
 
         const int64_t K = (int64_t) cparams.n_rs_seq + 1;
-        const bool sparse = mctx_cur->has_sparse_snapshots();
-        const int32_t selected = mctx_cur->get_selected_snapshot_token();
+        const auto & snapshot_mode = mctx_cur->get_snapshot_mode();
+        const bool sparse = snapshot_mode.sparse;
+        const int32_t selected = snapshot_mode.selected_token;
         const int64_t n_copies = sparse
                 ? (selected >= 0 ? 1 : K)
                 : K;
@@ -594,8 +595,9 @@ ggml_tensor * llm_build_delta_net_base::build_recurrent_attn(
 
     const int64_t D = S_v * S_v * H_v;
     const int64_t K = cparams.n_rs_seq + 1;
-    const bool sparse = mctx_cur->has_sparse_snapshots();
-    const int32_t selected = mctx_cur->get_selected_snapshot_token();
+    const auto & snapshot_mode = mctx_cur->get_snapshot_mode();
+    const bool sparse = snapshot_mode.sparse;
+    const int32_t selected = snapshot_mode.selected_token;
 
     // state s is 4D [S_v, S_v, H_v, n_seqs]; K snapshot slots are written into the output.
     ggml_tensor * gdn_out = sparse


### PR DESCRIPTION
Summary:
- have both post-v0.4.3 DeltaNet replay graph paths consume the consolidated immutable snapshot-mode object
- remove the now-redundant scalar snapshot accessors
- preserve snapshot selection, scheduling, configuration, sequence ownership, and kernel behavior unchanged

Scope boundary:
- cleanup-only follow-up to 5a6114253
- no multi-slot selected-replay behavior changes
- no fail-closed scheduling, per-sequence state, configuration, or kernel changes

Validation:
- fresh CPU Release build of test-server-prompt-checkpoint (also compiles llama recurrent memory, DeltaNet model graphs, and server context)
- ctest --test-dir build-mtp-cleanup --output-on-failure -R server-prompt-checkpoint
- git diff --check