### PR TITLE
tests: decouple VMM telemetry from unrelated fields

### DIFF
--- a/tests/test-vmm-allocation-telemetry-static.py
+++ b/tests/test-vmm-allocation-telemetry-static.py
@@ -116,9 +116,6 @@ def main() -> None:
         "live_context_workspace",
         "composed telemetry benchmark must publish the selected live-workspace policy",
     )
-    for excluded in ("phase_aware_workspace", "flash_attn_native_quants"):
-        if excluded in bench:
-            raise AssertionError(f"W02 must not depend on later feature field {excluded}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Remove historical W02 branch-isolation assertions that rejected unrelated future `llama-bench` fields by name.
- Retain the focused VMM guards for private proc-address payload layout, dormant opt-in activation, output field/value identity, allocation classification, and live-workspace trim coexistence.
- Change no production source, runtime behavior, result field, command identity, ABI, or build configuration.

## Maintenance-cost reduction

The removed checks asserted that `phase_aware_workspace` and `flash_attn_native_quants` were absent anywhere in `llama-bench`. Git history shows that this was useful while W02 was isolated from later feature branches, but it is not a VMM telemetry invariant on composed `beellama/main`. Keeping it would make unrelated benchmark-field additions fail the CUDA VMM suite and require telemetry-lane edits despite no telemetry interaction.

This narrows the test to contracts owned by the telemetry lane and reduces cross-PR composition coupling without moving logic or adding indirection.

## Validation

Base: `3641f4c1730e55bd06991765d3b8a7b28d885596`

```bash
git diff --check origin/beellama/main..HEAD
python3 tests/test-vmm-allocation-telemetry-static.py
python3 tests/test-live-context-workspace-static.py
python3 tests/test-std-kv-tail-static.py
python3 -m py_compile tests/test-vmm-allocation-telemetry-static.py
```

All commands passed. Compile impact: none; this deletes three Python test lines and changes no production or build-system file.
