### PR TITLE
kv-cache: preserve accelerator quantization for host KV stores

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -440,8 +440,12 @@ static bool ggml_backend_cpu_device_supports_op(ggml_backend_dev_t dev, const st
     }
 
     switch (op->op) {
-        case GGML_OP_CPY:
         case GGML_OP_SET_ROWS:
+            if (op->src[0] != nullptr && op->src[0]->type == op->type) {
+                return true;
+            }
+            [[fallthrough]];
+        case GGML_OP_CPY:
             return
                 op->type != GGML_TYPE_IQ3_XXS &&
                 op->type != GGML_TYPE_IQ3_S   &&

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -5155,12 +5155,59 @@ static void ggml_compute_forward_set_rows_impl(
     }
 }
 
+template<typename idx_t>
+static void ggml_compute_forward_set_rows_copy_impl(
+        const ggml_compute_params * params,
+              ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor * src1 = dst->src[1];
+
+    GGML_TENSOR_BINARY_OP_LOCALS
+
+    GGML_ASSERT(src0->type == dst->type);
+    GGML_ASSERT(ne0 == ne00 && ne2 == ne02 && ne3 == ne03);
+    GGML_ASSERT(ne02 % ne11 == 0 && ne03 % ne12 == 0);
+
+    const int64_t dr  = (ne01 + params->nth - 1)/params->nth;
+    const int64_t ir0 = dr*params->ith;
+    const int64_t ir1 = std::min(ir0 + dr, ne01);
+    const size_t row_bytes = ggml_row_size(src0->type, ne00);
+
+    for (int64_t i03 = 0; i03 < ne03; ++i03) {
+        for (int64_t i02 = 0; i02 < ne02; ++i02) {
+            for (int64_t i = ir0; i < ir1; ++i) {
+                const int64_t i12 = i03 % ne12;
+                const int64_t i11 = i02 % ne11;
+                const int64_t i1 = *(const idx_t *) ((const char *) src1->data +
+                        i*nb10 + i11*nb11 + i12*nb12);
+
+                GGML_ASSERT(i1 >= 0 && i1 < ne1);
+
+                memcpy((char *) dst->data + i1*nb1 + i02*nb2 + i03*nb3,
+                       (const char *) src0->data + i*nb01 + i02*nb02 + i03*nb03,
+                       row_bytes);
+            }
+        }
+    }
+}
+
 void ggml_compute_forward_set_rows(
         const ggml_compute_params * params,
         ggml_tensor * dst) {
 
     const ggml_tensor * src0 = dst->src[0];
     const ggml_tensor * src1 = dst->src[1];
+
+    if (src0->type == dst->type) {
+        if (src1->type == GGML_TYPE_I64) {
+            ggml_compute_forward_set_rows_copy_impl<int64_t>(params, dst);
+        } else if (src1->type == GGML_TYPE_I32) {
+            ggml_compute_forward_set_rows_copy_impl<int32_t>(params, dst);
+        } else {
+            GGML_ABORT("src1->type = %d (%s) not supported", src1->type, ggml_type_name(src1->type));
+        }
+        return;
+    }
 
     switch (src0->type) {
         case GGML_TYPE_F32:

--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -149,6 +149,25 @@ static __global__ void cpy_f32_q(const char * cx, char * cdst, const int64_t ne,
     cpy_blck(cx + x_offset, cdst + dst_offset);
 }
 
+static __global__ void cpy_f32_q8_0_pair(
+        const char * cx0, char * cdst0,
+        const char * cx1, char * cdst1,
+        int64_t n_blocks) {
+    const int64_t i = (int64_t) blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= 2*n_blocks) {
+        return;
+    }
+
+    const bool second = i >= n_blocks;
+    const int64_t ib = second ? i - n_blocks : i;
+    const char * cx = second ? cx1 : cx0;
+    char * cdst = second ? cdst1 : cdst0;
+
+    ggml_cuda_pdl_sync();
+    cpy_blck_f32_q8_0(cx + ib*QK8_0*sizeof(float), cdst + ib*sizeof(block_q8_0));
+}
+
 template <cpy_kernel_t cpy_blck, int qk>
 static __global__ void cpy_q_f32(const char * cx, char * cdst, const int64_t ne,
                                  const int64_t ne00, const int64_t ne01, const int64_t ne02, const int64_t nb00, const int64_t nb01, const int64_t nb02,
@@ -257,6 +276,28 @@ static void ggml_cpy_f32_q8_0_cuda(
     GGML_ASSERT(num_blocks <= INT_MAX);
     cpy_f32_q<cpy_blck_f32_q8_0, QK8_0><<<num_blocks, CUDA_CPY_BLOCK_SIZE, 0, stream>>>
         (cx, cdst, ne, ne00, ne01, ne02, nb00, nb01, nb02, nb03, ne10, ne11, ne12, nb10, nb11, nb12, nb13);
+}
+
+void ggml_cuda_cpy_f32_q8_0_pair(ggml_backend_cuda_context & ctx, ggml_tensor * dst0, ggml_tensor * dst1) {
+    const ggml_tensor * src0 = dst0->src[0];
+    const ggml_tensor * src1 = dst1->src[0];
+    const int64_t ne = ggml_nelements(src0);
+
+    GGML_ASSERT(ne == ggml_nelements(src1));
+    GGML_ASSERT(ne == ggml_nelements(dst0));
+    GGML_ASSERT(ne == ggml_nelements(dst1));
+    GGML_ASSERT(ne % QK8_0 == 0);
+
+    const int64_t n_blocks = ne/QK8_0;
+    GGML_ASSERT(n_blocks <= INT64_MAX/2);
+    const int64_t num_blocks = (2*n_blocks + CUDA_CPY_BLOCK_SIZE - 1) / CUDA_CPY_BLOCK_SIZE;
+    GGML_ASSERT(num_blocks <= INT_MAX);
+
+    cpy_f32_q8_0_pair<<<num_blocks, CUDA_CPY_BLOCK_SIZE, 0, ctx.stream()>>>(
+        (const char *) src0->data, (char *) dst0->data,
+        (const char *) src1->data, (char *) dst1->data,
+        n_blocks);
+    CUDA_CHECK(cudaGetLastError());
 }
 
 static void ggml_cpy_q8_0_f32_cuda(

--- a/ggml/src/ggml-cuda/cpy.cuh
+++ b/ggml/src/ggml-cuda/cpy.cuh
@@ -4,4 +4,6 @@
 
 void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, ggml_tensor * src1);
 
+void ggml_cuda_cpy_f32_q8_0_pair(ggml_backend_cuda_context & ctx, ggml_tensor * dst0, ggml_tensor * dst1);
+
 void ggml_cuda_dup(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3021,6 +3021,88 @@ static bool ggml_cuda_check_fusion_memory_ranges(const ggml_cgraph * cgraph,
     return is_ok;
 }
 
+static int ggml_cuda_get_graph_stream(const ggml_cuda_stream_context & stream_ctx, const ggml_tensor * node) {
+    int stream = 0;
+
+    for (const auto & entry : stream_ctx.concurrent_events) {
+        const auto it = entry.second.stream_mapping.find(node);
+        if (it == entry.second.stream_mapping.end()) {
+            continue;
+        }
+        if (stream != 0 && stream != it->second) {
+            return -1;
+        }
+        stream = it->second;
+    }
+
+    return stream;
+}
+
+static bool ggml_cuda_can_fuse_f32_q8_0_cpy_pair(ggml_backend_cuda_context * cuda_ctx, const ggml_cgraph * cgraph, int node_idx) {
+    if (!ggml_can_fuse_subgraph(cgraph, node_idx, { GGML_OP_CPY, GGML_OP_CPY }, { node_idx, node_idx + 1 })) {
+        return false;
+    }
+
+    const ggml_tensor * dst0 = cgraph->nodes[node_idx];
+    const ggml_tensor * dst1 = cgraph->nodes[node_idx + 1];
+    const ggml_tensor * src0 = dst0->src[0];
+    const ggml_tensor * src1 = dst1->src[0];
+
+    if (!src0 || !src1 || dst0->src[1] != dst0 || dst1->src[1] != dst1 || src0 == src1) {
+        return false;
+    }
+    if (src0->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32 ||
+        dst0->type != GGML_TYPE_Q8_0 || dst1->type != GGML_TYPE_Q8_0) {
+        return false;
+    }
+    if (!ggml_are_same_shape(src0, src1) || !ggml_are_same_shape(src0, dst0) || !ggml_are_same_shape(src1, dst1)) {
+        return false;
+    }
+    if (dst0->ne[0] <= 0 || dst0->ne[0] % QK8_0 != 0 || dst0->ne[1] <= 0 || dst0->ne[2] != 1 || dst0->ne[3] != 1) {
+        return false;
+    }
+    if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1) || !ggml_is_contiguous(dst0) || !ggml_is_contiguous(dst1)) {
+        return false;
+    }
+    if ((uintptr_t) src0->data % alignof(float) != 0 || (uintptr_t) src1->data % alignof(float) != 0 ||
+        (uintptr_t) dst0->data % alignof(block_q8_0) != 0 || (uintptr_t) dst1->data % alignof(block_q8_0) != 0) {
+        return false;
+    }
+
+    ggml_backend_buffer_type_t buft = ggml_backend_cuda_buffer_type(cuda_ctx->device);
+    const ggml_tensor * tensors[4] = { src0, dst0, src1, dst1 };
+    for (const ggml_tensor * tensor : tensors) {
+        if (!tensor->data || !tensor->buffer || tensor->buffer->buft != buft) {
+            return false;
+        }
+    }
+
+    auto overlaps = [](const ggml_tensor * a, const ggml_tensor * b) {
+        const uintptr_t a_begin = (uintptr_t) a->data;
+        const uintptr_t b_begin = (uintptr_t) b->data;
+        const size_t a_size = ggml_nbytes(a);
+        const size_t b_size = ggml_nbytes(b);
+        if (a_size > UINTPTR_MAX - a_begin || b_size > UINTPTR_MAX - b_begin) {
+            return true;
+        }
+        const uintptr_t a_end = a_begin + a_size;
+        const uintptr_t b_end = b_begin + b_size;
+        return a_begin < b_end && b_begin < a_end;
+    };
+    for (int i = 0; i < 4; ++i) {
+        for (int j = i + 1; j < 4; ++j) {
+            if (overlaps(tensors[i], tensors[j])) {
+                return false;
+            }
+        }
+    }
+
+    const ggml_cuda_stream_context & stream_ctx = cuda_ctx->stream_context();
+    const int stream0 = ggml_cuda_get_graph_stream(stream_ctx, dst0);
+    const int stream1 = ggml_cuda_get_graph_stream(stream_ctx, dst1);
+    return stream0 >= 0 && stream0 == stream1 && stream0 == cuda_ctx->curr_stream_no;
+}
+
 
 static bool ggml_cuda_can_fuse(const struct ggml_cgraph *                cgraph,
                                int                                       node_idx,
@@ -3282,6 +3364,11 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
     }
 
     ggml_tensor * node = cgraph->nodes[i];
+
+    if (node->op == GGML_OP_CPY && ggml_cuda_can_fuse_f32_q8_0_cpy_pair(cuda_ctx, cgraph, i)) {
+        ggml_cuda_cpy_f32_q8_0_pair(*cuda_ctx, node, cgraph->nodes[i + 1]);
+        return 1;
+    }
 
     // gated_delta_net -> cpy: scatter recurrent-state snapshots into the cache
     if (node->op == GGML_OP_GATED_DELTA_NET) {

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -3946,7 +3946,7 @@ struct ggml_tensor * ggml_set_rows(
     GGML_ASSERT(b->ne[2] % c->ne[1] == 0);
     GGML_ASSERT(b->ne[3] % c->ne[2] == 0);
     GGML_ASSERT(c->ne[3] == 1);
-    GGML_ASSERT(b->type == GGML_TYPE_F32 || b->type == GGML_TYPE_F16);
+    GGML_ASSERT(b->type == GGML_TYPE_F32 || b->type == GGML_TYPE_F16 || b->type == a->type);
     GGML_ASSERT(c->type == GGML_TYPE_I64 || c->type == GGML_TYPE_I32);
 
     GGML_ASSERT(ggml_is_contiguous_rows(a));

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -2821,8 +2821,7 @@ ggml_tensor * llm_graph_context::build_attn(
         const auto & k_idxs = inp->get_k_idxs();
         const auto & v_idxs = inp->get_v_idxs();
 
-        ggml_build_forward_expand(gf, mctx_cur->cpy_k(ctx0, k_cur, k_idxs, il));
-        ggml_build_forward_expand(gf, mctx_cur->cpy_v(ctx0, v_cur, v_idxs, il));
+        mctx_cur->build_kv_store(gf, ctx0, k_cur, k_idxs, v_cur, v_idxs, il);
     }
 
     ggml_tensor * kq_mask = inp->get_kq_mask();
@@ -3068,13 +3067,16 @@ ggml_tensor * llm_graph_context::build_attn(
     const auto * mctx_cur = is_swa ? mctx_iswa->get_swa() : mctx_iswa->get_base();
 
     // optionally store to KV cache
-    if (k_cur) {
+    if (k_cur && v_cur) {
+        const auto & k_idxs = is_swa ? inp->get_k_idxs_swa() : inp->get_k_idxs();
+        const auto & v_idxs = is_swa ? inp->get_v_idxs_swa() : inp->get_v_idxs();
+
+        mctx_cur->build_kv_store(gf, ctx0, k_cur, k_idxs, v_cur, v_idxs, il);
+    } else if (k_cur) {
         const auto & k_idxs = is_swa ? inp->get_k_idxs_swa() : inp->get_k_idxs();
 
         ggml_build_forward_expand(gf, mctx_cur->cpy_k(ctx0, k_cur, k_idxs, il));
-    }
-
-    if (v_cur) {
+    } else if (v_cur) {
         const auto & v_idxs = is_swa ? inp->get_v_idxs_swa() : inp->get_v_idxs();
 
         ggml_build_forward_expand(gf, mctx_cur->cpy_v(ctx0, v_cur, v_idxs, il));

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -180,6 +180,62 @@ llama_kv_cache::llama_kv_cache(
     const bool is_mla = hparams.is_mla();
     uint32_t n_gpu_resident = 0;
 
+    enum class kv_store_side {
+        key,
+        value,
+    };
+
+    const auto probe_store_quantize = [&](uint32_t il, ggml_type type, int64_t n_embd) {
+        if (!ggml_is_quantized(type)) {
+            return false;
+        }
+
+        auto * dev = model.dev_layer(il);
+        if (!dev || ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+            return false;
+        }
+
+        auto * buft = ggml_backend_dev_buffer_type(dev);
+        if (!buft || ggml_backend_buft_is_host(buft)) {
+            return false;
+        }
+
+        ggml_init_params params = {
+            /*.mem_size   =*/ 5*ggml_tensor_overhead(),
+            /*.mem_buffer =*/ nullptr,
+            /*.no_alloc   =*/ true,
+        };
+        ggml_context_ptr probe(ggml_init(params));
+        if (!probe) {
+            return false;
+        }
+
+        auto * dst = ggml_new_tensor_2d(probe.get(), type, n_embd, 1);
+        auto * src = ggml_new_tensor_2d(probe.get(), GGML_TYPE_F32, n_embd, 1);
+        auto * idx = ggml_new_tensor_1d(probe.get(), GGML_TYPE_I64, 1);
+        const bool direct_store = ggml_backend_dev_supports_op(
+                dev, ggml_set_rows(probe.get(), dst, src, idx));
+        const bool staged_store = ggml_backend_dev_supports_op(
+                dev, ggml_cpy(probe.get(), src, dst));
+        return direct_store && staged_store;
+    };
+
+    const auto resolve_store_quantize = [&](uint32_t il, ggml_type type, int64_t n_embd,
+                                             kv_store_side side) {
+        const bool store_quantize = probe_store_quantize(il, type, n_embd);
+        auto * layer_dev = model.dev_layer(il);
+        const bool accelerator_layer = layer_dev &&
+                ggml_backend_dev_type(layer_dev) != GGML_BACKEND_DEVICE_TYPE_CPU;
+        if (accelerator_layer && ggml_is_quantized(type) && !store_quantize) {
+            const char * side_label = side == kv_store_side::key ? "K" : "V";
+            throw std::runtime_error(format(
+                    "layer %u cannot preserve accelerator %s %s-cache store semantics in host-resident storage: "
+                    "the layer backend must support both direct and staged F32-to-%s conversion",
+                    il, ggml_backend_dev_name(layer_dev), side_label, ggml_type_name(type)));
+        }
+        return store_quantize;
+    };
+
     for (uint32_t il = 0; il < n_layer; il++) {
         if (!hparams.has_kv(il)) {
             LLAMA_LOG_DEBUG("%s: layer %3d: does not have KV cache\n", __func__, il);
@@ -256,6 +312,15 @@ llama_kv_cache::llama_kv_cache(
         ggml_tensor * k = has_k ? ggml_new_tensor_3d(ctx, type_k, n_embd_k_gqa, kv_size, n_stream) : nullptr;
         ggml_tensor * v = has_v ? ggml_new_tensor_3d(ctx, type_v, n_embd_v_gqa, kv_size, n_stream) : nullptr;
 
+        bool k_store_quantize = false;
+        bool v_store_quantize = false;
+        if (ggml_backend_buft_is_host(buft)) {
+            k_store_quantize = resolve_store_quantize(
+                    il, type_k, n_embd_k_gqa, kv_store_side::key);
+            v_store_quantize = has_v && !v_trans && resolve_store_quantize(
+                    il, type_v, n_embd_v_gqa, kv_store_side::value);
+        }
+
         has_k && ggml_format_name(k, "cache_k_l%d", il);
         has_v && ggml_format_name(v, "cache_v_l%d", il);
 
@@ -269,7 +334,7 @@ llama_kv_cache::llama_kv_cache(
 
         map_layer_ids[il] = layers.size();
 
-        layers.push_back({ il, k, v, k_stream, v_stream, });
+        layers.push_back({ il, k, v, k_store_quantize, v_store_quantize, k_stream, v_stream, });
     }
 
     if (!offload && placement.gpu_resident_layers > 0) {
@@ -1330,8 +1395,30 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
             ggml_row_size(v->type, kv_size*n_embd_v_gqa)*sinfo.s0);
 }
 
-ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const {
+ggml_tensor * llama_kv_cache::stage_store_rows(
+        ggml_context * ctx,
+        ggml_tensor  * source,
+             ggml_type type,
+                int32_t il,
+            const char * side) const {
+    GGML_ASSERT(source && source->type == GGML_TYPE_F32);
+
+    const int64_t n_embd   = source->ne[0]*source->ne[1];
+    const int64_t n_tokens = source->ne[2];
+    GGML_ASSERT(ggml_row_size(source->type, source->ne[0]) == source->nb[1]);
+
+    source = ggml_view_2d(ctx, source, n_embd, n_tokens, source->nb[2], 0);
+    source = ggml_cast(ctx, source, type);
+    ggml_format_name(source, "cache_%s_store_stage_l%d", side, il);
+    return source;
+}
+
+ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo, ggml_tensor ** store_stage) const {
     GGML_UNUSED(sinfo);
+
+    if (store_stage) {
+        *store_stage = nullptr;
+    }
 
     const int32_t ikv = map_layer_ids.at(il);
 
@@ -1347,7 +1434,14 @@ ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggm
     // TODO: add ggml helper function for this?
     GGML_ASSERT(ggml_row_size(k_cur->type, n_embd_head) == k_cur->nb[1]);
 
-    k_cur = ggml_view_2d(ctx, k_cur, n_embd_gqa, n_tokens, k_cur->nb[2], 0);
+    if (layers[ikv].k_store_quantize) {
+        k_cur = stage_store_rows(ctx, k_cur, k->type, il, "k");
+        if (store_stage) {
+            *store_stage = k_cur;
+        }
+    } else {
+        k_cur = ggml_view_2d(ctx, k_cur, n_embd_gqa, n_tokens, k_cur->nb[2], 0);
+    }
 
     const int64_t n_stream = k->ne[2];
 
@@ -1365,8 +1459,12 @@ ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggm
     return ggml_set_rows(ctx, k, k_cur, k_idxs);
 }
 
-ggml_tensor * llama_kv_cache::cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, const slot_info & sinfo) const {
+ggml_tensor * llama_kv_cache::cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, const slot_info & sinfo, ggml_tensor ** store_stage) const {
     GGML_UNUSED(sinfo);
+
+    if (store_stage) {
+        *store_stage = nullptr;
+    }
 
     const int32_t ikv = map_layer_ids.at(il);
 
@@ -1385,7 +1483,14 @@ ggml_tensor * llama_kv_cache::cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggm
 
     // take this branch when FA is enabled (the V cache is not transposed)
     if (!v_trans) {
-        v_cur = ggml_view_2d(ctx, v_cur, n_embd_gqa, n_tokens, v_cur->nb[2], 0);
+        if (layers[ikv].v_store_quantize) {
+            v_cur = stage_store_rows(ctx, v_cur, v->type, il, "v");
+            if (store_stage) {
+                *store_stage = v_cur;
+            }
+        } else {
+            v_cur = ggml_view_2d(ctx, v_cur, n_embd_gqa, n_tokens, v_cur->nb[2], 0);
+        }
 
         if (n_stream > 1) {
             const int64_t kv_size = get_size();
@@ -2631,12 +2736,39 @@ ggml_tensor * llama_kv_cache_context::get_v(ggml_context * ctx, int32_t il) cons
     return kv->get_v(ctx, il, n_kv, sinfos[i_cur]);
 }
 
-ggml_tensor * llama_kv_cache_context::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il) const {
-    return kv->cpy_k(ctx, k_cur, k_idxs, il, sinfos[i_cur]);
+ggml_tensor * llama_kv_cache_context::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, ggml_tensor ** store_stage) const {
+    return kv->cpy_k(ctx, k_cur, k_idxs, il, sinfos[i_cur], store_stage);
 }
 
-ggml_tensor * llama_kv_cache_context::cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il) const {
-    return kv->cpy_v(ctx, v_cur, v_idxs, il, sinfos[i_cur]);
+ggml_tensor * llama_kv_cache_context::cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, ggml_tensor ** store_stage) const {
+    return kv->cpy_v(ctx, v_cur, v_idxs, il, sinfos[i_cur], store_stage);
+}
+
+void llama_kv_cache_context::build_kv_store(
+        ggml_cgraph  * gf,
+        ggml_context * ctx,
+        ggml_tensor  * k_cur,
+        ggml_tensor  * k_idxs,
+        ggml_tensor  * v_cur,
+        ggml_tensor  * v_idxs,
+        int32_t        il) const {
+    ggml_tensor * k_stage = nullptr;
+    ggml_tensor * v_stage = nullptr;
+    ggml_tensor * k_store = cpy_k(ctx, k_cur, k_idxs, il, &k_stage);
+    ggml_tensor * v_store = cpy_v(ctx, v_cur, v_idxs, il, &v_stage);
+
+    if (k_stage && v_stage) {
+        ggml_build_forward_expand(gf, k_stage->src[0]);
+        ggml_build_forward_expand(gf, v_stage->src[0]);
+    }
+    if (k_stage) {
+        ggml_build_forward_expand(gf, k_stage);
+    }
+    if (v_stage) {
+        ggml_build_forward_expand(gf, v_stage);
+    }
+    ggml_build_forward_expand(gf, k_store);
+    ggml_build_forward_expand(gf, v_store);
 }
 
 ggml_tensor * llama_kv_cache_context::build_input_k_idxs(ggml_context * ctx, const llama_ubatch & ubatch) const {

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -182,8 +182,8 @@ public:
     ggml_tensor * get_v(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const;
 
     // store k_cur and v_cur in the cache based on the provided head location
-    ggml_tensor * cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const;
-    ggml_tensor * cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, const slot_info & sinfo) const;
+    ggml_tensor * cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo, ggml_tensor ** store_stage = nullptr) const;
+    ggml_tensor * cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, const slot_info & sinfo, ggml_tensor ** store_stage = nullptr) const;
 
     //
     // preparation API
@@ -235,6 +235,9 @@ private:
 
         ggml_tensor * k;
         ggml_tensor * v;
+
+        bool k_store_quantize;
+        bool v_store_quantize;
 
         std::vector<ggml_tensor *> k_stream;
         std::vector<ggml_tensor *> v_stream;
@@ -298,6 +301,13 @@ private:
 
     size_t size_k_bytes() const;
     size_t size_v_bytes() const;
+
+    ggml_tensor * stage_store_rows(
+            ggml_context * ctx,
+            ggml_tensor  * source,
+                 ggml_type type,
+                    int32_t il,
+                const char * side) const;
 
     ggml_tensor * build_rope_shift(
             const llama_cparams & cparams,
@@ -384,8 +394,17 @@ public:
     //   - k_idxs [n_tokens]
     //   - v_cur  [n_embd_head_v, n_head_v, n_tokens]
     //   - v_idxs [n_tokens] or [n_tokens*n_embd_v_gqa] depending if V cache is transposed
-    ggml_tensor * cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il) const;
-    ggml_tensor * cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il) const;
+    ggml_tensor * cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, ggml_tensor ** store_stage = nullptr) const;
+    ggml_tensor * cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, ggml_tensor ** store_stage = nullptr) const;
+
+    void build_kv_store(
+            ggml_cgraph  * gf,
+            ggml_context * ctx,
+            ggml_tensor  * k_cur,
+            ggml_tensor  * k_idxs,
+            ggml_tensor  * v_cur,
+            ggml_tensor  * v_idxs,
+            int32_t        il) const;
 
     // create destination indices for each head of the current batch for where it would be written in the KV cache
     // the indices address the global KV cache (not per stream) - this is not relevant for the user of this API, but

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -415,8 +415,7 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
                 if (v_rot) {
                     Vcur = llama_mul_mat_hadamard(ctx0, Vcur, v_rot);
                 }
-                ggml_build_forward_expand(gf, kv->cpy_k(ctx0, Kcur, k_idxs, il));
-                ggml_build_forward_expand(gf, kv->cpy_v(ctx0, Vcur, v_idxs, il));
+                kv->build_kv_store(gf, ctx0, Kcur, k_idxs, Vcur, v_idxs, il);
             } else {
                 // rotate K/V into the cache's rotated space
                 if (inp_attn->self_k_rot) {
@@ -425,8 +424,8 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
                 if (inp_attn->self_v_rot) {
                     Vcur = llama_mul_mat_hadamard(ctx0, Vcur, inp_attn->self_v_rot);
                 }
-                ggml_build_forward_expand(gf, inp_attn->mctx->cpy_k(ctx0, Kcur, inp_attn->get_k_idxs(), il));
-                ggml_build_forward_expand(gf, inp_attn->mctx->cpy_v(ctx0, Vcur, inp_attn->get_v_idxs(), il));
+                inp_attn->mctx->build_kv_store(
+                        gf, ctx0, Kcur, inp_attn->get_k_idxs(), Vcur, inp_attn->get_v_idxs(), il);
             }
         }
 

--- a/src/models/minimax-m3.cpp
+++ b/src/models/minimax-m3.cpp
@@ -365,8 +365,8 @@ llama_model_minimax_m3::graph::graph(const llama_model & model, const llm_graph_
                 ggml_build_forward_expand(gf, Qcur);
                 ggml_build_forward_expand(gf, Kcur);
                 ggml_build_forward_expand(gf, Vcur);
-                ggml_build_forward_expand(gf, mctx_cur->cpy_k(ctx0, Kcur, inp_attn->get_k_idxs(), il));
-                ggml_build_forward_expand(gf, mctx_cur->cpy_v(ctx0, Vcur, inp_attn->get_v_idxs(), il));
+                mctx_cur->build_kv_store(
+                        gf, ctx0, Kcur, inp_attn->get_k_idxs(), Vcur, inp_attn->get_v_idxs(), il);
                 ggml_tensor * k = mctx_cur->get_k(ctx0, il);
                 ggml_tensor * v = mctx_cur->get_v(ctx0, il);
                 GGML_ASSERT(!(v->nb[1] > v->nb[2]) && "MSA assumes v_trans=false (FA on)");

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1217,6 +1217,7 @@ struct test_case {
 
     virtual bool run_whole_graph() { return false; }
     virtual std::vector<ggml_tensor *> fusion_test_nodes() { return {}; }
+    virtual bool compare_bytes() { return false; }
     virtual bool use_weight_context() { return false; }
 
     ggml_cgraph * gf = nullptr;
@@ -1443,6 +1444,18 @@ struct test_case {
                     ud->ok = false;
                     return true;
                 }
+            }
+
+            if (ud->tc->compare_bytes()) {
+                std::vector<uint8_t> t1_data(ggml_nbytes(t1));
+                std::vector<uint8_t> t2_data(ggml_nbytes(t2));
+                ggml_backend_tensor_get(t1, t1_data.data(), 0, ggml_nbytes(t1));
+                ggml_backend_tensor_get(t2, t2_data.data(), 0, ggml_nbytes(t2));
+                if (t1_data != t2_data) {
+                    printf("[%s] byte mismatch ", ggml_op_desc(t1));
+                    ud->ok = false;
+                }
+                return true;
             }
 
             std::vector<float> f1 = tensor_to_float(t1);
@@ -3057,6 +3070,63 @@ struct test_cpy : public test_case {
             // test extended range of values to check if casting between f32 and i32 is consistent
             init_tensor_uniform(t, -150.f, 150.f);
         }
+    }
+};
+
+struct test_cpy_f32_q8_0_pair : public test_case {
+    const int64_t n_embd;
+    const int64_t n_tokens0;
+    const int64_t n_tokens1;
+    const bool strided_src0;
+    ggml_tensor * dst0 = nullptr;
+    ggml_tensor * dst1 = nullptr;
+
+    test_cpy_f32_q8_0_pair(int64_t n_embd, int64_t n_tokens0, int64_t n_tokens1, bool strided_src0)
+        : n_embd(n_embd), n_tokens0(n_tokens0), n_tokens1(n_tokens1), strided_src0(strided_src0) {}
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "CPY_F32_Q8_0_PAIR";
+    }
+
+    std::string vars() override {
+        return VARS_TO_STR4(n_embd, n_tokens0, n_tokens1, strided_src0);
+    }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * src0;
+        if (strided_src0) {
+            ggml_tensor * storage = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 2*n_embd, n_tokens0);
+            src0 = ggml_view_2d(ctx, storage, n_embd, n_tokens0, storage->nb[1], 0);
+        } else {
+            src0 = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_tokens0);
+        }
+        ggml_tensor * src1 = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_tokens1);
+        ggml_set_name(src0, "alpha");
+        ggml_set_name(src1, "beta");
+
+        dst0 = ggml_cast(ctx, src0, GGML_TYPE_Q8_0);
+        ggml_set_name(dst0, "gamma");
+
+        dst1 = ggml_new_tensor_2d(ctx, GGML_TYPE_Q8_0, n_embd, n_tokens1);
+        dst1 = ggml_cpy(ctx, src1, dst1);
+        ggml_set_name(dst1, "delta");
+
+        ggml_tensor * out = ggml_concat(ctx, dst0, dst1, 1);
+        ggml_set_name(out, "out");
+        return out;
+    }
+
+    bool run_whole_graph() override {
+        return true;
+    }
+
+    std::vector<ggml_tensor *> fusion_test_nodes() override {
+        return { dst0, dst1 };
+    }
+
+    bool compare_bytes() override {
+        return true;
     }
 };
 
