### PR TITLE
cuda: add opt-in VMM pool telemetry

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -532,7 +532,92 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
 };
 
 // pool with virtual memory
+struct ggml_cuda_vmm_pool_stats {
+    uint64_t live_bytes;
+    uint64_t live_peak_bytes;
+    uint64_t mapped_bytes;
+    uint64_t mapped_peak_bytes;
+    uint64_t active_pools;
+};
+
 #if defined(GGML_USE_VMM)
+struct ggml_cuda_vmm_pool_stats_atomic {
+    std::atomic<bool>     enabled           { false };
+    std::atomic<uint64_t> live_bytes        { 0 };
+    std::atomic<uint64_t> live_peak_bytes   { 0 };
+    std::atomic<uint64_t> mapped_bytes      { 0 };
+    std::atomic<uint64_t> mapped_peak_bytes { 0 };
+    std::atomic<uint64_t> active_pools      { 0 };
+
+    static void update_peak(std::atomic<uint64_t> & peak, uint64_t value) {
+        uint64_t observed = peak.load(std::memory_order_relaxed);
+        while (observed < value &&
+                !peak.compare_exchange_weak(observed, value,
+                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+        }
+    }
+
+    bool is_enabled() const {
+        return enabled.load(std::memory_order_relaxed);
+    }
+
+    void add_live(uint64_t size) {
+        const uint64_t live = live_bytes.fetch_add(size, std::memory_order_relaxed) + size;
+        update_peak(live_peak_bytes, live);
+    }
+
+    void remove_live(uint64_t size) {
+        live_bytes.fetch_sub(size, std::memory_order_relaxed);
+    }
+
+    void add_mapped(uint64_t size) {
+        const uint64_t mapped = mapped_bytes.fetch_add(size, std::memory_order_relaxed) + size;
+        update_peak(mapped_peak_bytes, mapped);
+    }
+
+    void remove_mapped(uint64_t size) {
+        mapped_bytes.fetch_sub(size, std::memory_order_relaxed);
+    }
+
+    void track_pool(uint64_t live, uint64_t mapped) {
+        active_pools.fetch_add(1, std::memory_order_relaxed);
+        add_live(live);
+        add_mapped(mapped);
+    }
+
+    void untrack_pool(uint64_t live, uint64_t mapped) {
+        remove_live(live);
+        remove_mapped(mapped);
+        active_pools.fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    ggml_cuda_vmm_pool_stats checkpoint() const {
+        return {
+            live_bytes.load(std::memory_order_relaxed),
+            live_peak_bytes.load(std::memory_order_relaxed),
+            mapped_bytes.load(std::memory_order_relaxed),
+            mapped_peak_bytes.load(std::memory_order_relaxed),
+            active_pools.load(std::memory_order_relaxed),
+        };
+    }
+
+    void reset_peaks() {
+        enabled.store(true, std::memory_order_relaxed);
+        live_peak_bytes.store(live_bytes.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        mapped_peak_bytes.store(mapped_bytes.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    }
+};
+
+static ggml_cuda_vmm_pool_stats_atomic g_cuda_vmm_pool_stats[GGML_CUDA_MAX_DEVICES];
+
+static ggml_cuda_vmm_pool_stats_atomic * ggml_cuda_vmm_pool_stats_for_device(int device) {
+    if (device < 0 || device >= ggml_cuda_info().device_count ||
+            !ggml_cuda_info().devices[device].vmm) {
+        return nullptr;
+    }
+    return &g_cuda_vmm_pool_stats[device];
+}
+
 struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
     static const size_t CUDA_POOL_VMM_MAX_SIZE = 1ull << 35; // 32 GB
 
@@ -542,6 +627,7 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
     size_t pool_used = 0;
     size_t pool_size = 0;
     size_t granularity;
+    bool telemetry_tracked = false;
 #if defined(GGML_USE_HIP)
     std::vector<std::pair<CUdeviceptr, size_t>> mappings;
 #endif
@@ -550,9 +636,21 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         device(device),
         physical_device(ggml_cuda_get_physical_device(device)),
         granularity(ggml_cuda_info().devices[device].vmm_granularity) {
+        track_telemetry();
+    }
+
+    void track_telemetry() {
+        auto & stats = g_cuda_vmm_pool_stats[device];
+        if (telemetry_tracked || !stats.is_enabled()) {
+            return;
+        }
+
+        telemetry_tracked = true;
+        stats.track_pool(pool_used, pool_size);
     }
 
     ~ggml_cuda_pool_vmm() {
+        track_telemetry();
         if (pool_addr != 0) {
 #if defined(GGML_USE_HIP)
             // Workaround for https://github.com/ROCm/ROCR-Runtime/issues/285
@@ -564,9 +662,13 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
 #endif
             CU_CHECK(cuMemAddressFree(pool_addr, CUDA_POOL_VMM_MAX_SIZE));
         }
+        if (telemetry_tracked) {
+            g_cuda_vmm_pool_stats[device].untrack_pool(pool_used, pool_size);
+        }
     }
 
     void * alloc(size_t size, size_t * actual_size) override {
+        track_telemetry();
         // round up the allocation size to the alignment to ensure that all allocations are aligned for all data types
         const size_t alignment = 128;
         size = alignment * ((size + alignment - 1) / alignment);
@@ -650,6 +752,9 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
 
             // add to the pool
             pool_size += reserve_size;
+            if (telemetry_tracked) {
+                g_cuda_vmm_pool_stats[device].add_mapped(reserve_size);
+            }
 
             //printf("cuda pool[%d]: size increased to %llu MB (reserved %llu MB)\n",
             //       device, (unsigned long long) (pool_size/1024/1024),
@@ -661,6 +766,9 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         void * ptr = (void *) ((CUdeviceptr)((char *)(pool_addr) + pool_used));
         *actual_size = size;
         pool_used += size;
+        if (telemetry_tracked) {
+            g_cuda_vmm_pool_stats[device].add_live(size);
+        }
 
 #ifdef DEBUG_CUDA_MALLOC
         printf("cuda pool[%d]: allocated %llu bytes at %llx\n", device, (unsigned long long) size, ptr);
@@ -670,17 +778,55 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
     }
 
     void free(void * ptr, size_t size) override {
+        track_telemetry();
 #ifdef DEBUG_CUDA_MALLOC
         printf("cuda pool[%d]: freed %llu bytes at %llx\n", device, (unsigned long long) size, ptr);
 #endif
 
         pool_used -= size;
+        if (telemetry_tracked) {
+            g_cuda_vmm_pool_stats[device].remove_live(size);
+        }
 
         // all deallocations must be in reverse order of the allocations
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
     }
 };
 #endif // defined(GGML_USE_VMM)
+
+static bool ggml_backend_cuda_vmm_pool_stats_get(int device, ggml_cuda_vmm_pool_stats * stats) {
+#if defined(GGML_USE_VMM)
+    if (stats == nullptr) {
+        return false;
+    }
+    ggml_cuda_vmm_pool_stats_atomic * source = ggml_cuda_vmm_pool_stats_for_device(device);
+    if (source == nullptr) {
+        return false;
+    }
+
+    *stats = source->checkpoint();
+    return true;
+#else
+    GGML_UNUSED(device);
+    GGML_UNUSED(stats);
+    return false;
+#endif
+}
+
+static bool ggml_backend_cuda_vmm_pool_stats_reset(int device) {
+#if defined(GGML_USE_VMM)
+    ggml_cuda_vmm_pool_stats_atomic * stats = ggml_cuda_vmm_pool_stats_for_device(device);
+    if (stats == nullptr) {
+        return false;
+    }
+
+    stats->reset_peaks();
+    return true;
+#else
+    GGML_UNUSED(device);
+    return false;
+#endif
+}
 
 std::unique_ptr<ggml_cuda_pool> ggml_backend_cuda_context::new_pool_for_device(int                  device,
                                                                                [[maybe_unused]] int stream_no) {
@@ -5486,6 +5632,12 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     }
     if (strcmp(name, "ggml_backend_get_features") == 0) {
         return (void *)ggml_backend_cuda_get_features;
+    }
+    if (strcmp(name, "ggml_backend_cuda_vmm_pool_stats_get") == 0) {
+        return (void *)ggml_backend_cuda_vmm_pool_stats_get;
+    }
+    if (strcmp(name, "ggml_backend_cuda_vmm_pool_stats_reset") == 0) {
+        return (void *)ggml_backend_cuda_vmm_pool_stats_reset;
     }
     return nullptr;
 }

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -359,6 +359,7 @@ struct cmd_params {
     bool                             verbose;
     bool                             progress;
     bool                             no_warmup;
+    bool                             cuda_vmm_telemetry;
     output_formats                   output_format;
     output_formats                   output_format_stderr;
 };
@@ -403,6 +404,7 @@ static const cmd_params cmd_params_defaults = {
     /* verbose              */ false,
     /* progress             */ false,
     /* no_warmup            */ false,
+    /* cuda_vmm_telemetry   */ false,
     /* output_format        */ MARKDOWN,
     /* output_format_stderr */ NONE,
 };
@@ -422,6 +424,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -v, --verbose                               verbose output\n");
     printf("  --progress                                  print test progress indicators\n");
     printf("  --no-warmup                                 skip warmup runs before benchmarking\n");
+    printf("  --cuda-vmm-telemetry                        report CUDA VMM pool allocation checkpoints\n");
     printf("  -fitt, --fit-target <MiB>                   fit model to device memory with this margin per device in MiB (default: off)\n");
     printf("  -fitc, --fit-ctx <n>                        minimum ctx size for --fit-target (default: 4096)\n");
     if (llama_supports_rpc()) {
@@ -520,6 +523,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     params.delay                = cmd_params_defaults.delay;
     params.progress             = cmd_params_defaults.progress;
     params.no_warmup            = cmd_params_defaults.no_warmup;
+    params.cuda_vmm_telemetry   = cmd_params_defaults.cuda_vmm_telemetry;
     params.offline              = cmd_params_defaults.offline;
 
     if (const char * env = getenv("HF_TOKEN")) {
@@ -1040,6 +1044,8 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 params.progress = true;
             } else if (arg == "--no-warmup") {
                 params.no_warmup = true;
+            } else if (arg == "--cuda-vmm-telemetry") {
+                params.cuda_vmm_telemetry = true;
             } else if (arg == "-fitt" || arg == "--fit-target") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1435,6 +1441,14 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
 
     return instances;
 }
+
+struct bench_cuda_vmm_pool_stats {
+    uint64_t live_bytes;
+    uint64_t live_peak_bytes;
+    uint64_t mapped_bytes;
+    uint64_t mapped_peak_bytes;
+    uint64_t active_pools;
+};
 
 struct test {
     static const std::string build_commit;
@@ -2185,6 +2199,80 @@ static std::unique_ptr<printer> create_printer(output_formats format) {
     GGML_ABORT("fatal error");
 }
 
+using bench_cuda_vmm_pool_stats_get_fn = bool (*)(int, bench_cuda_vmm_pool_stats *);
+using bench_cuda_vmm_pool_stats_reset_fn = bool (*)(int);
+
+static ggml_backend_dev_t bench_cuda_vmm_device(const cmd_params_instance & inst) {
+    if (inst.main_gpu >= 0 && size_t(inst.main_gpu) < inst.devices.size() &&
+            inst.devices[inst.main_gpu] != nullptr) {
+        return inst.devices[inst.main_gpu];
+    }
+    for (ggml_backend_dev_t dev : inst.devices) {
+        if (dev != nullptr && ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+            return dev;
+        }
+    }
+    return ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_GPU);
+}
+
+class bench_cuda_vmm_telemetry {
+public:
+    void init(ggml_backend_dev_t dev) {
+        if (dev == nullptr) {
+            return;
+        }
+        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+        for (size_t i = 0; i < ggml_backend_reg_dev_count(reg); ++i) {
+            if (ggml_backend_reg_dev_get(reg, i) == dev) {
+                cuda_device_ = int(i);
+                break;
+            }
+        }
+        if (cuda_device_ < 0) {
+            return;
+        }
+        get_ = reinterpret_cast<bench_cuda_vmm_pool_stats_get_fn>(
+            ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_vmm_pool_stats_get"));
+        reset_ = reinterpret_cast<bench_cuda_vmm_pool_stats_reset_fn>(
+            ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_vmm_pool_stats_reset"));
+    }
+
+    int device() const {
+        return cuda_device_;
+    }
+
+    bool reset() const {
+        return reset_ != nullptr && reset_(cuda_device_);
+    }
+
+    bench_cuda_vmm_pool_stats checkpoint() const {
+        bench_cuda_vmm_pool_stats stats = {};
+        if (get_ != nullptr) {
+            (void) get_(cuda_device_, &stats);
+        }
+        return stats;
+    }
+
+private:
+    int                                cuda_device_ = -1;
+    bench_cuda_vmm_pool_stats_get_fn   get_ = nullptr;
+    bench_cuda_vmm_pool_stats_reset_fn reset_ = nullptr;
+};
+
+static void bench_cuda_vmm_print(
+        int cuda_device,
+        const bench_cuda_vmm_pool_stats & model,
+        const bench_cuda_vmm_pool_stats & context,
+        const bench_cuda_vmm_pool_stats & workload,
+        const bench_cuda_vmm_pool_stats & teardown) {
+    fprintf(stderr, "llama-bench: CUDA VMM device %d: model live=%" PRIu64 " mapped=%" PRIu64 " pools=%" PRIu64 "; context live=%" PRIu64 " mapped=%" PRIu64 " pools=%" PRIu64 "; workload live=%" PRIu64 " mapped=%" PRIu64 " live_peak=%" PRIu64 " mapped_peak=%" PRIu64 " pools=%" PRIu64 "; teardown live=%" PRIu64 " mapped=%" PRIu64 " pools=%" PRIu64 "\n",
+            cuda_device,
+            model.live_bytes, model.mapped_bytes, model.active_pools,
+            context.live_bytes, context.mapped_bytes, context.active_pools,
+            workload.live_bytes, workload.mapped_bytes, workload.live_peak_bytes, workload.mapped_peak_bytes, workload.active_pools,
+            teardown.live_bytes, teardown.mapped_bytes, teardown.active_pools);
+}
+
 // satisfies -Wmissing-declarations
 int llama_bench(int argc, char ** argv);
 
@@ -2312,6 +2400,21 @@ int llama_bench(int argc, char ** argv) {
             prev_inst = &inst;
         }
 
+        bench_cuda_vmm_telemetry vmm_telemetry;
+        bench_cuda_vmm_pool_stats cuda_vmm_model = {};
+        bench_cuda_vmm_pool_stats cuda_vmm_context = {};
+        bool cuda_vmm_telemetry_active = false;
+        if (params.cuda_vmm_telemetry) {
+            ggml_backend_dev_t vmm_dev = bench_cuda_vmm_device(inst);
+            vmm_telemetry.init(vmm_dev);
+            cuda_vmm_telemetry_active = vmm_telemetry.reset();
+            if (cuda_vmm_telemetry_active) {
+                cuda_vmm_model = vmm_telemetry.checkpoint();
+            } else {
+                fprintf(stderr, "llama-bench: CUDA VMM telemetry is unavailable for the selected device\n");
+            }
+        }
+
         llama_context * ctx = llama_init_from_model(lmodel, cparams);
         if (ctx == NULL) {
             fprintf(stderr, "%s: error: failed to create context with model '%s'\n", __func__, inst.model.c_str());
@@ -2320,6 +2423,9 @@ int llama_bench(int argc, char ** argv) {
         }
 
         test t(inst, lmodel, ctx);
+        if (cuda_vmm_telemetry_active) {
+            cuda_vmm_context = vmm_telemetry.checkpoint();
+        }
 
         llama_memory_clear(llama_get_memory(ctx), false);
 
@@ -2376,6 +2482,10 @@ int llama_bench(int argc, char ** argv) {
                     exit(1);
                 }
             }
+        }
+
+        if (cuda_vmm_telemetry_active) {
+            (void) vmm_telemetry.reset();
         }
 
         for (int i = 0; i < params.reps; i++) {
@@ -2451,6 +2561,17 @@ int llama_bench(int argc, char ** argv) {
             t.samples_ns.push_back(t_ns);
         }
 
+        if (cuda_vmm_telemetry_active) {
+            const bench_cuda_vmm_pool_stats cuda_vmm_after_workload = vmm_telemetry.checkpoint();
+
+            llama_perf_context_print(ctx);
+            llama_free(ctx);
+            ctx = nullptr;
+
+            const bench_cuda_vmm_pool_stats cuda_vmm_after_context = vmm_telemetry.checkpoint();
+            bench_cuda_vmm_print(vmm_telemetry.device(), cuda_vmm_model, cuda_vmm_context, cuda_vmm_after_workload, cuda_vmm_after_context);
+        }
+
         if (p) {
             p->print_test(t);
             fflush(p->fout);
@@ -2461,9 +2582,10 @@ int llama_bench(int argc, char ** argv) {
             fflush(p_err->fout);
         }
 
-        llama_perf_context_print(ctx);
-
-        llama_free(ctx);
+        if (ctx != nullptr) {
+            llama_perf_context_print(ctx);
+            llama_free(ctx);
+        }
 
         ggml_threadpool_free_fn(threadpool);
     }


### PR DESCRIPTION
Adds an isolated --cuda-vmm-telemetry mode to llama-bench. The CUDA backend exposes private VMM live, mapped, peak, and active-pool counters through its existing proc-address registry; llama-bench reports model, context, workload, and teardown checkpoints to stderr only when requested.

Default benchmark output schemas and behavior remain unchanged. Device selection resolves the selected backend device to its CUDA registry ordinal, including explicit device filtering or reordering.

Validation: git diff --check, CPU-only llama-bench compilation, option visibility, and unchanged default output-schema checks passed. CUDA compilation and runtime telemetry validation remain pending before readiness.