### PR TITLE
speculative: add independent draft ubatch

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1303,6 +1303,7 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
             common_params_print_completion(ctx_arg);
             exit(0);
         }
+        common_validate_speculative_params(ctx_arg.params.speculative, ctx_arg.params.n_ubatch);
         params.lr.init();
     } catch (const std::invalid_argument & ex) {
         fprintf(stderr, "%s\n", ex.what());
@@ -4139,6 +4140,17 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.speculative.draft.n_min = value;
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_N_MIN"));
+    add_opt(common_arg(
+        {"--spec-draft-ubatch-size", "--ubatch-size-draft", "-ubd"}, "N",
+        "physical maximum batch size for the draft context (default: 0, inherit target ubatch); "
+        "draft-mtp requires 0 or the target ubatch",
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("invalid value");
+            }
+            params.speculative.draft.n_ubatch = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_UBATCH"));
 
     add_opt(common_arg(
         {"--spec-draft-p-split", "--draft-p-split"}, "P",

--- a/common/common.h
+++ b/common/common.h
@@ -324,6 +324,7 @@ struct common_params_model {
 struct common_params_speculative_draft {
     int32_t n_max = 3; // maximum number of tokens to draft during speculative decoding
     int32_t n_min = 0; // minimum number of draft tokens to use for speculative decoding
+    int32_t n_ubatch = 0; // physical draft batch size (0 = inherit target)
 
     float p_split = 0.1f; // speculative decoding split probability
     float p_min   = 0.0f; // minimum speculative decoding probability (greedy)

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2208,6 +2208,20 @@ std::string common_speculative_type_to_str(common_speculative_type type) {
     }
 }
 
+void common_validate_speculative_params(
+        const common_params_speculative & params,
+        int32_t target_ubatch) {
+    const bool has_mtp = std::find(
+            params.types.begin(), params.types.end(), COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params.types.end();
+
+    if (has_mtp && params.draft.n_ubatch > 0 && target_ubatch > 0 && params.draft.n_ubatch != target_ubatch) {
+        throw std::invalid_argument(string_format(
+                "draft-mtp requires spec-draft-ubatch-size (%d) to match the target ubatch (%d); "
+                "omit the draft override or use the target ubatch",
+                params.draft.n_ubatch, target_ubatch));
+    }
+}
+
 std::vector<common_speculative_type> common_speculative_types_from_names(const std::vector<std::string> & names) {
     std::vector<common_speculative_type> types;
     types.reserve(names.size());
@@ -2339,6 +2353,9 @@ common_params common_base_params_to_speculative(const common_params & params) {
 
     result.cache_type_k  = params_spec.cache_type_k;
     result.cache_type_v  = params_spec.cache_type_v;
+    if (params_spec.n_ubatch > 0) {
+        result.n_ubatch = params_spec.n_ubatch;
+    }
     result.n_outputs_max = params.n_parallel;
     result.n_outputs_max_per_seq = 1;
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -23,6 +23,10 @@ enum common_speculative_type common_speculative_type_from_name(const std::string
 // convert type to string
 std::string common_speculative_type_to_str(enum common_speculative_type type);
 
+void common_validate_speculative_params(
+        const common_params_speculative & params,
+        int32_t target_ubatch);
+
 // return the max number of draft tokens based on the speculative parameters
 int32_t common_speculative_n_max(const common_params_speculative * spec);
 

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -89,6 +89,9 @@ int main(int argc, char ** argv) {
     params.devices = params.speculative.draft.devices;
     params.model = params.speculative.draft.mparams;
     params.n_gpu_layers = params.speculative.draft.n_gpu_layers;
+    if (params.speculative.draft.n_ubatch > 0) {
+        params.n_ubatch = params.speculative.draft.n_ubatch;
+    }
     params.n_outputs_max = params.n_parallel;
     params.n_outputs_max_per_seq = 1;
     if (params.speculative.draft.cpuparams.n_threads > 0) {

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -200,6 +200,31 @@ static void test(void) {
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
     assert(params.speculative.draft.n_max == 123);
 
+    params = common_params();
+    argv = {"binary_name", "-m", "model_file.gguf", "--spec-draft-ubatch-size", "64"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+    assert(params.speculative.draft.n_ubatch == 64);
+
+    params = common_params();
+    argv = {"binary_name", "-m", "model_file.gguf", "--ubatch-size-draft", "32"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+    assert(params.speculative.draft.n_ubatch == 32);
+
+    params = common_params();
+    argv = {"binary_name", "-m", "model_file.gguf", "-ubd", "16"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+    assert(params.speculative.draft.n_ubatch == 16);
+
+    params = common_params();
+    argv = {"binary_name", "-m", "model_file.gguf", "--spec-draft-ubatch-size", "-1"};
+    assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+
+    params = common_params();
+    argv = {"binary_name", "--spec-type", "draft-mtp", "--ubatch-size", "512", "--spec-draft-ubatch-size", "128"};
+    assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SERVER));
+
+    params = common_params();
+    params.model.path = "model_file.gguf";
     argv = {"binary_name", "-lm", "none"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.load_mode == LLAMA_LOAD_MODE_NONE);
@@ -260,6 +285,13 @@ static void test(void) {
     printf("test-arg-parser: skip on windows build\n");
 #else
     printf("test-arg-parser: test environment variables (valid + invalid usages)\n\n");
+
+    setenv("LLAMA_ARG_SPEC_DRAFT_UBATCH", "32", true);
+    params = common_params();
+    argv = {"binary_name", "-m", "model_file.gguf"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+    assert(params.speculative.draft.n_ubatch == 32);
+    unsetenv("LLAMA_ARG_SPEC_DRAFT_UBATCH");
 
     setenv("LLAMA_ARG_THREADS", "blah", true);
     argv = {"binary_name"};
@@ -349,9 +381,49 @@ static void test(void) {
     printf("test-arg-parser: all tests OK\n\n");
 }
 
+static void test_draft_ubatch_override() {
+    common_params params;
+    params.n_ubatch = 512;
+
+    const common_params inherited = common_base_params_to_speculative(params);
+    assert(inherited.n_ubatch == 512);
+
+    params.speculative.draft.n_ubatch = 64;
+    const common_params overridden = common_base_params_to_speculative(params);
+    assert(overridden.n_ubatch == 64);
+
+    const llama_context_params cparams = common_context_params_to_llama(overridden);
+    assert(cparams.n_ubatch == 64);
+
+    assert(params.n_ubatch == 512);
+}
+
+static void test_mtp_draft_ubatch_validation() {
+    common_params_speculative params;
+    params.types = { COMMON_SPECULATIVE_TYPE_DRAFT_MTP };
+
+    common_validate_speculative_params(params, 512);
+    params.draft.n_ubatch = 512;
+    common_validate_speculative_params(params, 512);
+
+    params.draft.n_ubatch = 128;
+    bool rejected = false;
+    try {
+        common_validate_speculative_params(params, 512);
+    } catch (const std::invalid_argument &) {
+        rejected = true;
+    }
+    assert(rejected);
+
+    params.types = { COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH };
+    common_validate_speculative_params(params, 512);
+}
+
 int main(void) {
     try {
         test();
+        test_draft_ubatch_override();
+        test_mtp_draft_ubatch_validation();
     } catch (std::exception & e) {
         fprintf(stderr, "test-arg-parser: exception: %s\n", e.what());
         return 1;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -967,6 +967,13 @@ private:
         params_base.n_outputs_max = output_limits.total;
         params_base.n_outputs_max_per_seq = output_limits.per_seq;
 
+        try {
+            common_validate_speculative_params(params_base.speculative, params_base.n_ubatch);
+        } catch (const std::invalid_argument & e) {
+            SRV_ERR("invalid speculative configuration: %s\n", e.what());
+            return false;
+        }
+
         const bool has_mmproj = !params.mmproj.path.empty();
         const bool has_draft = params.speculative.has_dft();
         const bool spec_mtp = std::find(params_base.speculative.types.begin(),


### PR DESCRIPTION
Adds an independent physical ubatch override for separate draft contexts through --spec-draft-ubatch-size, --ubatch-size-draft, and -ubd. Zero preserves inheritance from the target context.

MTP drafting rejects an explicit draft ubatch that differs from the target physical ubatch, preserving recurrent prompt synchronization. Draft KV residency is intentionally excluded and will be tracked separately after target residency.

Validation: focused CPU builds for test-arg-parser, llama-speculative, llama-speculative-simple, llama-server, and llama-cli passed; test-arg-parser and help/alias checks passed; git diff --check passed.