@@ -8427,6 +8497,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_I64, { 1, 8, 1, 3 }, { 1, 1 }, 2, false));
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_I32, { 1, 8, 1, 3 }, { 1, 1 }, 2, false));
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_F32, GGML_TYPE_Q8_0, GGML_TYPE_I32, { 256, 5, 1, 3 }, { 1, 1, }, 1, false));
+    test_cases.emplace_back(new test_set_rows(GGML_TYPE_Q4_0, GGML_TYPE_Q4_0, GGML_TYPE_I64, { 256, 11, 2, 3 }, { 1, 1 }, 3, false));
+    test_cases.emplace_back(new test_set_rows(GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, GGML_TYPE_I32, { 256, 11, 2, 3 }, { 1, 1 }, 3, false));
+    test_cases.emplace_back(new test_set_rows(GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, GGML_TYPE_I64, { 256, 11, 2, 3 }, { 1, 1 }, 3, false));
     for (ggml_type src_type : {GGML_TYPE_F16, GGML_TYPE_F32}) {
         for (ggml_type type : all_types) {
             for (int b : {1, 7}) {
@@ -8863,6 +8936,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     // quant block count not a multiple of the kernel block size
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_Q4_0, {96, 1, 1, 1}));
     test_cases.emplace_back(new test_cpy(GGML_TYPE_Q4_0, GGML_TYPE_F32, {96, 1, 1, 1}));
+    test_cases.emplace_back(new test_cpy_f32_q8_0_pair(256, 1, 1, false));
+    test_cases.emplace_back(new test_cpy_f32_q8_0_pair(256, 7, 7, false));
+    test_cases.emplace_back(new test_cpy_f32_q8_0_pair(256, 7, 5, false));
+    test_cases.emplace_back(new test_cpy_f32_q8_0_pair(256, 7, 7, true));
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_I32, {256, 2, 3, 4}));
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_I32, {256, 2, 3, 4}, {-1,-1,-1,-1}, {1, 0, 2, 3}));
     test_cases.emplace_back(new test_cpy(GGML_TYPE_I32, GGML_TYPE_F32, {256, 2, 3, 4}));


