### PR TITLE
KVarN + host-resident KV: fail closed instead of degrading (issue stays open)

### DIFF
--- a/docs/kvarn-host-offload.md
+++ b/docs/kvarn-host-offload.md
@@ -1,0 +1,89 @@
+# KVarN and host-resident KV: open issue
+
+**Status: open.** The guard described below is a stopgap. KVarN has not been
+integrated into the KV-offload line at all, and until it is, KVarN and
+`--no-kv-offload` are mutually exclusive on a discrete accelerator.
+
+## What happens today
+
+KVarN is inherited from BeeLlama. The host-KV-offload line — `--kv-cpu-pinned`,
+`--kv-gpu-layers`, the `offload_attn_compute` separation of storage placement
+from attention execution — is this fork's, and none of it was extended to
+KVarN. BeeLlama v0.4.3 carries KVarN across 89 files and contains no occurrence
+of `kv_cpu_pinned`, `offload_attn_compute` or `kv_gpu_layers`; this tree has
+them in 9–11 files each.
+
+The combination is currently permitted:
+`llama_kvarn_backend_supports_ops(nullptr)` returns true on the grounds that
+"the built-in CPU backend implements store + materialize". It does — correctly,
+and very expensively.
+
+`ggml_backend_cuda_device_supports_buft` accepts a host buffer only on an
+integrated GPU. On a discrete one it refuses, so the scheduler places every node
+that touches the host-resident KVarN records on the CPU backend and reserves
+host workspace for their intermediates.
+
+Scheduler assignment, `GGML_SCHED_DEBUG=2`, `-c 8192`, host-resident, RTX 4070:
+
+| Cache | CPU-assigned nodes | host compute buffer |
+|---|---|---:|
+| `q8_0` | 9 × `GET_ROWS` | **20.28 MiB** |
+| `kvarn5` | 576 `SET_ROWS`, 576 `KVARN_STOR`, 384 `MUL_MAT`, 384 `CONCAT`, 288 `KVARN_WHT` | **2,195.90 MiB** |
+
+The large CPU tensors are `KVARN_WHT` and `GET_ROWS` at 640 MiB each,
+`SOFT_MAX` at 414 MiB and `MUL_MAT` at 384 MiB.
+
+A standard quantized cache avoids this because its K/V reach attention as
+copyable split inputs, which the scheduler stages to the device — that staging
+is the context-linear transfer measured in
+[`pinned-host-kv-decode-experiments.md`](pinned-host-kv-decode-experiments.md).
+KVarN's records reach attention through `KVARN_VIEW` chains instead, so there is
+nothing for the scheduler to stage and it falls back wholesale.
+
+## Cost
+
+`kvarn5`, host-resident, reserved host compute workspace:
+
+| Context | host workspace | host KVarN cache |
+|---:|---:|---:|
+| 8,192 | 2,195.90 MiB | — |
+| 32,768 | 3,309.90 MiB | — |
+| 65,536 | 6,541.90 MiB | — |
+| 262,144 | 25,933.90 MiB | 5,528.00 MiB |
+
+Between 32,768 and 262,144 that is about 0.099 MiB per context token. The same
+cache GPU-resident at 65,536 reserves 84.65 MiB. The reservation is identical
+for `kvarn8`, `kvarn6` and `kvarn5`, so it tracks context, not cache width, and
+`--live-context-workspace` does not bound it (25,933.90 MiB with and without).
+
+At 262,144 the workspace is roughly 4.7x the cache it compresses, and together
+they exceed this host's 31 GiB. Attention also executes on the CPU, which
+Experiment 004 measured as needing about a 6.6x CPU-attention speedup merely to
+break even against the staged-transfer path.
+
+So KVarN currently trades a real 36.5% cache reduction (`kvarn5` 5,528 MiB
+against `q8_0` 8,704 MiB at 262,144) for a workspace and an execution placement
+that cost far more than the reduction is worth.
+
+## What this change does, and does not, do
+
+It fails closed. When a layer's accelerator cannot operate on the buffer its
+KVarN records would live in, context construction now raises an error naming the
+device, the buffer type, and the two configurations that do exist — keep the
+KVarN cache device-resident, or use a standard quantized type for host-resident
+KV.
+
+It does **not** make KVarN work with host offload. That needs KVarN brought into
+the KV-offload line properly:
+
+- give the KVarN body the same staged-input treatment standard KV gets, so
+  attention stays on the accelerator while storage stays on the host, which is
+  what `offload_attn_compute` already expresses for standard caches;
+- decide whether `KVARN_VIEW` operands can be staged at all, or whether the
+  records need a device-side mirror with its own residency policy;
+- extend `--kv-gpu-layers` to KVarN layers so partial residency is expressible;
+- then qualify it the way the standard types were: exactness, KLD, allocation
+  high-water, and throughput at depth.
+
+Integrated GPUs are unaffected — `supports_buft` accepts host buffers there, so
+the guard does not trigger. CPU-only builds are unaffected for the same reason.

