### PR TITLE
alloc: model shared member lifecycle explicitly

### DIFF
--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -518,17 +518,24 @@ struct ggml_gallocr {
     int * shared_entry_ids; // [n_buffers]
 };
 
+struct ggml_gallocr_shared_member_state {
+    bool active;
+    bool shrink_seen;
+};
+
+struct ggml_gallocr_shared_member_plan {
+    size_t requirements[GGML_VBUFFER_MAX_CHUNKS];
+};
+
 struct ggml_gallocr_shared_buffer_entry {
     ggml_backend_buffer_type_t buft;
     struct vbuffer * buffer;
     size_t allocated_sizes[GGML_VBUFFER_MAX_CHUNKS];
-    size_t * requirements; // [members_capacity][GGML_VBUFFER_MAX_CHUNKS]
-    bool * members_present; // [members_capacity]
+    struct ggml_gallocr_shared_member_plan * member_plans; // [members_capacity]
 };
 
 struct ggml_gallocr_shared_buffers {
-    bool * members_active;
-    bool * shrink_seen;
+    struct ggml_gallocr_shared_member_state * members;
     int members_capacity;
 
     struct ggml_gallocr_shared_buffer_entry * entries;
@@ -540,26 +547,19 @@ struct ggml_gallocr_shared_buffers {
     bool shrink_pending;
 };
 
-static size_t * ggml_gallocr_shared_member_requirements(
-        struct ggml_gallocr_shared_buffers * shared,
-        struct ggml_gallocr_shared_buffer_entry * entry,
-        int member) {
-    GGML_ASSERT(member >= 0 && member < shared->members_capacity);
-    return entry->requirements + (size_t) member * GGML_VBUFFER_MAX_CHUNKS;
-}
-
 static bool ggml_gallocr_shared_resize_entry(
         struct ggml_gallocr_shared_buffers * shared,
         struct ggml_gallocr_shared_buffer_entry * entry,
         bool shrink_ready) {
     size_t required[GGML_VBUFFER_MAX_CHUNKS] = {0};
     for (int member = 0; member < shared->members_capacity; ++member) {
-        if (!shared->members_active[member] || !entry->members_present[member]) {
+        const struct ggml_gallocr_shared_member_state * state = &shared->members[member];
+        const struct ggml_gallocr_shared_member_plan * plan = &entry->member_plans[member];
+        if (!state->active) {
             continue;
         }
-        const size_t * member_req = ggml_gallocr_shared_member_requirements(shared, entry, member);
         for (int chunk = 0; chunk < GGML_VBUFFER_MAX_CHUNKS; ++chunk) {
-            required[chunk] = MAX(required[chunk], member_req[chunk]);
+            required[chunk] = MAX(required[chunk], plan->requirements[chunk]);
         }
     }
 
@@ -633,23 +633,24 @@ static bool ggml_gallocr_shared_reserve(ggml_gallocr_t galloc) {
         }
         entry_updated[entry_id] = true;
 
-        size_t * requirements = ggml_gallocr_shared_member_requirements(
-                galloc->shared, &galloc->shared->entries[entry_id], galloc->shared_member);
+        struct ggml_gallocr_shared_member_plan * plan =
+                &galloc->shared->entries[entry_id].member_plans[galloc->shared_member];
         size_t next[GGML_VBUFFER_MAX_CHUNKS] = {0};
         for (int c = 0; c < galloc->buf_tallocs[i]->n_chunks; ++c) {
             next[c] = ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i], c);
         }
-        memcpy(requirements, next, sizeof(next));
+        memcpy(plan->requirements, next, sizeof(next));
     }
     free(entry_updated);
 
     bool shrink_ready = false;
     if (galloc->shared->shrink_pending) {
-        galloc->shared->shrink_seen[galloc->shared_member] = true;
+        galloc->shared->members[galloc->shared_member].shrink_seen = true;
         shrink_ready = true;
         for (int member = 0; member < galloc->shared->members_capacity; ++member) {
-            if (galloc->shared->members_active[member] &&
-                    !galloc->shared->shrink_seen[member]) {
+            const struct ggml_gallocr_shared_member_state * state =
+                    &galloc->shared->members[member];
+            if (state->active && !state->shrink_seen) {
                 shrink_ready = false;
                 break;
             }
@@ -659,9 +660,8 @@ static bool ggml_gallocr_shared_reserve(ggml_gallocr_t galloc) {
     const bool ok = ggml_gallocr_shared_resize_all(galloc->shared, shrink_ready);
     if (ok && shrink_ready) {
         galloc->shared->shrink_pending = false;
-        if (galloc->shared->members_capacity > 0) {
-            memset(galloc->shared->shrink_seen, 0,
-                    (size_t) galloc->shared->members_capacity * sizeof(bool));
+        for (int member = 0; member < galloc->shared->members_capacity; ++member) {
+            galloc->shared->members[member].shrink_seen = false;
         }
     }
     return ok;
@@ -680,12 +680,10 @@ void ggml_gallocr_shared_buffers_free(ggml_gallocr_shared_buffers_t shared) {
     }
     for (int i = 0; i < shared->n_entries; ++i) {
         ggml_vbuffer_free(shared->entries[i].buffer);
-        free(shared->entries[i].requirements);
-        free(shared->entries[i].members_present);
+        free(shared->entries[i].member_plans);
     }
     free(shared->entries);
-    free(shared->members_active);
-    free(shared->shrink_seen);
+    free(shared->members);
     free(shared);
 }
 
@@ -703,9 +701,8 @@ void ggml_gallocr_shared_buffers_request_shrink(ggml_gallocr_shared_buffers_t sh
         return;
     }
     shared->shrink_pending = true;
-    if (shared->members_capacity > 0) {
-        memset(shared->shrink_seen, 0,
-                (size_t) shared->members_capacity * sizeof(bool));
+    for (int member = 0; member < shared->members_capacity; ++member) {
+        shared->members[member].shrink_seen = false;
     }
     shared->plan_generation++;
 }
@@ -720,50 +717,45 @@ static void ggml_gallocr_shared_grow_members(
     while (new_capacity < capacity) {
         new_capacity *= 2;
     }
-    shared->members_active = (bool *) realloc(
-            shared->members_active, (size_t) new_capacity * sizeof(bool));
-    GGML_ASSERT(shared->members_active != NULL);
-    memset(shared->members_active + old_capacity, 0,
-            (size_t) (new_capacity - old_capacity) * sizeof(bool));
-    shared->shrink_seen = (bool *) realloc(
-            shared->shrink_seen, (size_t) new_capacity * sizeof(bool));
-    GGML_ASSERT(shared->shrink_seen != NULL);
-    memset(shared->shrink_seen + old_capacity, 0,
-            (size_t) (new_capacity - old_capacity) * sizeof(bool));
+    shared->members = (struct ggml_gallocr_shared_member_state *) realloc(
+            shared->members, (size_t) new_capacity * sizeof(*shared->members));
+    GGML_ASSERT(shared->members != NULL);
+    memset(shared->members + old_capacity, 0,
+            (size_t) (new_capacity - old_capacity) * sizeof(*shared->members));
 
     for (int i = 0; i < shared->n_entries; ++i) {
         struct ggml_gallocr_shared_buffer_entry * entry = &shared->entries[i];
-        entry->requirements = (size_t *) realloc(entry->requirements,
-                (size_t) new_capacity * GGML_VBUFFER_MAX_CHUNKS * sizeof(size_t));
-        GGML_ASSERT(entry->requirements != NULL);
-        memset(entry->requirements + (size_t) old_capacity * GGML_VBUFFER_MAX_CHUNKS, 0,
-                (size_t) (new_capacity - old_capacity) * GGML_VBUFFER_MAX_CHUNKS * sizeof(size_t));
-        entry->members_present = (bool *) realloc(
-                entry->members_present, (size_t) new_capacity * sizeof(bool));
-        GGML_ASSERT(entry->members_present != NULL);
-        memset(entry->members_present + old_capacity, 0,
-                (size_t) (new_capacity - old_capacity) * sizeof(bool));
+        entry->member_plans = (struct ggml_gallocr_shared_member_plan *) realloc(
+                entry->member_plans, (size_t) new_capacity * sizeof(*entry->member_plans));
+        GGML_ASSERT(entry->member_plans != NULL);
+        memset(entry->member_plans + old_capacity, 0,
+                (size_t) (new_capacity - old_capacity) * sizeof(*entry->member_plans));
     }
     shared->members_capacity = new_capacity;
 }
 
+static void ggml_gallocr_shared_clear_member_plans(
+        struct ggml_gallocr_shared_buffers * shared,
+        int member) {
+    GGML_ASSERT(member >= 0 && member < shared->members_capacity);
+    for (int i = 0; i < shared->n_entries; ++i) {
+        struct ggml_gallocr_shared_buffer_entry * entry = &shared->entries[i];
+        memset(&entry->member_plans[member], 0, sizeof(entry->member_plans[member]));
+    }
+}
+
 static int ggml_gallocr_shared_register_member(struct ggml_gallocr_shared_buffers * shared) {
     for (int i = 0; i < shared->members_capacity; ++i) {
-        if (!shared->members_active[i]) {
-            for (int j = 0; j < shared->n_entries; ++j) {
-                struct ggml_gallocr_shared_buffer_entry * entry = &shared->entries[j];
-                memset(ggml_gallocr_shared_member_requirements(shared, entry, i), 0,
-                        GGML_VBUFFER_MAX_CHUNKS * sizeof(size_t));
-                entry->members_present[i] = false;
-            }
-            shared->shrink_seen[i] = false;
-            shared->members_active[i] = true;
+        if (!shared->members[i].active) {
+            ggml_gallocr_shared_clear_member_plans(shared, i);
+            shared->members[i].shrink_seen = false;
+            shared->members[i].active = true;
             return i;
         }
     }
     const int member = shared->members_capacity;
     ggml_gallocr_shared_grow_members(shared, member + 1);
-    shared->members_active[member] = true;
+    shared->members[member].active = true;
     return member;
 }
 
@@ -771,18 +763,11 @@ static void ggml_gallocr_shared_unregister_member(
         struct ggml_gallocr_shared_buffers * shared,
         int member) {
     GGML_ASSERT(member >= 0 && member < shared->members_capacity);
-    shared->members_active[member] = false;
-    shared->shrink_seen[member] = false;
-    for (int i = 0; i < shared->n_entries; ++i) {
-        struct ggml_gallocr_shared_buffer_entry * entry = &shared->entries[i];
-        size_t * requirements = ggml_gallocr_shared_member_requirements(shared, entry, member);
-        memset(requirements, 0, GGML_VBUFFER_MAX_CHUNKS * sizeof(size_t));
-        if (entry->members_present[member]) {
-            entry->members_present[member] = false;
-        }
-    }
+    shared->members[member].active = false;
+    shared->members[member].shrink_seen = false;
+    ggml_gallocr_shared_clear_member_plans(shared, member);
     for (int other = 0; other < shared->members_capacity; ++other) {
-        if (shared->members_active[other]) {
+        if (shared->members[other].active) {
             // A live peer must republish before a former member's maximum
             // can be reclaimed without invalidating a graph in flight.
             ggml_gallocr_shared_buffers_request_shrink(shared);
@@ -815,12 +800,9 @@ static int ggml_gallocr_shared_find_or_add_entry(
     struct ggml_gallocr_shared_buffer_entry * entry = &shared->entries[id];
     memset(entry, 0, sizeof(*entry));
     entry->buft = buft;
-    entry->requirements = (size_t *) calloc(
-            (size_t) shared->members_capacity * GGML_VBUFFER_MAX_CHUNKS, sizeof(size_t));
-    GGML_ASSERT(entry->requirements != NULL || shared->members_capacity == 0);
-    entry->members_present = (bool *) calloc(
-            (size_t) shared->members_capacity, sizeof(bool));
-    GGML_ASSERT(entry->members_present != NULL || shared->members_capacity == 0);
+    entry->member_plans = (struct ggml_gallocr_shared_member_plan *) calloc(
+            (size_t) shared->members_capacity, sizeof(*entry->member_plans));
+    GGML_ASSERT(entry->member_plans != NULL || shared->members_capacity == 0);
     return id;
 }
 
@@ -942,7 +924,6 @@ void ggml_gallocr_set_shared_buffers(
 
     for (int i = 0; i < galloc->n_buffers; ++i) {
         galloc->shared_entry_ids[i] = ggml_gallocr_shared_find_or_add_entry(shared, galloc->bufts[i]);
-        shared->entries[galloc->shared_entry_ids[i]].members_present[galloc->shared_member] = true;
     }
 }
 

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -756,6 +756,91 @@ static void test_shared_buffers_single_member_resize() {
     GGML_ASSERT(backend.context->allocated_total() == 0);
 }
 
+static void test_shared_buffers_reuse_member_slot() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+
+    auto make_add_graph = [](int64_t n_elements) {
+        auto result = make_context();
+        ggml_tensor * a = make_input_1d(result.ctx, n_elements);
+        ggml_tensor * b = make_input_1d(result.ctx, n_elements);
+        ggml_build_forward_expand(result.graph, ggml_add(result.ctx, a, b));
+        return result;
+    };
+
+    auto survivor_graph = make_add_graph(4);
+    auto replacement_graph = make_add_graph(4);
+    auto departing_graph = make_add_graph(24);
+
+    ggml_gallocr_shared_buffers_t shared = ggml_gallocr_shared_buffers_new();
+    {
+        ggml_gallocr_ptr survivor(ggml_gallocr_new(&backend.buffer_type));
+        ggml_gallocr_ptr departing(ggml_gallocr_new(&backend.buffer_type));
+        ggml_gallocr_set_shared_buffers(survivor.get(), shared);
+        ggml_gallocr_set_shared_buffers(departing.get(), shared);
+
+        GGML_ASSERT(ggml_gallocr_reserve(survivor.get(), survivor_graph.graph));
+        const size_t small_size = backend.context->allocated_total();
+        GGML_ASSERT(ggml_gallocr_reserve(departing.get(), departing_graph.graph));
+        const size_t large_size = backend.context->allocated_total();
+        GGML_ASSERT(large_size > small_size);
+
+        departing.reset();
+        GGML_ASSERT(backend.context->allocated_total() == large_size);
+
+        ggml_gallocr_ptr replacement(ggml_gallocr_new(&backend.buffer_type));
+        ggml_gallocr_set_shared_buffers(replacement.get(), shared);
+
+        // Reusing the departed member's slot must clear its large plan, while
+        // the pending shrink still waits for the replacement to publish.
+        GGML_ASSERT(ggml_gallocr_reserve(survivor.get(), survivor_graph.graph));
+        GGML_ASSERT(backend.context->allocated_total() == large_size);
+        GGML_ASSERT(ggml_gallocr_reserve(replacement.get(), replacement_graph.graph));
+        GGML_ASSERT(backend.context->allocated_total() == small_size);
+
+        GGML_ASSERT(ggml_gallocr_alloc_graph(survivor.get(), survivor_graph.graph));
+        check_all_allocated(survivor_graph.graph);
+        GGML_ASSERT(ggml_gallocr_alloc_graph(replacement.get(), replacement_graph.graph));
+        check_all_allocated(replacement_graph.graph);
+    }
+    ggml_gallocr_shared_buffers_free(shared);
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_shared_buffers_alias_duplicate_buffer_types() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+    auto [ctx, graph, ctx_ptr] = make_context();
+
+    ggml_tensor * a = make_input_with_size(ctx, 16);
+    ggml_tensor * b = make_input_with_size(ctx, 16);
+    ggml_tensor * out = ggml_add(ctx, a, b);
+    ggml_set_output(out);
+    ggml_build_forward_expand(graph, out);
+
+    GGML_ASSERT(graph->n_leafs == 2);
+    GGML_ASSERT(graph->n_nodes == 1);
+    int leaf_buffer_ids[2] = { 0, 1 };
+    int node_buffer_ids[1] = { 1 };
+    ggml_backend_buffer_type_t bufts[2] = { &backend.buffer_type, &backend.buffer_type };
+
+    ggml_gallocr_shared_buffers_t shared = ggml_gallocr_shared_buffers_new();
+    {
+        ggml_gallocr_ptr alloc(ggml_gallocr_new_n(bufts, 2));
+        ggml_gallocr_set_shared_buffers(alloc.get(), shared);
+        GGML_ASSERT(ggml_gallocr_reserve_n(alloc.get(), graph, node_buffer_ids, leaf_buffer_ids));
+
+        const size_t shared_size = ggml_gallocr_get_buffer_size(alloc.get(), 0);
+        GGML_ASSERT(shared_size > 0);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(alloc.get(), 1) == 0);
+        GGML_ASSERT(backend.context->allocated_total() == shared_size);
+
+        GGML_ASSERT(ggml_gallocr_alloc_graph(alloc.get(), graph));
+        check_all_allocated(graph);
+        check_no_overlap(graph);
+    }
+    ggml_gallocr_shared_buffers_free(shared);
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
 static void test_shared_buffers_ignore_nonmembers() {
     dummy_backend first_backend  = dummy_backend_init(SIZE_MAX, /*align*/ 4);
     dummy_backend second_backend = dummy_backend_init(SIZE_MAX, /*align*/ 4);
@@ -829,6 +914,8 @@ int main() {
     run("test_reallocation", test_reallocation);
     run("test_shared_buffers_track_maximum_plan", test_shared_buffers_track_maximum_plan);
     run("test_shared_buffers_single_member_resize", test_shared_buffers_single_member_resize);
+    run("test_shared_buffers_reuse_member_slot", test_shared_buffers_reuse_member_slot);
+    run("test_shared_buffers_alias_duplicate_buffer_types", test_shared_buffers_alias_duplicate_buffer_types);
     run("test_shared_buffers_ignore_nonmembers", test_shared_buffers_ignore_nonmembers);
     return 0;
 }


### PR DESCRIPTION
## Summary

- replace four capacity-coupled shared-lifecycle arrays with a typed member-state array and per-entry member-plan arrays
- remove the redundant per-entry membership bit; non-member rows are zero throughout construction, growth, removal, and slot reuse, so they contribute the same zero requirement to maximum-plan sizing
- add behavioral coverage for member-slot reuse during a pending shrink epoch and duplicate-buffer-type aliasing under shared backing

## Maintenance-cost reduction

The fork-local shared allocator previously had to grow, clear, index, and free four synchronized raw arrays, including manual `[member][chunk]` pointer arithmetic. This change encodes the two ownership relationships directly: group-owned member lifecycle state and entry-owned member plans. Member growth now has two reallocating ownership sites instead of four, row clearing has one private lifecycle helper, and the allocator implementation is 19 lines smaller despite the explicit types.

This stays inside the post-v0.4.3 shared lifecycle block. It does not change public headers, allocator APIs, the inherited private allocation/free loops, scheduler/context code, or shared physical-buffer ownership.

## Behavior preserved

- maximum-plan sizing across active target/MTP members
- group-wide shrink publication barrier, including disjoint backend topologies
- free-before-replace generation invalidation and allocation failure ordering
- deferred reclaim after member removal and safe inactive-slot reuse
- duplicate buffer-type aliasing to one physical shared backing
- caller-owned allocator/group lifetimes and all public compatibility

Diagnostics cross-review found no blocker. It verified that absent member-entry rows are zeroed by entry creation, capacity growth, unregister, and slot reuse; `present` never represented shrink publication. Broader ownership wrappers were rejected because they would only move state and churn inherited paths, while changing group ownership would alter caller-visible lifetime behavior.

## Tests

CPU Debug configuration (`GGML_CUDA=OFF`, tests enabled):

```text
cmake --build build-cleanup --target llama test-alloc --parallel 12
ctest --test-dir build-cleanup --output-on-failure \
  -R '^(test-alloc|test-live-context-workspace-static|test-vmm-allocation-telemetry-static)$'
```

3/3 passed. The allocator binary also passed directly, including the two new lifecycle cases. No GPU run was needed for this internal metadata-only refactor.