### PR DESCRIPTION
## Summary

Fix CPU-resident quantized KV stores when layer compute remains accelerator-resident. CPU and accelerator quantizers can produce different valid quantized bytes from the same F32 input; allowing placement to select the quantizer therefore made generated output placement-dependent. This change preserves accelerator quantization semantics before copying canonical quantized records into host KV storage.

## Implementation

- Detect the path through backend capabilities, not tensor names or model-specific rules, and fail closed when an accelerator cannot provide the required conversion semantics.
- Build graph-owned F32-to-quantized staging tensors, so staging storage participates in scheduler liveness reuse instead of creating persistent per-layer VRAM allocations.
- Add same-type CPU `SET_ROWS` copies for already-quantized records, avoiding a second quantization on the host.
- Build paired K/V staging conversions adjacently. This ordering is intentional: CUDA's existing structural fusion pass can recognize the two compatible F32-to-Q8_0 `CPY` nodes and launch one paired kernel. Correctness does not depend on fusion; unsupported shapes, buffers, streams, overlap, or backends fall back to ordinary graph execution.
- Preserve K-only and V-only call paths and the existing `llama/dev` placement contract.

The change adds no public API, command-line option, environment variable, persistent telemetry, or model-name special case.

## Validation

The current commit is patch-identical by stable patch ID to the previously validated PR30 candidate.