--- a/ggml/src/ggml-cuda/fattn-mma-kvarn-case.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-kvarn-case.cuh
@@ -176,7 +176,7 @@ static __global__ void ggml_cuda_fattn_kvarn_window_f16_partial_kernel(
     constexpr bool needs_fixup = false;
     constexpr bool is_fixup = true;
     flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup>
-        (Q_f2, K_h2, V_h2, mask_h, false, sinks_f, dstk, partial_ptr, nullptr, scale, slope, logit_softcap,
+        (Q_f2, K_h2, V_h2, mask_h, false, nullptr, sinks_f, dstk, partial_ptr, nullptr, scale, slope, logit_softcap,
          ne01, ne02, gqa_ratio, ne11, nb01 / (int32_t) sizeof(float2), nb02 / (int32_t) sizeof(float2),
          nb11 / (int32_t) sizeof(half2), nb21 / (int32_t) sizeof(half2), nb31 / (int32_t) sizeof(half),
          jt, zt_gqa, 0, iter_k, (int) GGML_TYPE_COUNT); // V is a template argument here
@@ -243,7 +243,7 @@ static __global__ void ggml_cuda_fattn_kvarn_window_f16_direct_kernel(
     constexpr bool needs_fixup = false;
     constexpr bool is_fixup = false;
     flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup>
-        (Q_f2, K_h2, V_h2, mask_h, false, sinks_f, dstk, nullptr, nullptr, scale, slope, logit_softcap,
+        (Q_f2, K_h2, V_h2, mask_h, false, nullptr, sinks_f, dstk, nullptr, nullptr, scale, slope, logit_softcap,
          ne01, ne02, gqa_ratio, ne11, nb01 / (int32_t) sizeof(float2), nb02 / (int32_t) sizeof(float2),
          nb11 / (int32_t) sizeof(half2), nb21 / (int32_t) sizeof(half2), nb31 / (int32_t) sizeof(half),
          jt, zt_gqa, 0, iter_k, (int) GGML_TYPE_COUNT); // V is a template argument here

--- a/src/llama-kv-cache-kvarn.cpp
+++ b/src/llama-kv-cache-kvarn.cpp
@@ -1291,6 +1291,34 @@ llama_kv_cache_kvarn::llama_kv_cache_kvarn(
         auto * buft = offload ?
                 ggml_backend_dev_buffer_type(dev) :
                 llama_kv_cache_get_host_buft(model, il, placement.cpu_pinned);
+
+        // Host-resident KVarN records only work when the accelerator that owns
+        // the layer can read the host buffer directly. On a discrete GPU it
+        // cannot, so the scheduler places KVARN_STORE, KVARN_WHT and the
+        // attention math that consumes them on the CPU backend, and then has to
+        // reserve host workspace for every intermediate they produce. That
+        // reservation grows with context -- measured at roughly 0.099 MiB per
+        // context token on an RTX 4070, or 25.9 GiB at 262,144 tokens against
+        // 20 MiB for a standard quantized cache in the same configuration --
+        // and the attention itself runs on the CPU. Both are silent today.
+        //
+        // Fail closed rather than degrade: there is no fast configuration on
+        // this path, so the caller has to choose one that exists.
+        if (!offload) {
+            auto * layer_dev = model.dev_layer(il);
+            if (layer_dev &&
+                    ggml_backend_dev_type(layer_dev) != GGML_BACKEND_DEVICE_TYPE_CPU &&
+                    buft && !ggml_backend_dev_supports_buft(layer_dev, buft)) {
+                throw std::runtime_error(format(
+                    "KVarN layer %u cannot be host-resident: %s cannot operate on %s, so KVarN "
+                    "store, materialize and attention would fall back to the CPU backend and "
+                    "reserve host workspace proportional to the context. Keep the KVarN cache "
+                    "device-resident (drop --no-kv-offload, or cover these layers with "
+                    "--kv-gpu-layers), or use a standard quantized cache type for host-resident KV",
+                    il, ggml_backend_dev_name(layer_dev), ggml_backend_buft_name(buft)));
+            }
+        }
+
         auto * ctx = ctx_for_buft(buft);
         if (!ctx) {
             throw std::runtime_error("failed to create KVarN cache tensor context");


### PR DESCRIPTION
Draft, and **the underlying issue stays open**. This does not make KVarN work
with host-resident KV — it stops it from silently pretending to. The real work
is integrating KVarN into the KV-offload line, which has never been done and is
tracked in [`docs/kvarn-host-offload.md`](docs/kvarn-host-offload.md).

## The trap

`--no-kv-offload` with a `kvarn*` cache is permitted today, because
`llama_kvarn_backend_supports_ops(nullptr)` reports that the CPU backend
implements store and materialize. It does — correctly, and very expensively.

`ggml_backend_cuda_device_supports_buft` accepts a host buffer only on an
integrated GPU. On a discrete one it refuses, so the scheduler puts every node
that touches the host-resident KVarN records on the CPU backend and then has to
reserve host workspace for their intermediates.

`GGML_SCHED_DEBUG=2`, `-c 8192`, host-resident, RTX 4070:

| Cache | CPU-assigned nodes | host compute buffer |
|---|---|---:|
| `q8_0` | 9 × `GET_ROWS` | **20.28 MiB** |
| `kvarn5` | 576 `SET_ROWS`, 576 `KVARN_STOR`, 384 `MUL_MAT`, 384 `CONCAT`, 288 `KVARN_WHT` | **2,195.90 MiB** |

The big CPU tensors are `KVARN_WHT` and `GET_ROWS` at 640 MiB each, `SOFT_MAX`
at 414 MiB, `MUL_MAT` at 384 MiB. Attention runs on the CPU.

The reservation is linear in context and independent of KVarN width:

| Context | `kvarn5` host workspace |
|---:|---:|
| 8,192 | 2,195.90 MiB |
| 32,768 | 3,309.90 MiB |
| 65,536 | 6,541.90 MiB |
| 262,144 | **25,933.90 MiB** |

About 0.099 MiB per context token between 32K and 256K. `kvarn8`, `kvarn6` and
`kvarn5` all reserve exactly 25,933.90 MiB at 262,144, and
`--live-context-workspace` does not bound it (identical with and without). The
same cache GPU-resident at 65,536 reserves 84.65 MiB.

At 262,144 that workspace is roughly 4.7x the cache it compresses and exceeds
the host's 31 GiB together with it. So KVarN trades a real 36.5% cache reduction
(`kvarn5` 5,528 MiB against `q8_0` 8,704 MiB) for a workspace and an execution
placement that cost far more than the reduction is worth — all of it invisible
to the user.

## What this PR does

1. `cuda: update the KVarN tile calls to the current process_tile signature` —
   both call sites in `fattn-mma-kvarn-case.cuh` still passed the argument list
   from before compact causal masking added `causal_prefix_first_bound_smem`,
   26 arguments to a 27-parameter function, so `GGML_CUDA_KVARN=ON` did not
   compile here. Needed to build KVarN at all.
2. `kv-cache: fail closed on host-resident KVarN instead of degrading` —
   construction now raises an error when the layer's accelerator cannot operate
   on the buffer its KVarN records would live in, naming the device, the buffer
   type, and the two configurations that do exist.

Integrated GPUs and CPU-only builds are unaffected: `supports_buft` accepts host
buffers there, so the guard does not trigger.

## Why it is still open

KVarN is inherited from BeeLlama; the host-KV-offload line is this fork's, and
none of it was extended to KVarN. BeeLlama v0.4.3 carries KVarN across 89 files
and contains no occurrence of `kv_cpu_pinned`, `offload_attn_compute` or
`kv_gpu_layers`; this tree has them in 9–11 files each.

A standard quantized cache survives host residency because its K/V reach
attention as copyable split inputs that the scheduler stages to the device.
KVarN's records reach attention through `KVARN_VIEW` chains, so there is nothing
to stage and it falls back wholesale. Closing this properly needs:

- the KVarN body given the same staged-input treatment, so attention stays on
  the accelerator while storage stays on the host — what `offload_attn_compute`
  already expresses for standard caches;
- a decision on whether `KVARN_VIEW` operands can be staged at all, or whether
  the records need a device-side mirror with its own residency policy;
- `--kv-gpu-layers` extended to KVarN layers;
- then the same qualification the standard types got: exactness, KLD, allocation
  high-water, throughput at depth.

## Status

Syntax-checked; the full `GGML_CUDA_KVARN=ON` build was still running when this
was opened. The identical tile-call fix already completed a clean
`GGML_CUDA_KVARN=ON` + `GGML_CUDA_FA_ALL_QUANTS=ON` build (`EXIT=0`) on the
sibling branch, so the CUDA half is proven; the guard is a small C++ change in
`llama-kv-cache-kvarn.cpp`. Runtime verification of the error path is pending
and will be added before this leaves draft.

Measurements come from the host-KV decode lane (RTX 4070, Qwen3.8-27B-UD-IQ2_M,
base `946c1e5b6`); that work is separate and continues in
`beellama/kv-host-decode-transport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8bBMKTLSzVbDBSUfdQc9N
