### PR TITLE
speculative: add independent draft KV residency

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -4096,6 +4096,19 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_V"));
     add_opt(common_arg(
+        {"--spec-draft-kv-gpu-layers", "--kv-gpu-layers-draft"}, "N",
+        "override target KV placement for the separate draft context and keep the first N independently owned "
+        "draft attention KV layers device-resident; shared KV layers follow their owner "
+        "(default: inherit target KV placement)",
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("--spec-draft-kv-gpu-layers must not be negative");
+            }
+            params.speculative.draft.kv_gpu_layers = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI})
+      .set_env("LLAMA_ARG_SPEC_DRAFT_KV_GPU_LAYERS"));
+    add_opt(common_arg(
         {"--spec-draft-override-tensor", "-otd", "--override-tensor-draft"}, "<tensor name pattern>=<buffer type>,...",
         "override tensor buffer type for draft model", [](common_params & params, const std::string & value) {
             parse_tensor_buffer_overrides(value, params.speculative.draft.tensor_buft_overrides);

--- a/common/common.h
+++ b/common/common.h
@@ -325,6 +325,7 @@ struct common_params_speculative_draft {
     int32_t n_max = 3; // maximum number of tokens to draft during speculative decoding
     int32_t n_min = 0; // minimum number of draft tokens to use for speculative decoding
     int32_t n_ubatch = 0; // physical draft batch size (0 = inherit target)
+    int32_t kv_gpu_layers = -1; // independently owned draft KV layers on GPU (-1 = inherit target policy)
 
     float p_split = 0.1f; // speculative decoding split probability
     float p_min   = 0.0f; // minimum speculative decoding probability (greedy)

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2356,6 +2356,10 @@ common_params common_base_params_to_speculative(const common_params & params) {
     if (params_spec.n_ubatch > 0) {
         result.n_ubatch = params_spec.n_ubatch;
     }
+    if (params_spec.kv_gpu_layers >= 0) {
+        result.no_kv_offload = true;
+        result.kv_gpu_layers = params_spec.kv_gpu_layers;
+    }
     result.n_outputs_max = params.n_parallel;
     result.n_outputs_max_per_seq = 1;
 

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -94,6 +94,10 @@ int main(int argc, char ** argv) {
     }
     params.n_outputs_max = params.n_parallel;
     params.n_outputs_max_per_seq = 1;
+    if (params.speculative.draft.kv_gpu_layers >= 0) {
+        params.no_kv_offload = true;
+        params.kv_gpu_layers = params.speculative.draft.kv_gpu_layers;
+    }
     if (params.speculative.draft.cpuparams.n_threads > 0) {
         params.cpuparams.n_threads = params.speculative.draft.cpuparams.n_threads;
     }

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -128,6 +128,9 @@ static void test(void) {
     argv = {"binary_name", "--kv-gpu-layers", "-1"};
     assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
 
+    argv = {"binary_name", "--spec-draft-kv-gpu-layers", "-1"};
+    assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+
     // wrong value (enum)
     argv = {"binary_name", "-sm", "hello"};
     assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
@@ -225,6 +228,12 @@ static void test(void) {
 
     params = common_params();
     params.model.path = "model_file.gguf";
+
+    common_params draft_arg_params;
+    assert(draft_arg_params.speculative.draft.kv_gpu_layers == -1);
+    argv = {"binary_name", "-m", "model_file.gguf", "--kv-gpu-layers-draft", "0"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), draft_arg_params, LLAMA_EXAMPLE_SPECULATIVE));
+    assert(draft_arg_params.speculative.draft.kv_gpu_layers == 0);
     argv = {"binary_name", "-lm", "none"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.load_mode == LLAMA_LOAD_MODE_NONE);
@@ -271,6 +280,34 @@ static void test(void) {
         assert(!placement_params.recurrent_state_offload);
     }
 
+    {
+        common_params draft_placement_params;
+        draft_placement_params.no_kv_offload = true;
+        draft_placement_params.kv_gpu_layers = 7;
+
+        const auto inherited = common_base_params_to_speculative(draft_placement_params);
+        assert(inherited.no_kv_offload);
+        assert(inherited.kv_gpu_layers == 7);
+
+        draft_placement_params.no_kv_offload = false;
+        draft_placement_params.speculative.draft.kv_gpu_layers = 3;
+        const auto overridden = common_base_params_to_speculative(draft_placement_params);
+        assert(overridden.no_kv_offload);
+        assert(overridden.kv_gpu_layers == 3);
+
+        const auto cparams = common_context_params_to_llama(overridden);
+        assert(!cparams.offload_kqv);
+        assert(cparams.kv_gpu_layers == 3);
+
+        draft_placement_params.speculative.draft.kv_gpu_layers = 0;
+        const auto host_only = common_base_params_to_speculative(draft_placement_params);
+        assert(host_only.no_kv_offload);
+        assert(host_only.kv_gpu_layers == 0);
+
+        assert(!draft_placement_params.no_kv_offload);
+        assert(draft_placement_params.kv_gpu_layers == 7);
+    }
+
     // multi-value args (CSV)
     argv = {"binary_name", "--lora", "file1.gguf,\"file2,2.gguf\",\"file3\"\"3\"\".gguf\",file4\".gguf"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
@@ -292,6 +329,13 @@ static void test(void) {
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
     assert(params.speculative.draft.n_ubatch == 32);
     unsetenv("LLAMA_ARG_SPEC_DRAFT_UBATCH");
+
+    setenv("LLAMA_ARG_SPEC_DRAFT_KV_GPU_LAYERS", "3", true);
+    common_params draft_env_params;
+    argv = {"binary_name", "-m", "model_file.gguf"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), draft_env_params, LLAMA_EXAMPLE_SPECULATIVE));
+    assert(draft_env_params.speculative.draft.kv_gpu_layers == 3);
+    unsetenv("LLAMA_ARG_SPEC_DRAFT_KV_GPU_LAYERS");
 
     setenv("LLAMA_ARG_THREADS", "blah", true);
     argv = {"binary_name"};


### PR DESCRIPTION
Stacked on draft PR #28 (and its placement foundation #25). Adds --spec-draft-kv-gpu-layers and --kv-gpu-layers-draft for the separate speculative draft context.

The default -1 inherits target KV placement. An explicit value forces only the draft context into host/partial KV placement with the requested number of independently owned attention-KV layers resident on assigned devices; explicit zero selects host-only draft KV. This PR is independent of draft-ubatch PR #27.

Validation: CPU-only test-arg-parser and llama-speculative builds passed; parser, environment, inheritance, override, zero, negative-value, help/alias, and git diff checks passed. GPU runtime and performance validation remain pending before readiness.