### Exactness

- Qwen3.8 27B, 30,000-token real-corpus prompt, Q8_0 K/V, 64 generated tokens.
- PR30 host-resident pinned Q8 versus PR30 full-GPU Q8 produced identical generated token IDs and content.
- Serialized KV states were byte-identical: 1,204,289,704 bytes each, SHA-256 `07444ecee5aba60b72ba1d3252a2ce6549ef3f91ec68e12ae9a40ee14ca012b2`.
- Earlier focused exactness covered Gemma and eligible additional quantized-cache configurations.

### Performance and memory

Matched fresh-process baseline/PR30/baseline brackets against `llama/dev` (`ae797a6d7be1b223435698a8fd4f7eee570f56a9`) on an RTX 5070 Ti:

| Qwen context | Prompt change | Decode change | Process VRAM delta |
|---|---:|---:|---:|
| 30K | +0.784% | +0.341% | 0 MiB |
| 64K | +0.613% | -0.143% | 0 MiB |

Baseline drift remained below 1% for prompt and decode. The optimized shallow Gemma PP512 workload retained the previously measured approximately 11.6% prompt-processing gain, with no persistent staging VRAM increase.

### Build and regression coverage

- Fresh local Release CUDA builds of both the exact baseline and PR30 server completed successfully.
- Full fatal-warnings-off CPU and CUDA CI, backend operations, runtime/lifecycle coverage, and eligible full-build Q5 perplexity passed on the patch-equivalent candidate.
- Vulkan parity coverage passed on the patch-equivalent candidate.
- Current PR CI has passed the standard CUDA, HIP, MUSA, Linux x64 CPU, Linux server, wasm/WebGPU, and HIP quality lanes at the time of final review; remaining queued private-fork runner lanes are not treated as evidence failures.

## Maintenance notes

The CUDA paired conversion is a small structural fusion in the existing `can_fuse`/`try_fuse` framework rather than a KV-specific dispatch hook. All recognition predicates validate operation type, tensor type and shape, contiguity, buffer ownership, memory overlap, and stream placement. Failure to meet any predicate preserves the ordinary path.
