### PR TITLE
tests: simplify staged-store exactness cleanup

### DIFF
--- a/tests/test-std-kv-tail-graph.cpp
+++ b/tests/test-std-kv-tail-graph.cpp
@@ -1,5 +1,6 @@
 #include "ggml.h"
 #include "ggml-backend.h"
+#include "ggml-cpp.h"
 #include "llama-kv-cache-tail.h"
 
 #include <cmath>
@@ -220,47 +221,45 @@ static void test_quantized_store_cross_residency(
     constexpr int64_t writes = 3;
 
     ggml_init_params params = { 1024*1024, nullptr, true };
-    ggml_context * device_ctx = ggml_init(params);
-    ggml_tensor * source = ggml_new_tensor_2d(device_ctx, GGML_TYPE_F32, width, writes);
-    ggml_tensor * direct_body = ggml_new_tensor_2d(device_ctx, GGML_TYPE_Q8_0, width, slots);
-    ggml_tensor * direct_idxs = ggml_new_tensor_1d(device_ctx, GGML_TYPE_I64, writes);
-    ggml_tensor * stage = ggml_new_tensor_2d(device_ctx, GGML_TYPE_Q8_0, width, writes);
-    ggml_backend_buffer_t device_buffer = ggml_backend_alloc_ctx_tensors(device_ctx, accelerator);
+    ggml_context_ptr device_ctx { ggml_init(params) };
+    ggml_tensor * source = ggml_new_tensor_2d(device_ctx.get(), GGML_TYPE_F32, width, writes);
+    ggml_tensor * direct_body = ggml_new_tensor_2d(device_ctx.get(), GGML_TYPE_Q8_0, width, slots);
+    ggml_tensor * direct_idxs = ggml_new_tensor_1d(device_ctx.get(), GGML_TYPE_I64, writes);
+    ggml_tensor * stage = ggml_new_tensor_2d(device_ctx.get(), GGML_TYPE_Q8_0, width, writes);
+    ggml_backend_buffer_ptr device_buffer {
+        ggml_backend_alloc_ctx_tensors(device_ctx.get(), accelerator)
+    };
     if (!device_buffer) {
         fail("cross-residency device allocation failed");
     }
 
-    ggml_context * host_ctx = ggml_init(params);
-    ggml_tensor * host_body = ggml_new_tensor_2d(host_ctx, GGML_TYPE_Q8_0, width, slots);
-    ggml_tensor * host_idxs = ggml_new_tensor_1d(host_ctx, GGML_TYPE_I64, writes);
-    ggml_backend_buffer_t host_buffer = ggml_backend_alloc_ctx_tensors(host_ctx, cpu);
-    if (!host_buffer || !ggml_backend_buft_is_host(ggml_backend_buffer_get_type(host_buffer))) {
+    ggml_context_ptr host_ctx { ggml_init(params) };
+    ggml_tensor * host_body = ggml_new_tensor_2d(host_ctx.get(), GGML_TYPE_Q8_0, width, slots);
+    ggml_tensor * host_idxs = ggml_new_tensor_1d(host_ctx.get(), GGML_TYPE_I64, writes);
+    ggml_backend_buffer_ptr host_buffer {
+        ggml_backend_alloc_ctx_tensors(host_ctx.get(), cpu)
+    };
+    if (!host_buffer || !ggml_backend_buft_is_host(ggml_backend_buffer_get_type(host_buffer.get()))) {
         fail("cross-residency host allocation failed");
     }
 
-    ggml_context * direct_ctx = ggml_init(params);
+    ggml_context_ptr direct_ctx { ggml_init(params) };
     ggml_tensor * direct_write = ggml_set_rows(
-            direct_ctx, direct_body, source, direct_idxs);
-    ggml_cgraph * direct_graph = ggml_new_graph(direct_ctx);
+            direct_ctx.get(), direct_body, source, direct_idxs);
+    ggml_cgraph * direct_graph = ggml_new_graph(direct_ctx.get());
     ggml_build_forward_expand(direct_graph, direct_write);
 
-    ggml_context * staged_ctx = ggml_init(params);
-    ggml_tensor * converted = ggml_cpy(staged_ctx, source, stage);
+    ggml_context_ptr staged_ctx { ggml_init(params) };
+    ggml_tensor * converted = ggml_cpy(staged_ctx.get(), source, stage);
     ggml_tensor * host_write = ggml_set_rows(
-            staged_ctx, host_body, converted, host_idxs);
-    ggml_cgraph * staged_graph = ggml_new_graph(staged_ctx);
+            staged_ctx.get(), host_body, converted, host_idxs);
+    ggml_cgraph * staged_graph = ggml_new_graph(staged_ctx.get());
     ggml_build_forward_expand(staged_graph, host_write);
 
     if (!ggml_backend_supports_op(accelerator, direct_write) ||
             !ggml_backend_supports_op(accelerator, converted)) {
         std::printf("cross-residency Q8 store route unsupported by %s; skipping\n",
                 ggml_backend_name(accelerator));
-        ggml_free(staged_ctx);
-        ggml_free(direct_ctx);
-        ggml_backend_buffer_free(host_buffer);
-        ggml_free(host_ctx);
-        ggml_backend_buffer_free(device_buffer);
-        ggml_free(device_ctx);
         return;
     }
 
