### PR TITLE
kv-cache: add partial GPU residency

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2426,6 +2426,18 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_RECURRENT_STATE_OFFLOAD"));
     add_opt(common_arg(
+        {"--kv-gpu-layers"}, "N",
+        string_format("with --no-kv-offload, keep the first N independently owned attention KV layers device-resident "
+                      "for standard and direct hybrid caches. Unsupported specialized caches ignore this option "
+                      "(default: %d)", params.kv_gpu_layers),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("--kv-gpu-layers must not be negative");
+            }
+            params.kv_gpu_layers = value;
+        }
+    ).set_env("LLAMA_ARG_KV_GPU_LAYERS"));
+    add_opt(common_arg(
         {"--repack"},
         {"-nr", "--no-repack"},
         string_format("whether to enable weight repacking (default: %s)", params.no_extra_bufts ? "disabled" : "enabled"),

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1745,6 +1745,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.offload_kqv       = !params.no_kv_offload;
     cparams.kv_cpu_pinned     = params.kv_cpu_pinned;
     cparams.recurrent_state_offload = params.recurrent_state_offload;
+    cparams.kv_gpu_layers     = (uint32_t) std::max(0, params.kv_gpu_layers);
     cparams.no_perf           = params.no_perf;
     cparams.op_offload        = !params.no_op_offload;
     cparams.swa_full          = params.swa_full;

--- a/common/common.h
+++ b/common/common.h
@@ -568,6 +568,7 @@ struct common_params {
     bool no_kv_offload     = false; // disable KV offloading
     bool kv_cpu_pinned     = false; // use pinned host buffers for CPU-resident KV cache storage
     bool recurrent_state_offload = false; // offload recurrent state independently of attention KV storage
+    int32_t kv_gpu_layers  = 0;     // with no_kv_offload, keep this many attention KV layers device-resident
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device

--- a/include/llama.h
+++ b/include/llama.h
@@ -356,6 +356,7 @@ extern "C" {
         uint32_t n_rs_seq;              // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
         uint32_t n_outputs_max;         // max outputs in a ubatch (0 = n_batch)
         uint32_t n_outputs_max_per_seq; // max outputs per sequence (0 = n_outputs_max)
+        uint32_t kv_gpu_layers;         // with offload_kqv=false, keep this many standard or direct hybrid attention KV layers on their assigned devices
         int32_t  n_threads;             // number of threads to use for generation
         int32_t  n_threads_batch;       // number of threads to use for batch processing
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -121,6 +121,7 @@ llama_context::llama_context(
     cparams.kv_cpu_pinned           = params.kv_cpu_pinned;
     cparams.recurrent_state_offload = params.recurrent_state_offload;
     cparams.offload_attn_compute    = params.offload_kqv || (params.op_offload && params.kv_cpu_pinned);
+    cparams.kv_gpu_layers           = params.kv_gpu_layers;
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
 
@@ -396,6 +397,14 @@ llama_context::llama_context(
         };
 
         memory.reset(model.create_memory(params_mem, cparams));
+
+        if (!cparams.offload_kqv && cparams.kv_gpu_layers > 0) {
+            if (memory && memory->get_supports_partial_kv()) {
+                cparams.offload_attn_compute = cparams.offload_attn_compute || cparams.op_offload;
+            } else {
+                LLAMA_LOG_WARN("%s: partial GPU KV residency is not supported for this memory layout; ignoring kv_gpu_layers\n", __func__);
+            }
+        }
     }
 
     // init backends
@@ -3518,6 +3527,7 @@ llama_context_params llama_context_default_params() {
         /*.n_rs_seq                    =*/ 0,
         /*.n_outputs_max               =*/ 0,
         /*.n_outputs_max_per_seq       =*/ 1,
+        /*.kv_gpu_layers               =*/ 0,
         /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
         /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
         /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -16,6 +16,7 @@ struct llama_cparams {
     uint32_t n_rs_seq;        // number of recurrent-state snapshots per seq for rollback
     uint32_t n_outputs_max;   // max outputs supported by the context
     uint32_t n_outputs_max_per_seq;
+    uint32_t kv_gpu_layers;
     int32_t  n_threads;       // number of threads to use for generation
     int32_t  n_threads_batch; // number of threads to use for batch processing
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -178,6 +178,7 @@ llama_kv_cache::llama_kv_cache(
     }
 
     const bool is_mla = hparams.is_mla();
+    uint32_t n_gpu_resident = 0;
 
     for (uint32_t il = 0; il < n_layer; il++) {
         if (!hparams.has_kv(il)) {
@@ -228,13 +229,18 @@ llama_kv_cache::llama_kv_cache(
 
         const char * dev_name = "CPU";
 
+        const bool layer_offload = offload || n_gpu_resident < placement.gpu_resident_layers;
         ggml_backend_buffer_type_t buft = llama_kv_cache_get_host_buft(model, il, placement.cpu_pinned);
 
-        if (offload) {
+        if (layer_offload) {
             auto * dev = model.dev_layer(il);
             buft = ggml_backend_dev_buffer_type(dev);
 
             dev_name = ggml_backend_dev_name(dev);
+        }
+
+        if (!offload && layer_offload) {
+            ++n_gpu_resident;
         }
 
         LLAMA_LOG_DEBUG("%s: layer %3d: dev = %s\n", __func__, il, dev_name);
@@ -264,6 +270,11 @@ llama_kv_cache::llama_kv_cache(
         map_layer_ids[il] = layers.size();
 
         layers.push_back({ il, k, v, k_stream, v_stream, });
+    }
+
+    if (!offload && placement.gpu_resident_layers > 0) {
+        LLAMA_LOG_INFO("%s: partial GPU KV residency: %u of %u requested owned attention layers device-resident\n",
+                __func__, n_gpu_resident, placement.gpu_resident_layers);
     }
 
     if (reuse) {

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -132,6 +132,10 @@ public:
 
     bool get_can_shift() const override;
 
+    bool get_supports_partial_kv() const override {
+        return true;
+    }
+
     void clear(bool data) override;
 
     bool seq_rm  (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1) override;

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -59,6 +59,10 @@ public:
 
     bool get_can_shift() const override;
 
+    bool get_supports_partial_kv() const override {
+        return true;
+    }
+
     void clear(bool data) override;
 
     bool seq_rm  (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1) override;

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -16,6 +16,7 @@ class llama_io_read_i;
 
 struct llama_memory_placement_options {
     bool cpu_pinned = false;
+    uint32_t gpu_resident_layers = 0;
     bool recurrent_offload = false;
 };
 
@@ -104,6 +105,10 @@ struct llama_memory_i {
 
     // getters
     virtual bool get_can_shift() const = 0;
+
+    virtual bool get_supports_partial_kv() const {
+        return false;
+    }
 
     //
     // ops

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2189,8 +2189,11 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
     llama_memory_i * res;
     const llama_memory_placement_options placement = {
         cparams.kv_cpu_pinned,
+        cparams.kv_gpu_layers,
         cparams.offload_kqv || cparams.recurrent_state_offload,
     };
+    llama_memory_placement_options specialized_placement = placement;
+    specialized_placement.gpu_resident_layers = 0;
 
     switch (arch) {
         // Models that need specific instantiation should be handled in the
@@ -2233,7 +2236,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                         nullptr,
                         filter_idx,
                         nullptr,
-                        placement);
+                        specialized_placement);
             } break;
         case LLM_ARCH_GLM_DSA:
         case LLM_ARCH_DEEPSEEK32:
@@ -2287,7 +2290,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             filter_mla,
                             filter_lid,
                             nullptr,
-                            placement);
+                            specialized_placement);
                 }
             } break;
         case LLM_ARCH_DOTS3NOTE:
@@ -2340,7 +2343,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             filter_mla,
                             filter_lid,
                             nullptr,
-                            placement);
+                            specialized_placement);
                 }
             } break;
         case LLM_ARCH_DEEPSEEK4:
@@ -2368,7 +2371,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             filter_mtp,
                             nullptr,
                             nullptr,
-                            placement);
+                            specialized_placement);
                 } else {
                     res = new llama_kv_cache_dsv4(
                             *this,
@@ -2385,7 +2388,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             cparams.n_rs_seq,
                             nullptr,
                             nullptr,
-                            placement);
+                            specialized_placement);
                 }
             } break;
         case LLM_ARCH_DFLASH:
@@ -2410,7 +2413,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             nullptr,
                             nullptr,
                             nullptr,
-                            placement);
+                            specialized_placement);
                     break;
                 }
             }
@@ -2474,7 +2477,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             /* attn_n_ubatch     */ cparams.n_ubatch,
                             /* attn_n_pad        */ 1,
                             /* attn_offload      */ cparams.offload_kqv,
-                            /* placement         */ placement,
+                            /* placement         */ specialized_placement,
                             /* recurrent_type_r  */ GGML_TYPE_F32,
                             /* recurrent_type_s  */ GGML_TYPE_F32,
                             /* recurrent_rs_size */ std::max((uint32_t) 1, cparams.n_seq_max),
@@ -2567,7 +2570,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                     filter,
                                     reuse,
                                     share,
-                                    placement);
+                                    specialized_placement);
                         } else {
                             res = new llama_kv_cache_iswa(
                                     *this,
@@ -2585,7 +2588,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                     filter,
                                     reuse,
                                     share,
-                                    placement);
+                                    specialized_placement);
                         }
                     } else {
                         GGML_ASSERT(!hparams.is_swa_any());

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -125,6 +125,9 @@ static void test(void) {
     argv = {"binary_name", "-ngl", "hello"};
     assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
 
+    argv = {"binary_name", "--kv-gpu-layers", "-1"};
+    assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
+
     // wrong value (enum)
     argv = {"binary_name", "-sm", "hello"};
     assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
@@ -221,17 +224,20 @@ static void test(void) {
         const auto defaults = llama_context_default_params();
         assert(!defaults.kv_cpu_pinned);
         assert(!defaults.recurrent_state_offload);
+        assert(defaults.kv_gpu_layers == 0);
 
         common_params placement_params;
-        argv = {"binary_name", "-m", "model.gguf", "--no-kv-offload", "--kv-cpu-pinned", "--recurrent-state-offload"};
+        argv = {"binary_name", "-m", "model.gguf", "--no-kv-offload", "--kv-cpu-pinned", "--kv-gpu-layers", "4", "--recurrent-state-offload"};
         assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), placement_params, LLAMA_EXAMPLE_COMMON));
         assert(placement_params.no_kv_offload);
         assert(placement_params.kv_cpu_pinned);
+        assert(placement_params.kv_gpu_layers == 4);
         assert(placement_params.recurrent_state_offload);
 
         const auto cparams = common_context_params_to_llama(placement_params);
         assert(!cparams.offload_kqv);
         assert(cparams.kv_cpu_pinned);
+        assert(cparams.kv_gpu_layers == 4);
         assert(cparams.recurrent_state_offload);
 
         argv = {"binary_name", "--no-kv-cpu-pinned", "--no-recurrent-state-offload"};


### PR DESCRIPTION
Stacked on draft PR #25. Adds --kv-gpu-layers so --no-kv-offload can retain the first N independently owned attention-KV layers on their assigned devices while the remaining cache stays in host memory.

Partial residency is enabled only for standard KV caches and the direct non-iSWA hybrid owner. MSA, DSA, DSV4, iSWA, and other specialized layouts explicitly keep their original placement; pinned-host behavior from #25 remains available. Accelerator attention is enabled only when the constructed memory reports partial-residency support.

Validation: full CPU Release compilation of the current model/cache translation units, test-arg-parser execution, and git diff --check passed. GPU runtime and performance validation remain pending before readiness.