### PR TITLE
fix: restore CUDA KVarN build

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-kvarn-case.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-kvarn-case.cuh
@@ -176,7 +176,7 @@ static __global__ void ggml_cuda_fattn_kvarn_window_f16_partial_kernel(
     constexpr bool needs_fixup = false;
     constexpr bool is_fixup = true;
     flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup>
-        (Q_f2, K_h2, V_h2, mask_h, false, sinks_f, dstk, partial_ptr, nullptr, scale, slope, logit_softcap,
+        (Q_f2, K_h2, V_h2, mask_h, false, nullptr, sinks_f, dstk, partial_ptr, nullptr, scale, slope, logit_softcap,
          ne01, ne02, gqa_ratio, ne11, nb01 / (int32_t) sizeof(float2), nb02 / (int32_t) sizeof(float2),
          nb11 / (int32_t) sizeof(half2), nb21 / (int32_t) sizeof(half2), nb31 / (int32_t) sizeof(half),
          jt, zt_gqa, 0, iter_k, (int) GGML_TYPE_COUNT); // V is a template argument here
@@ -243,7 +243,7 @@ static __global__ void ggml_cuda_fattn_kvarn_window_f16_direct_kernel(
     constexpr bool needs_fixup = false;
     constexpr bool is_fixup = false;
     flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup>
-        (Q_f2, K_h2, V_h2, mask_h, false, sinks_f, dstk, nullptr, nullptr, scale, slope, logit_softcap,
+        (Q_f2, K_h2, V_h2, mask_h, false, nullptr, sinks_f, dstk, nullptr, nullptr, scale, slope, logit_softcap,
          ne01, ne02, gqa_ratio, ne11, nb01 / (int32_t) sizeof(float2), nb02 / (int32_t) sizeof(float2),
          nb11 / (int32_t) sizeof(half2), nb21 / (int32_t) sizeof(half2), nb31 / (int32_t) sizeof(half),
          jt, zt_gqa, 0, iter_k, (int) GGML_TYPE_COUNT); // V is a template argument here


### PR DESCRIPTION
## Summary
- pass the causal_prefix_first_bound_smem argument required by flash_attn_ext_f16_process_tile in both KVarN direct-attention call sites
- use nullptr, matching the non-compact causal KVarN path

## Validation
- configured a clean CUDA build with GGML_CUDA=ON, GGML_CUDA_KVARN=ON, GGML_CUDA_FA=ON, GGML_NATIVE=ON, and CMAKE_BUILD_TYPE=Release
- full CUDA build is running under the project CUDA build lock; the KVarN CUDA sources compile past the previously stale call sites