@@ -272,8 +271,8 @@ static void test_quantized_store_cross_residency(
         }
     }
     const int64_t indices[] = { 2, 5, 1 };
-    ggml_backend_buffer_clear(device_buffer, 0);
-    ggml_backend_buffer_clear(host_buffer, 0);
+    ggml_backend_buffer_clear(device_buffer.get(), 0);
+    ggml_backend_buffer_clear(host_buffer.get(), 0);
     ggml_backend_tensor_set(source, source_data.data(), 0,
             source_data.size()*sizeof(source_data[0]));
     ggml_backend_tensor_set(direct_idxs, indices, 0, sizeof(indices));
@@ -284,15 +283,16 @@ static void test_quantized_store_cross_residency(
     }
 
     ggml_backend_t backends[] = { accelerator, cpu };
-    ggml_backend_sched_t sched = ggml_backend_sched_new(
-            backends, nullptr, 2, 32, false, true);
-    if (!sched || !ggml_backend_sched_alloc_graph(sched, staged_graph)) {
+    ggml_backend_sched_ptr sched {
+        ggml_backend_sched_new(backends, nullptr, 2, 32, false, true)
+    };
+    if (!sched || !ggml_backend_sched_alloc_graph(sched.get(), staged_graph)) {
         fail("cross-residency Q8 store graph allocation failed");
     }
-    if (ggml_backend_sched_get_tensor_backend(sched, converted) != accelerator) {
+    if (ggml_backend_sched_get_tensor_backend(sched.get(), converted) != accelerator) {
         fail("cross-residency Q8 conversion was not pinned by its persistent device stage");
     }
-    if (ggml_backend_sched_graph_compute(sched, staged_graph) != GGML_STATUS_SUCCESS) {
+    if (ggml_backend_sched_graph_compute(sched.get(), staged_graph) != GGML_STATUS_SUCCESS) {
         fail("cross-residency Q8 store failed");
     }
 
@@ -303,14 +303,6 @@ static void test_quantized_store_cross_residency(
     if (direct_bytes != host_bytes) {
         fail("cross-residency Q8 store differs from direct accelerator bytes");
     }
-
-    ggml_backend_sched_free(sched);
-    ggml_free(staged_ctx);
-    ggml_free(direct_ctx);
-    ggml_backend_buffer_free(host_buffer);
-    ggml_free(host_ctx);
-    ggml_backend_buffer_free(device_buffer);
-    ggml_free(device_ctx);
 }
 
 static void test_fully_masked_quant_body(ggml_backend_t backend, ggml_type body_type) {


### PR DESCRIPTION
## Summary
- use existing GGML RAII ownership aliases in the dedicated cross-residency Q8 store test
- remove duplicated manual teardown from the supported and unsupported paths
- leave production staging, placement, scheduler, and format behavior unchanged

## Validation
- CPU: ctest --test-dir build-cpu -R ^test-std-kv-tail-graph$ --output-on-failure
- CUDA sm_120: build-cuda-all/bin/test-std-kv-tail-graph under the single-GPU lock
- placement-lane cross-review approved the ownership and destruction-order proof

## Audit disposition
No further production staged-store consolidation is warranted. Shared aliases would add an unrepresented write hazard; transient staging would require scheduler ownership and could change conversion placement.