### PR TITLE
llama: share target and MTP phase workspaces

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2427,6 +2427,15 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_RECURRENT_STATE_OFFLOAD"));
     add_opt(common_arg(
+        {"--phase-aware-workspace"},
+        {"--no-phase-aware-workspace"},
+        string_format("resize compute workspaces between prompt processing and token generation; later prompt turns regrow the prompt reservation (default: %s)",
+                      params.phase_aware_workspace ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.phase_aware_workspace = value;
+        }
+    ).set_env("LLAMA_ARG_PHASE_AWARE_WORKSPACE"));
+    add_opt(common_arg(
         {"--kv-gpu-layers"}, "N",
         string_format("with --no-kv-offload, keep the first N independently owned attention KV layers device-resident "
                       "for standard and direct hybrid caches. Unsupported specialized caches ignore this option "

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1746,6 +1746,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.kv_cpu_pinned     = params.kv_cpu_pinned;
     cparams.recurrent_state_offload = params.recurrent_state_offload;
     cparams.kv_gpu_layers     = (uint32_t) std::max(0, params.kv_gpu_layers);
+    cparams.phase_aware_workspace = params.phase_aware_workspace;
     cparams.no_perf           = params.no_perf;
     cparams.op_offload        = !params.no_op_offload;
     cparams.swa_full          = params.swa_full;

--- a/common/common.h
+++ b/common/common.h
@@ -571,6 +571,7 @@ struct common_params {
     bool kv_cpu_pinned     = false; // use pinned host buffers for CPU-resident KV cache storage
     bool recurrent_state_offload = false; // offload recurrent state independently of attention KV storage
     int32_t kv_gpu_layers  = 0;     // with no_kv_offload, keep this many attention KV layers device-resident
+    bool phase_aware_workspace = false; // resize compute schedulers between prompt and generation phases
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1297,6 +1297,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     int32_t n_mtp_layers  = 1;
     bool    is_mem_shared = false;   // gemma4
     bool    chain_heads   = false;   // derived in the ctor: n_mtp_layers > 1 && !is_mem_shared
+    bool    shared_workspace = false;
 
     // Per-sequence cross-batch carryover: pair (h_p, x_{p+1}) at MTP pos p+1.
     // The last h-row of one process() call needs the first token of the NEXT
@@ -1373,6 +1374,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
         chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
+        shared_workspace = llama_contexts_share_workspace(ctx_tgt, ctx_dft);
 
         if (chain_heads) {
             this->params.n_max = std::min(this->params.n_max, n_mtp_layers);
@@ -1462,6 +1464,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         auto * ctx_tgt = this->params.ctx_tgt;
         auto * ctx_dft = this->params.ctx_dft;
+        if (shared_workspace && is_mem_shared) {
+            llama_synchronize(ctx_tgt);
+        }
 
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
 
@@ -1524,6 +1529,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 llama_set_nextn_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
             }
             if (!ok) {
+                if (shared_workspace) {
+                    llama_synchronize(ctx_dft);
+                }
                 return false;
             }
         }
@@ -1582,6 +1590,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         }
 
         int i = 0;
+        bool decode_failed = false;
 
         while (n_drafting > 0) {
             // each step decodes under a different head, i.e. a different decoder layer, and
@@ -1603,6 +1612,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             int ret = llama_decode(ctx_dft, batch);
             if (ret != 0) {
                 SPC_ERR("llama_decode[%d] returned %d\n", i, ret);
+                decode_failed = true;
                 break;
             }
 
@@ -1686,6 +1696,10 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         if (chain_heads) {
             llama_set_nextn_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
+        }
+
+        if (shared_workspace && (is_mem_shared || decode_failed)) {
+            llama_synchronize(ctx_dft);
         }
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
@@ -2449,6 +2463,18 @@ common_speculative_init_result::common_speculative_init_result(
         }
 
         pimpl->context.reset(ctx_dft);
+    }
+
+    if (pimpl->context && spec_mtp && params.phase_aware_workspace) {
+        const int32_t status = llama_attach_shared_workspace(pimpl->context.get(), ctx_tgt);
+        if (status < 0) {
+            LOG_ERR("%s: failed to prepare shared target/MTP workspaces\n", __func__);
+            pimpl->context.reset();
+            return;
+        }
+        if (status == 0) {
+            LOG_INF("%s: target and MTP placements do not share a compute buffer type\n", __func__);
+        }
     }
 }
 

--- a/ggml/include/ggml-alloc.h
+++ b/ggml/include/ggml-alloc.h
@@ -48,6 +48,10 @@ typedef struct ggml_gallocr * ggml_gallocr_t;
 GGML_API ggml_gallocr_t ggml_gallocr_new(ggml_backend_buffer_type_t buft);
 GGML_API ggml_gallocr_t ggml_gallocr_new_n(ggml_backend_buffer_type_t * bufts, int n_bufs);
 GGML_API void           ggml_gallocr_free(ggml_gallocr_t galloc);
+// Set owner to NULL to create an owner. A generation change invalidates cached graph addresses.
+GGML_API bool           ggml_gallocr_set_resizable(ggml_gallocr_t galloc, ggml_gallocr_t owner);
+GGML_API void           ggml_gallocr_get_resizable_state(ggml_gallocr_t galloc, uint64_t * generation, uint64_t * shrink_generation);
+GGML_API void           ggml_gallocr_request_shrink(ggml_gallocr_t galloc);
 
 // pre-allocate buffers from a measure graph - does not allocate or modify the graph
 // call with a worst-case graph to avoid buffer reallocations

--- a/ggml/include/ggml-alloc.h
+++ b/ggml/include/ggml-alloc.h
@@ -48,7 +48,10 @@ typedef struct ggml_gallocr * ggml_gallocr_t;
 GGML_API ggml_gallocr_t ggml_gallocr_new(ggml_backend_buffer_type_t buft);
 GGML_API ggml_gallocr_t ggml_gallocr_new_n(ggml_backend_buffer_type_t * bufts, int n_bufs);
 GGML_API void           ggml_gallocr_free(ggml_gallocr_t galloc);
-// Set owner to NULL to create an owner. A generation change invalidates cached graph addresses.
+// A NULL owner creates the shared-buffer owner. Otherwise, galloc attaches as the only borrower for matching buffer types.
+// Shared buffers use the largest published requirement and shrink after every active role republishes.
+// A generation change invalidates graph addresses. A shrink-generation change invalidates cached reserve plans.
+// Shared buffers remain valid until both roles detach.
 GGML_API bool           ggml_gallocr_set_resizable(ggml_gallocr_t galloc, ggml_gallocr_t owner);
 GGML_API void           ggml_gallocr_get_resizable_state(ggml_gallocr_t galloc, uint64_t * generation, uint64_t * shrink_generation);
 GGML_API void           ggml_gallocr_request_shrink(ggml_gallocr_t galloc);

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -319,6 +319,10 @@ extern "C" {
     GGML_API ggml_backend_sched_t ggml_backend_sched_new(ggml_backend_t * backends, ggml_backend_buffer_type_t * bufts, int n_backends, size_t graph_size, bool parallel, bool op_offload);
     GGML_API void                 ggml_backend_sched_free(ggml_backend_sched_t sched);
 
+    GGML_API bool                 ggml_backend_sched_set_resizable(ggml_backend_sched_t sched, ggml_backend_sched_t owner);
+    GGML_API void                 ggml_backend_sched_get_buffer_state(ggml_backend_sched_t sched, uint64_t * generation, uint64_t * shrink_generation);
+    GGML_API void                 ggml_backend_sched_request_buffer_shrink(ggml_backend_sched_t sched);
+
     // Initialize backend buffers from a measure graph
     GGML_API void                 ggml_backend_sched_reserve_size(ggml_backend_sched_t sched, struct ggml_cgraph * measure_graph, size_t * sizes);
     GGML_API bool                 ggml_backend_sched_reserve(ggml_backend_sched_t sched, struct ggml_cgraph * measure_graph); // returns success

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -439,6 +439,26 @@ static struct vbuffer * ggml_vbuffer_alloc(ggml_backend_buffer_type_t buft, cons
     return buf;
 }
 
+static struct vbuffer * ggml_vbuffer_alloc_sizes(
+        ggml_backend_buffer_type_t buft,
+        const size_t sizes[GGML_VBUFFER_MAX_CHUNKS],
+        enum ggml_backend_buffer_usage usage) {
+    struct vbuffer * buf = (struct vbuffer *) calloc(1, sizeof(struct vbuffer));
+    if (buf == NULL) {
+        return NULL;
+    }
+
+    for (int n = 0; n < GGML_VBUFFER_MAX_CHUNKS && sizes[n] > 0; ++n) {
+        buf->chunks[n] = ggml_backend_buft_alloc_buffer(buft, sizes[n]);
+        if (buf->chunks[n] == NULL) {
+            ggml_vbuffer_free(buf);
+            return NULL;
+        }
+        ggml_backend_buffer_set_usage(buf->chunks[n], usage);
+    }
+    return buf;
+}
+
 static void ggml_vbuffer_tensor_alloc(struct vbuffer * buf, struct ggml_tensor * tensor, struct buffer_address buf_addr) {
     void * base = ggml_backend_buffer_get_base(buf->chunks[buf_addr.chunk]);
     void * addr = (char *)base + buf_addr.offset;
@@ -493,7 +513,231 @@ struct ggml_gallocr {
 
     struct leaf_alloc * leaf_allocs; // [n_leafs]
     int n_leafs;
+
+    bool resizable;
+    bool shrink_requested;
+    uint64_t generation;
+
+    struct ggml_gallocr_resizable_buffers * resizable_buffers;
+    int resizable_role;
+    int * resizable_entry_ids; // [n_buffers], -1 for private buffers
 };
+
+enum ggml_gallocr_resizable_role {
+    GGML_GALLOCR_RESIZABLE_ROLE_OWNER    = 0,
+    GGML_GALLOCR_RESIZABLE_ROLE_BORROWER = 1,
+    GGML_GALLOCR_RESIZABLE_ROLE_COUNT    = 2,
+};
+
+struct ggml_gallocr_resizable_entry {
+    ggml_backend_buffer_type_t buft;
+    struct vbuffer * buffer;
+    size_t requirements[GGML_GALLOCR_RESIZABLE_ROLE_COUNT][GGML_VBUFFER_MAX_CHUNKS];
+};
+
+struct ggml_gallocr_resizable_buffers {
+    struct ggml_gallocr_resizable_entry * entries;
+    int n_entries;
+    int refs;
+
+    bool active[GGML_GALLOCR_RESIZABLE_ROLE_COUNT];
+    bool shrink_seen[GGML_GALLOCR_RESIZABLE_ROLE_COUNT];
+    bool shrink_pending;
+
+    uint64_t generation;
+    uint64_t shrink_generation;
+};
+
+static bool ggml_gallocr_resize_buffer(
+        ggml_gallocr_t galloc,
+        int buffer_id,
+        bool shrink) {
+    size_t required[GGML_VBUFFER_MAX_CHUNKS] = {0};
+    for (int chunk = 0; chunk < galloc->buf_tallocs[buffer_id]->n_chunks; ++chunk) {
+        required[chunk] = ggml_dyn_tallocr_max_size(galloc->buf_tallocs[buffer_id], chunk);
+    }
+
+    bool changed = false;
+    bool needs_growth = false;
+    for (int chunk = 0; chunk < GGML_VBUFFER_MAX_CHUNKS; ++chunk) {
+        const size_t allocated = galloc->buffers[buffer_id] ?
+                ggml_vbuffer_chunk_size(galloc->buffers[buffer_id], chunk) : 0;
+        changed = changed || allocated != required[chunk];
+        needs_growth = needs_growth || allocated < required[chunk];
+    }
+
+    if (!changed || (!needs_growth && !shrink)) {
+        return true;
+    }
+
+    struct vbuffer * old = galloc->buffers[buffer_id];
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        if (galloc->buf_tallocs[i] == galloc->buf_tallocs[buffer_id]) {
+            galloc->buffers[i] = NULL;
+        }
+    }
+    ggml_vbuffer_free(old);
+    galloc->generation++;
+
+    struct vbuffer * replacement = NULL;
+    if (required[0] > 0) {
+        replacement = ggml_vbuffer_alloc_sizes(galloc->bufts[buffer_id], required, GGML_BACKEND_BUFFER_USAGE_COMPUTE);
+        if (replacement == NULL) {
+            GGML_LOG_ERROR("%s: failed to allocate resizable %s workspace of size %.2f MiB\n",
+                    __func__, ggml_backend_buft_name(galloc->bufts[buffer_id]), required[0] / 1024.0 / 1024.0);
+            return false;
+        }
+    }
+
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        if (galloc->buf_tallocs[i] == galloc->buf_tallocs[buffer_id]) {
+            galloc->buffers[i] = replacement;
+        }
+    }
+
+    return true;
+}
+
+static bool ggml_gallocr_resize_private_buffers(ggml_gallocr_t galloc) {
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        if (galloc->resizable_buffers != NULL && galloc->resizable_entry_ids[i] >= 0) {
+            continue;
+        }
+
+        bool duplicate = false;
+        for (int j = 0; j < i; ++j) {
+            if (galloc->buf_tallocs[j] == galloc->buf_tallocs[i]) {
+                galloc->buffers[i] = galloc->buffers[j];
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            continue;
+        }
+        if (!ggml_gallocr_resize_buffer(galloc, i, galloc->shrink_requested)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool ggml_gallocr_resizable_resize_entry(
+        struct ggml_gallocr_resizable_buffers * shared,
+        struct ggml_gallocr_resizable_entry * entry,
+        bool shrink) {
+    size_t required[GGML_VBUFFER_MAX_CHUNKS] = {0};
+    for (int role = 0; role < GGML_GALLOCR_RESIZABLE_ROLE_COUNT; ++role) {
+        if (!shared->active[role]) {
+            continue;
+        }
+        for (int chunk = 0; chunk < GGML_VBUFFER_MAX_CHUNKS; ++chunk) {
+            required[chunk] = MAX(required[chunk], entry->requirements[role][chunk]);
+        }
+    }
+
+    bool changed = false;
+    bool needs_growth = false;
+    for (int chunk = 0; chunk < GGML_VBUFFER_MAX_CHUNKS; ++chunk) {
+        const size_t allocated = entry->buffer ? ggml_vbuffer_chunk_size(entry->buffer, chunk) : 0;
+        changed = changed || allocated != required[chunk];
+        needs_growth = needs_growth || allocated < required[chunk];
+    }
+
+    if (!changed || (!needs_growth && !shrink)) {
+        return true;
+    }
+
+    ggml_vbuffer_free(entry->buffer);
+    entry->buffer = NULL;
+    shared->generation++;
+
+    // Keep the published requirements after failure. Any role can retry the same shared maximum.
+    if (required[0] > 0) {
+        entry->buffer = ggml_vbuffer_alloc_sizes(entry->buft, required, GGML_BACKEND_BUFFER_USAGE_COMPUTE);
+        if (entry->buffer == NULL) {
+            GGML_LOG_ERROR("%s: failed to allocate shared %s workspace of size %.2f MiB\n",
+                    __func__, ggml_backend_buft_name(entry->buft), required[0] / 1024.0 / 1024.0);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool ggml_gallocr_resizable_publish(ggml_gallocr_t galloc) {
+    struct ggml_gallocr_resizable_buffers * shared = galloc->resizable_buffers;
+    GGML_ASSERT(shared != NULL);
+
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        const int entry_id = galloc->resizable_entry_ids[i];
+        if (entry_id < 0) {
+            continue;
+        }
+
+        bool duplicate = false;
+        for (int j = 0; j < i; ++j) {
+            if (galloc->resizable_entry_ids[j] == entry_id) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            continue;
+        }
+
+        size_t * requirements = shared->entries[entry_id].requirements[galloc->resizable_role];
+        memset(requirements, 0, GGML_VBUFFER_MAX_CHUNKS * sizeof(*requirements));
+        for (int chunk = 0; chunk < galloc->buf_tallocs[i]->n_chunks; ++chunk) {
+            requirements[chunk] = ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i], chunk);
+        }
+    }
+
+    bool shrink = false;
+    if (shared->shrink_pending) {
+        shared->shrink_seen[galloc->resizable_role] = true;
+        shrink = true;
+        for (int role = 0; role < GGML_GALLOCR_RESIZABLE_ROLE_COUNT; ++role) {
+            if (shared->active[role] && !shared->shrink_seen[role]) {
+                shrink = false;
+                break;
+            }
+        }
+    }
+
+    for (int i = 0; i < shared->n_entries; ++i) {
+        if (!ggml_gallocr_resizable_resize_entry(shared, &shared->entries[i], shrink)) {
+            return false;
+        }
+    }
+
+    if (shrink) {
+        shared->shrink_pending = false;
+        memset(shared->shrink_seen, 0, sizeof(shared->shrink_seen));
+    }
+    return true;
+}
+
+static bool ggml_gallocr_resize_buffers(ggml_gallocr_t galloc) {
+    if (galloc->resizable_buffers != NULL && !ggml_gallocr_resizable_publish(galloc)) {
+        return false;
+    }
+    if (!ggml_gallocr_resize_private_buffers(galloc)) {
+        return false;
+    }
+    galloc->shrink_requested = false;
+    return true;
+}
+
+static struct vbuffer * ggml_gallocr_get_vbuffer(ggml_gallocr_t galloc, int buffer_id) {
+    if (galloc->resizable_buffers != NULL) {
+        const int entry_id = galloc->resizable_entry_ids[buffer_id];
+        if (entry_id >= 0) {
+            return galloc->resizable_buffers->entries[entry_id].buffer;
+        }
+    }
+    return galloc->buffers[buffer_id];
+}
 
 ggml_gallocr_t ggml_gallocr_new_n(ggml_backend_buffer_type_t * bufts, int n_bufs) {
     ggml_gallocr_t galloc = (ggml_gallocr_t)calloc(1, sizeof(struct ggml_gallocr));
@@ -535,10 +779,50 @@ ggml_gallocr_t ggml_gallocr_new(ggml_backend_buffer_type_t buft) {
     return ggml_gallocr_new_n(&buft, 1);
 }
 
+static void ggml_gallocr_resizable_start_shrink(struct ggml_gallocr_resizable_buffers * shared) {
+    shared->shrink_pending = true;
+    memset(shared->shrink_seen, 0, sizeof(shared->shrink_seen));
+    shared->shrink_generation++;
+}
+
+static void ggml_gallocr_resizable_free(struct ggml_gallocr_resizable_buffers * shared) {
+    for (int i = 0; i < shared->n_entries; ++i) {
+        ggml_vbuffer_free(shared->entries[i].buffer);
+    }
+    free(shared->entries);
+    free(shared);
+}
+
+static void ggml_gallocr_resizable_detach(ggml_gallocr_t galloc) {
+    struct ggml_gallocr_resizable_buffers * shared = galloc->resizable_buffers;
+    if (shared == NULL) {
+        return;
+    }
+
+    const int role = galloc->resizable_role;
+    GGML_ASSERT(role >= 0 && role < GGML_GALLOCR_RESIZABLE_ROLE_COUNT);
+    GGML_ASSERT(shared->active[role]);
+    shared->active[role] = false;
+    shared->shrink_seen[role] = false;
+    for (int i = 0; i < shared->n_entries; ++i) {
+        memset(shared->entries[i].requirements[role], 0, sizeof(shared->entries[i].requirements[role]));
+    }
+
+    shared->refs--;
+    if (shared->refs == 0) {
+        ggml_gallocr_resizable_free(shared);
+    } else {
+        ggml_gallocr_resizable_start_shrink(shared);
+    }
+    galloc->resizable_buffers = NULL;
+}
+
 void ggml_gallocr_free(ggml_gallocr_t galloc) {
     if (galloc == NULL) {
         return;
     }
+
+    ggml_gallocr_resizable_detach(galloc);
 
     for (int i = 0; i < galloc->n_buffers; i++) {
         if (galloc->buffers != NULL) {
@@ -576,7 +860,124 @@ void ggml_gallocr_free(ggml_gallocr_t galloc) {
     free(galloc->buf_tallocs);
     free(galloc->node_allocs);
     free(galloc->leaf_allocs);
+    free(galloc->resizable_entry_ids);
     free(galloc);
+}
+
+static void ggml_gallocr_set_resizable_owner(ggml_gallocr_t galloc) {
+    GGML_ASSERT(galloc != NULL);
+    GGML_ASSERT(!galloc->resizable);
+
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        GGML_ASSERT(galloc->buffers[i] == NULL);
+    }
+
+    struct ggml_gallocr_resizable_buffers * shared =
+            (struct ggml_gallocr_resizable_buffers *) calloc(1, sizeof(*shared));
+    GGML_ASSERT(shared != NULL);
+    shared->entries = (struct ggml_gallocr_resizable_entry *) calloc(
+            (size_t) galloc->n_buffers, sizeof(*shared->entries));
+    GGML_ASSERT(shared->entries != NULL);
+
+    galloc->resizable_entry_ids = (int *) malloc((size_t) galloc->n_buffers * sizeof(int));
+    GGML_ASSERT(galloc->resizable_entry_ids != NULL);
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        int entry_id = -1;
+        for (int j = 0; j < shared->n_entries; ++j) {
+            if (shared->entries[j].buft == galloc->bufts[i]) {
+                entry_id = j;
+                break;
+            }
+        }
+        if (entry_id < 0) {
+            entry_id = shared->n_entries++;
+            shared->entries[entry_id].buft = galloc->bufts[i];
+        }
+        galloc->resizable_entry_ids[i] = entry_id;
+    }
+
+    shared->refs = 1;
+    shared->active[GGML_GALLOCR_RESIZABLE_ROLE_OWNER] = true;
+
+    galloc->resizable = true;
+    galloc->resizable_buffers = shared;
+    galloc->resizable_role = GGML_GALLOCR_RESIZABLE_ROLE_OWNER;
+}
+
+static bool ggml_gallocr_set_resizable_borrower(ggml_gallocr_t galloc, ggml_gallocr_t owner) {
+    GGML_ASSERT(galloc != NULL);
+    GGML_ASSERT(owner != NULL);
+    GGML_ASSERT(galloc != owner);
+    GGML_ASSERT(!galloc->resizable);
+
+    struct ggml_gallocr_resizable_buffers * shared = owner->resizable_buffers;
+    if (shared == NULL || owner->resizable_role != GGML_GALLOCR_RESIZABLE_ROLE_OWNER ||
+            shared->active[GGML_GALLOCR_RESIZABLE_ROLE_BORROWER]) {
+        return false;
+    }
+
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        GGML_ASSERT(galloc->buffers[i] == NULL);
+    }
+
+    int * entry_ids = (int *) malloc((size_t) galloc->n_buffers * sizeof(int));
+    GGML_ASSERT(entry_ids != NULL);
+    bool compatible = false;
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        entry_ids[i] = -1;
+        for (int j = 0; j < shared->n_entries; ++j) {
+            if (shared->entries[j].buft == galloc->bufts[i]) {
+                entry_ids[i] = j;
+                compatible = true;
+                break;
+            }
+        }
+    }
+
+    if (!compatible) {
+        free(entry_ids);
+        return false;
+    }
+
+    shared->refs++;
+    shared->active[GGML_GALLOCR_RESIZABLE_ROLE_BORROWER] = true;
+    shared->shrink_seen[GGML_GALLOCR_RESIZABLE_ROLE_BORROWER] = false;
+
+    galloc->resizable = true;
+    galloc->resizable_buffers = shared;
+    galloc->resizable_role = GGML_GALLOCR_RESIZABLE_ROLE_BORROWER;
+    galloc->resizable_entry_ids = entry_ids;
+    return true;
+}
+
+bool ggml_gallocr_set_resizable(ggml_gallocr_t galloc, ggml_gallocr_t owner) {
+    GGML_ASSERT(galloc != NULL);
+    if (owner != NULL) {
+        return ggml_gallocr_set_resizable_borrower(galloc, owner);
+    }
+    ggml_gallocr_set_resizable_owner(galloc);
+    return true;
+}
+
+void ggml_gallocr_get_resizable_state(
+        ggml_gallocr_t galloc,
+        uint64_t * generation,
+        uint64_t * shrink_generation) {
+    GGML_ASSERT(galloc != NULL);
+    GGML_ASSERT(generation != NULL);
+    GGML_ASSERT(shrink_generation != NULL);
+    *generation = galloc->generation +
+            (galloc->resizable_buffers ? galloc->resizable_buffers->generation : 0);
+    *shrink_generation = galloc->resizable_buffers ? galloc->resizable_buffers->shrink_generation : 0;
+}
+
+void ggml_gallocr_request_shrink(ggml_gallocr_t galloc) {
+    GGML_ASSERT(galloc != NULL);
+    GGML_ASSERT(galloc->resizable);
+    galloc->shrink_requested = true;
+    if (galloc->resizable_buffers != NULL && !galloc->resizable_buffers->shrink_pending) {
+        ggml_gallocr_resizable_start_shrink(galloc->resizable_buffers);
+    }
 }
 
 typedef struct ggml_gallocr * ggml_gallocr_t;
@@ -901,7 +1302,11 @@ static bool ggml_gallocr_reserve_n_impl(
         }
     }
 
-    // reallocate buffers if needed
+    if (galloc->resizable && !no_alloc) {
+        return ggml_gallocr_resize_buffers(galloc);
+    }
+
+    // reallocate private buffers if needed
     for (int i = 0; i < galloc->n_buffers; i++) {
         // if the buffer type is used multiple times, we reuse the same buffer
         for (int j = 0; j < i; j++) {
@@ -984,7 +1389,9 @@ static void ggml_gallocr_init_tensor(ggml_gallocr_t galloc, struct ggml_tensor *
         if (tensor->data == NULL) {
             assert(tensor_alloc->addr.offset != SIZE_MAX);
             assert(ggml_backend_buft_get_alloc_size(galloc->bufts[buffer_id], tensor) <= tensor_alloc->size_max);
-            ggml_vbuffer_tensor_alloc(galloc->buffers[buffer_id], tensor, tensor_alloc->addr);
+            struct vbuffer * buffer = ggml_gallocr_get_vbuffer(galloc, buffer_id);
+            GGML_ASSERT(buffer != NULL);
+            ggml_vbuffer_tensor_alloc(buffer, tensor, tensor_alloc->addr);
         } else {
             if (tensor->buffer == NULL) {
                 // this tensor was allocated without ggml-backend
@@ -1068,8 +1475,23 @@ bool ggml_gallocr_alloc_graph(ggml_gallocr_t galloc, struct ggml_cgraph * graph)
 
     // reset buffers
     for (int i = 0; i < galloc->n_buffers; i++) {
-        if (galloc->buffers[i] != NULL) {
-            ggml_vbuffer_reset(galloc->buffers[i]);
+        struct vbuffer * buffer = ggml_gallocr_get_vbuffer(galloc, i);
+        if (buffer != NULL) {
+            if (!galloc->resizable) {
+                ggml_vbuffer_reset(buffer);
+                continue;
+            }
+
+            bool already_reset = false;
+            for (int j = 0; j < i; ++j) {
+                if (ggml_gallocr_get_vbuffer(galloc, j) == buffer) {
+                    already_reset = true;
+                    break;
+                }
+            }
+            if (!already_reset) {
+                ggml_vbuffer_reset(buffer);
+            }
         }
     }
 
@@ -1100,19 +1522,20 @@ bool ggml_gallocr_alloc_graph(ggml_gallocr_t galloc, struct ggml_cgraph * graph)
 size_t ggml_gallocr_get_buffer_size(ggml_gallocr_t galloc, int buffer_id) {
     GGML_ASSERT(buffer_id >= 0 && buffer_id < galloc->n_buffers);
 
-    if (galloc->buffers[buffer_id] == NULL) {
+    struct vbuffer * buffer = ggml_gallocr_get_vbuffer(galloc, buffer_id);
+    if (buffer == NULL) {
         return 0;
     }
 
     for (int i = 0; i < buffer_id; i++) {
-        if (galloc->buffers[i] == galloc->buffers[buffer_id]) {
+        if (ggml_gallocr_get_vbuffer(galloc, i) == buffer) {
             // this buffer is the same as a previous one due to the same buffer type being used multiple times
             // only return the buffer size the first time it appears to avoid double counting
             return 0;
         }
     }
 
-    return ggml_vbuffer_size(galloc->buffers[buffer_id]);
+    return ggml_vbuffer_size(buffer);
 }
 
 // utils

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -518,30 +518,30 @@ struct ggml_gallocr {
     bool shrink_requested;
     uint64_t generation;
 
-    struct ggml_gallocr_resizable_buffers * resizable_buffers;
-    int resizable_role;
-    int * resizable_entry_ids; // [n_buffers], -1 for private buffers
+    struct ggml_gallocr_shared_buffers * shared_buffers;
+    int shared_role;
+    int * shared_entry_ids; // [n_buffers], -1 for private buffers
 };
 
-enum ggml_gallocr_resizable_role {
-    GGML_GALLOCR_RESIZABLE_ROLE_OWNER    = 0,
-    GGML_GALLOCR_RESIZABLE_ROLE_BORROWER = 1,
-    GGML_GALLOCR_RESIZABLE_ROLE_COUNT    = 2,
+enum ggml_gallocr_shared_role {
+    GGML_GALLOCR_SHARED_ROLE_OWNER    = 0,
+    GGML_GALLOCR_SHARED_ROLE_BORROWER = 1,
+    GGML_GALLOCR_SHARED_ROLE_COUNT    = 2,
 };
 
-struct ggml_gallocr_resizable_entry {
+struct ggml_gallocr_shared_entry {
     ggml_backend_buffer_type_t buft;
     struct vbuffer * buffer;
-    size_t requirements[GGML_GALLOCR_RESIZABLE_ROLE_COUNT][GGML_VBUFFER_MAX_CHUNKS];
+    size_t requirements[GGML_GALLOCR_SHARED_ROLE_COUNT][GGML_VBUFFER_MAX_CHUNKS];
 };
 
-struct ggml_gallocr_resizable_buffers {
-    struct ggml_gallocr_resizable_entry * entries;
+struct ggml_gallocr_shared_buffers {
+    struct ggml_gallocr_shared_entry * entries;
     int n_entries;
     int refs;
 
-    bool active[GGML_GALLOCR_RESIZABLE_ROLE_COUNT];
-    bool shrink_seen[GGML_GALLOCR_RESIZABLE_ROLE_COUNT];
+    bool active[GGML_GALLOCR_SHARED_ROLE_COUNT];
+    bool shrink_seen[GGML_GALLOCR_SHARED_ROLE_COUNT];
     bool shrink_pending;
 
     uint64_t generation;
@@ -600,7 +600,7 @@ static bool ggml_gallocr_resize_buffer(
 
 static bool ggml_gallocr_resize_private_buffers(ggml_gallocr_t galloc) {
     for (int i = 0; i < galloc->n_buffers; ++i) {
-        if (galloc->resizable_buffers != NULL && galloc->resizable_entry_ids[i] >= 0) {
+        if (galloc->shared_buffers != NULL && galloc->shared_entry_ids[i] >= 0) {
             continue;
         }
 
@@ -622,12 +622,12 @@ static bool ggml_gallocr_resize_private_buffers(ggml_gallocr_t galloc) {
     return true;
 }
 
-static bool ggml_gallocr_resizable_resize_entry(
-        struct ggml_gallocr_resizable_buffers * shared,
-        struct ggml_gallocr_resizable_entry * entry,
+static bool ggml_gallocr_resize_shared_entry(
+        struct ggml_gallocr_shared_buffers * shared,
+        struct ggml_gallocr_shared_entry * entry,
         bool shrink) {
     size_t required[GGML_VBUFFER_MAX_CHUNKS] = {0};
-    for (int role = 0; role < GGML_GALLOCR_RESIZABLE_ROLE_COUNT; ++role) {
+    for (int role = 0; role < GGML_GALLOCR_SHARED_ROLE_COUNT; ++role) {
         if (!shared->active[role]) {
             continue;
         }
@@ -665,19 +665,19 @@ static bool ggml_gallocr_resizable_resize_entry(
     return true;
 }
 
-static bool ggml_gallocr_resizable_publish(ggml_gallocr_t galloc) {
-    struct ggml_gallocr_resizable_buffers * shared = galloc->resizable_buffers;
+static bool ggml_gallocr_publish_shared_requirements(ggml_gallocr_t galloc) {
+    struct ggml_gallocr_shared_buffers * shared = galloc->shared_buffers;
     GGML_ASSERT(shared != NULL);
 
     for (int i = 0; i < galloc->n_buffers; ++i) {
-        const int entry_id = galloc->resizable_entry_ids[i];
+        const int entry_id = galloc->shared_entry_ids[i];
         if (entry_id < 0) {
             continue;
         }
 
         bool duplicate = false;
         for (int j = 0; j < i; ++j) {
-            if (galloc->resizable_entry_ids[j] == entry_id) {
+            if (galloc->shared_entry_ids[j] == entry_id) {
                 duplicate = true;
                 break;
             }
@@ -686,7 +686,7 @@ static bool ggml_gallocr_resizable_publish(ggml_gallocr_t galloc) {
             continue;
         }
 
-        size_t * requirements = shared->entries[entry_id].requirements[galloc->resizable_role];
+        size_t * requirements = shared->entries[entry_id].requirements[galloc->shared_role];
         memset(requirements, 0, GGML_VBUFFER_MAX_CHUNKS * sizeof(*requirements));
         for (int chunk = 0; chunk < galloc->buf_tallocs[i]->n_chunks; ++chunk) {
             requirements[chunk] = ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i], chunk);
@@ -695,9 +695,9 @@ static bool ggml_gallocr_resizable_publish(ggml_gallocr_t galloc) {
 
     bool shrink = false;
     if (shared->shrink_pending) {
-        shared->shrink_seen[galloc->resizable_role] = true;
+        shared->shrink_seen[galloc->shared_role] = true;
         shrink = true;
-        for (int role = 0; role < GGML_GALLOCR_RESIZABLE_ROLE_COUNT; ++role) {
+        for (int role = 0; role < GGML_GALLOCR_SHARED_ROLE_COUNT; ++role) {
             if (shared->active[role] && !shared->shrink_seen[role]) {
                 shrink = false;
                 break;
@@ -706,7 +706,7 @@ static bool ggml_gallocr_resizable_publish(ggml_gallocr_t galloc) {
     }
 
     for (int i = 0; i < shared->n_entries; ++i) {
-        if (!ggml_gallocr_resizable_resize_entry(shared, &shared->entries[i], shrink)) {
+        if (!ggml_gallocr_resize_shared_entry(shared, &shared->entries[i], shrink)) {
             return false;
         }
     }
@@ -719,7 +719,7 @@ static bool ggml_gallocr_resizable_publish(ggml_gallocr_t galloc) {
 }
 
 static bool ggml_gallocr_resize_buffers(ggml_gallocr_t galloc) {
-    if (galloc->resizable_buffers != NULL && !ggml_gallocr_resizable_publish(galloc)) {
+    if (galloc->shared_buffers != NULL && !ggml_gallocr_publish_shared_requirements(galloc)) {
         return false;
     }
     if (!ggml_gallocr_resize_private_buffers(galloc)) {
@@ -730,10 +730,10 @@ static bool ggml_gallocr_resize_buffers(ggml_gallocr_t galloc) {
 }
 
 static struct vbuffer * ggml_gallocr_get_vbuffer(ggml_gallocr_t galloc, int buffer_id) {
-    if (galloc->resizable_buffers != NULL) {
-        const int entry_id = galloc->resizable_entry_ids[buffer_id];
+    if (galloc->shared_buffers != NULL) {
+        const int entry_id = galloc->shared_entry_ids[buffer_id];
         if (entry_id >= 0) {
-            return galloc->resizable_buffers->entries[entry_id].buffer;
+            return galloc->shared_buffers->entries[entry_id].buffer;
         }
     }
     return galloc->buffers[buffer_id];
@@ -779,13 +779,13 @@ ggml_gallocr_t ggml_gallocr_new(ggml_backend_buffer_type_t buft) {
     return ggml_gallocr_new_n(&buft, 1);
 }
 
-static void ggml_gallocr_resizable_start_shrink(struct ggml_gallocr_resizable_buffers * shared) {
+static void ggml_gallocr_shared_start_shrink(struct ggml_gallocr_shared_buffers * shared) {
     shared->shrink_pending = true;
     memset(shared->shrink_seen, 0, sizeof(shared->shrink_seen));
     shared->shrink_generation++;
 }
 
-static void ggml_gallocr_resizable_free(struct ggml_gallocr_resizable_buffers * shared) {
+static void ggml_gallocr_shared_free(struct ggml_gallocr_shared_buffers * shared) {
     for (int i = 0; i < shared->n_entries; ++i) {
         ggml_vbuffer_free(shared->entries[i].buffer);
     }
@@ -793,14 +793,14 @@ static void ggml_gallocr_resizable_free(struct ggml_gallocr_resizable_buffers * 
     free(shared);
 }
 
-static void ggml_gallocr_resizable_detach(ggml_gallocr_t galloc) {
-    struct ggml_gallocr_resizable_buffers * shared = galloc->resizable_buffers;
+static void ggml_gallocr_detach_shared_buffers(ggml_gallocr_t galloc) {
+    struct ggml_gallocr_shared_buffers * shared = galloc->shared_buffers;
     if (shared == NULL) {
         return;
     }
 
-    const int role = galloc->resizable_role;
-    GGML_ASSERT(role >= 0 && role < GGML_GALLOCR_RESIZABLE_ROLE_COUNT);
+    const int role = galloc->shared_role;
+    GGML_ASSERT(role >= 0 && role < GGML_GALLOCR_SHARED_ROLE_COUNT);
     GGML_ASSERT(shared->active[role]);
     shared->active[role] = false;
     shared->shrink_seen[role] = false;
@@ -810,11 +810,11 @@ static void ggml_gallocr_resizable_detach(ggml_gallocr_t galloc) {
 
     shared->refs--;
     if (shared->refs == 0) {
-        ggml_gallocr_resizable_free(shared);
+        ggml_gallocr_shared_free(shared);
     } else {
-        ggml_gallocr_resizable_start_shrink(shared);
+        ggml_gallocr_shared_start_shrink(shared);
     }
-    galloc->resizable_buffers = NULL;
+    galloc->shared_buffers = NULL;
 }
 
 void ggml_gallocr_free(ggml_gallocr_t galloc) {
@@ -822,7 +822,7 @@ void ggml_gallocr_free(ggml_gallocr_t galloc) {
         return;
     }
 
-    ggml_gallocr_resizable_detach(galloc);
+    ggml_gallocr_detach_shared_buffers(galloc);
 
     for (int i = 0; i < galloc->n_buffers; i++) {
         if (galloc->buffers != NULL) {
@@ -860,7 +860,7 @@ void ggml_gallocr_free(ggml_gallocr_t galloc) {
     free(galloc->buf_tallocs);
     free(galloc->node_allocs);
     free(galloc->leaf_allocs);
-    free(galloc->resizable_entry_ids);
+    free(galloc->shared_entry_ids);
     free(galloc);
 }
 
@@ -872,15 +872,15 @@ static void ggml_gallocr_set_resizable_owner(ggml_gallocr_t galloc) {
         GGML_ASSERT(galloc->buffers[i] == NULL);
     }
 
-    struct ggml_gallocr_resizable_buffers * shared =
-            (struct ggml_gallocr_resizable_buffers *) calloc(1, sizeof(*shared));
+    struct ggml_gallocr_shared_buffers * shared =
+            (struct ggml_gallocr_shared_buffers *) calloc(1, sizeof(*shared));
     GGML_ASSERT(shared != NULL);
-    shared->entries = (struct ggml_gallocr_resizable_entry *) calloc(
+    shared->entries = (struct ggml_gallocr_shared_entry *) calloc(
             (size_t) galloc->n_buffers, sizeof(*shared->entries));
     GGML_ASSERT(shared->entries != NULL);
 
-    galloc->resizable_entry_ids = (int *) malloc((size_t) galloc->n_buffers * sizeof(int));
-    GGML_ASSERT(galloc->resizable_entry_ids != NULL);
+    galloc->shared_entry_ids = (int *) malloc((size_t) galloc->n_buffers * sizeof(int));
+    GGML_ASSERT(galloc->shared_entry_ids != NULL);
     for (int i = 0; i < galloc->n_buffers; ++i) {
         int entry_id = -1;
         for (int j = 0; j < shared->n_entries; ++j) {
@@ -893,15 +893,15 @@ static void ggml_gallocr_set_resizable_owner(ggml_gallocr_t galloc) {
             entry_id = shared->n_entries++;
             shared->entries[entry_id].buft = galloc->bufts[i];
         }
-        galloc->resizable_entry_ids[i] = entry_id;
+        galloc->shared_entry_ids[i] = entry_id;
     }
 
     shared->refs = 1;
-    shared->active[GGML_GALLOCR_RESIZABLE_ROLE_OWNER] = true;
+    shared->active[GGML_GALLOCR_SHARED_ROLE_OWNER] = true;
 
     galloc->resizable = true;
-    galloc->resizable_buffers = shared;
-    galloc->resizable_role = GGML_GALLOCR_RESIZABLE_ROLE_OWNER;
+    galloc->shared_buffers = shared;
+    galloc->shared_role = GGML_GALLOCR_SHARED_ROLE_OWNER;
 }
 
 static bool ggml_gallocr_set_resizable_borrower(ggml_gallocr_t galloc, ggml_gallocr_t owner) {
@@ -910,9 +910,9 @@ static bool ggml_gallocr_set_resizable_borrower(ggml_gallocr_t galloc, ggml_gall
     GGML_ASSERT(galloc != owner);
     GGML_ASSERT(!galloc->resizable);
 
-    struct ggml_gallocr_resizable_buffers * shared = owner->resizable_buffers;
-    if (shared == NULL || owner->resizable_role != GGML_GALLOCR_RESIZABLE_ROLE_OWNER ||
-            shared->active[GGML_GALLOCR_RESIZABLE_ROLE_BORROWER]) {
+    struct ggml_gallocr_shared_buffers * shared = owner->shared_buffers;
+    if (shared == NULL || owner->shared_role != GGML_GALLOCR_SHARED_ROLE_OWNER ||
+            shared->active[GGML_GALLOCR_SHARED_ROLE_BORROWER]) {
         return false;
     }
 
@@ -940,13 +940,13 @@ static bool ggml_gallocr_set_resizable_borrower(ggml_gallocr_t galloc, ggml_gall
     }
 
     shared->refs++;
-    shared->active[GGML_GALLOCR_RESIZABLE_ROLE_BORROWER] = true;
-    shared->shrink_seen[GGML_GALLOCR_RESIZABLE_ROLE_BORROWER] = false;
+    shared->active[GGML_GALLOCR_SHARED_ROLE_BORROWER] = true;
+    shared->shrink_seen[GGML_GALLOCR_SHARED_ROLE_BORROWER] = false;
 
     galloc->resizable = true;
-    galloc->resizable_buffers = shared;
-    galloc->resizable_role = GGML_GALLOCR_RESIZABLE_ROLE_BORROWER;
-    galloc->resizable_entry_ids = entry_ids;
+    galloc->shared_buffers = shared;
+    galloc->shared_role = GGML_GALLOCR_SHARED_ROLE_BORROWER;
+    galloc->shared_entry_ids = entry_ids;
     return true;
 }
 
@@ -967,16 +967,16 @@ void ggml_gallocr_get_resizable_state(
     GGML_ASSERT(generation != NULL);
     GGML_ASSERT(shrink_generation != NULL);
     *generation = galloc->generation +
-            (galloc->resizable_buffers ? galloc->resizable_buffers->generation : 0);
-    *shrink_generation = galloc->resizable_buffers ? galloc->resizable_buffers->shrink_generation : 0;
+            (galloc->shared_buffers ? galloc->shared_buffers->generation : 0);
+    *shrink_generation = galloc->shared_buffers ? galloc->shared_buffers->shrink_generation : 0;
 }
 
 void ggml_gallocr_request_shrink(ggml_gallocr_t galloc) {
     GGML_ASSERT(galloc != NULL);
     GGML_ASSERT(galloc->resizable);
     galloc->shrink_requested = true;
-    if (galloc->resizable_buffers != NULL && !galloc->resizable_buffers->shrink_pending) {
-        ggml_gallocr_resizable_start_shrink(galloc->resizable_buffers);
+    if (galloc->shared_buffers != NULL && !galloc->shared_buffers->shrink_pending) {
+        ggml_gallocr_shared_start_shrink(galloc->shared_buffers);
     }
 }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1581,7 +1581,10 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
             ggml_backend_synchronize(sched->backends[i]);
         }
 
-        ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids);
+        if (!ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids)) {
+            GGML_LOG_ERROR("%s: failed to allocate graph\n", __func__);
+            return false;
+        }
         if (!ggml_gallocr_alloc_graph(sched->galloc, &sched->graph)) {
             GGML_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             return false;
@@ -1888,6 +1891,24 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
     free(sched->graph.nodes);
     free(sched->graph.leafs);
     free(sched);
+}
+
+bool ggml_backend_sched_set_resizable(ggml_backend_sched_t sched, ggml_backend_sched_t owner) {
+    GGML_ASSERT(sched != nullptr);
+    return ggml_gallocr_set_resizable(sched->galloc, owner ? owner->galloc : nullptr);
+}
+
+void ggml_backend_sched_get_buffer_state(
+        ggml_backend_sched_t sched,
+        uint64_t * generation,
+        uint64_t * shrink_generation) {
+    GGML_ASSERT(sched != nullptr);
+    ggml_gallocr_get_resizable_state(sched->galloc, generation, shrink_generation);
+}
+
+void ggml_backend_sched_request_buffer_shrink(ggml_backend_sched_t sched) {
+    GGML_ASSERT(sched != nullptr);
+    ggml_gallocr_request_shrink(sched->galloc);
 }
 
 void ggml_backend_sched_reset(ggml_backend_sched_t sched) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -401,6 +401,7 @@ extern "C" {
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
         bool kv_cpu_pinned;           // use pinned host buffers for CPU-resident KV cache storage when available
         bool recurrent_state_offload; // offload recurrent state independently of attention KV storage
+        bool phase_aware_workspace;   // resize this context's compute scheduler between prompt processing and token generation
 
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)
@@ -408,8 +409,7 @@ extern "C" {
         struct llama_sampler_seq_config * samplers;
         size_t                            n_samplers;
 
-        // a source/target/parent context
-        // can be utilized in various ways, for example by sharing results or llama_memory between 2 contexts
+        // A source/target/parent context that can share results or llama_memory.
         struct llama_context * ctx_other;
     };
 
@@ -964,6 +964,7 @@ extern "C" {
     // For encode-decoder contexts, processes the batch using the encoder.
     // Can store the encoder output internally for later use by the decoder's cross-attention layers.
     //   0 - success
+    //  -2 - failed to prepare or allocate execution resources
     // < 0 - error. the memory state is restored to the state before this call
     LLAMA_API int32_t llama_encode(
             struct llama_context * ctx,
@@ -980,6 +981,7 @@ extern "C" {
     //    1 - could not find a KV slot for the batch (try reducing the size of the batch or increase the context)
     //    2 - aborted     (processed ubatches will remain in the context's memory)
     //   -1 - invalid input batch
+    //   -2 - failed to prepare or allocate execution resources
     // < -1 - fatal error (processed ubatches will remain in the context's memory)
     LLAMA_API int32_t llama_decode(
             struct llama_context * ctx,

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -630,6 +630,18 @@ llama_context * llama_context::shared_workspace_peer() const {
     return sched_buffer_owner != nullptr ? sched_buffer_owner : sched_buffer_borrower;
 }
 
+void llama_context::reset_sched_workspace() {
+    sched.reset();
+    gf_res_prev.reset();
+    gf_res_reserve.reset();
+    sched_buffer_generation = 0;
+    sched_shrink_generation = 0;
+    sched_buffers_shared = false;
+    workspace_in_flight = false;
+    sched_reserved_tokens = 0;
+    sched_need_reserve = true;
+}
+
 void llama_context::acquire_shared_workspace() {
     llama_context * peer = shared_workspace_peer();
     if (peer != nullptr && peer->workspace_in_flight) {
@@ -928,13 +940,7 @@ int llama_context::attach_shared_workspace(llama_context & owner) {
 
     synchronize();
     owner.synchronize();
-    sched.reset();
-    gf_res_prev.reset();
-    gf_res_reserve.reset();
-    sched_buffer_generation = 0;
-    sched_shrink_generation = 0;
-    sched_reserved_tokens = 0;
-    sched_need_reserve = true;
+    reset_sched_workspace();
 
     try {
         const auto owner_plan = owner.make_sched_reserve_plan(0);
@@ -952,13 +958,8 @@ int llama_context::attach_shared_workspace(llama_context & owner) {
         sched_reserve(0);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: failed to attach the draft workspace: %s\n", __func__, err.what());
-        sched.reset();
+        reset_sched_workspace();
         sched_buffer_owner = nullptr;
-        sched_buffers_shared = false;
-        sched_buffer_generation = 0;
-        sched_shrink_generation = 0;
-        sched_reserved_tokens = 0;
-        sched_need_reserve = true;
         return -1;
     }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -13,6 +13,7 @@
 #include "llama-sampler.h"
 #include "llama.h"
 
+#include <algorithm>
 #include <cinttypes>
 #include <cmath>
 #include <cstring>
@@ -122,6 +123,7 @@ llama_context::llama_context(
     cparams.recurrent_state_offload = params.recurrent_state_offload;
     cparams.offload_attn_compute    = params.offload_kqv || (params.op_offload && params.kv_cpu_pinned);
     cparams.kv_gpu_layers           = params.kv_gpu_layers;
+    cparams.phase_aware_workspace   = params.phase_aware_workspace;
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
 
@@ -253,6 +255,9 @@ llama_context::llama_context(
     cparams.n_outputs_max = params.n_outputs_max == 0 || llama_model_has_encoder(&model) ? cparams.n_batch : params.n_outputs_max;
     cparams.n_outputs_max_per_seq = params.n_outputs_max_per_seq == 0 ?
             cparams.n_outputs_max : std::min(params.n_outputs_max_per_seq, cparams.n_outputs_max);
+    sched_decode_outputs = llama_model_has_encoder(&model) ? cparams.n_batch :
+            params.n_outputs_max != 0 ? params.n_outputs_max :
+            cparams.phase_aware_workspace ? cparams.n_seq_max : cparams.n_outputs_max;
 
     // Initialize backend samplers here so they are part of the sampling graph
     // before the reserve passes run later in this function. This avoids a later
@@ -501,7 +506,11 @@ llama_context::~llama_context() {
 
             const size_t size_exp = backend_buf_exp_size[i];
             const size_t size_act = ggml_backend_sched_get_buffer_size(sched.get(), backend);
-            if (size_exp == size_act) {
+            if (cparams.phase_aware_workspace) {
+                LLAMA_LOG_DEBUG("%s: %10s resizable compute backing size is %8.4f MiB (last observed %8.4f MiB)\n",
+                        __func__, ggml_backend_buft_name(buft),
+                        size_act / (1024.0*1024.0), size_exp / (1024.0*1024.0));
+            } else if (size_exp == size_act) {
                 LLAMA_LOG_DEBUG("%s: %10s compute buffer size is %8.4f MiB, matches expectation of %8.4f MiB\n",
                     __func__, ggml_backend_buft_name(buft), size_act / (1024.0*1024.0), size_exp / (1024.0*1024.0));
             } else {
@@ -511,6 +520,14 @@ llama_context::~llama_context() {
         }
     }
     ggml_opt_free(opt_ctx);
+
+    if (sched_buffer_owner != nullptr && sched_buffer_owner->sched_buffer_borrower == this) {
+        sched_buffer_owner->sched_buffer_borrower = nullptr;
+    }
+    if (sched_buffer_borrower != nullptr && sched_buffer_borrower->sched_buffer_owner == this) {
+        sched_buffer_borrower->sched_buffer_owner = nullptr;
+        sched_buffer_borrower->sched_buffers_shared = false;
+    }
 }
 
 void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint32_t n_seqs) {
@@ -590,30 +607,141 @@ void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint3
     }
 }
 
-void llama_context::sched_reserve() {
-    if (!sched_need_reserve) {
+llama_context::sched_reserve_plan llama_context::make_sched_reserve_plan(uint32_t n_tokens_req) const {
+    sched_reserve_plan plan;
+    plan.n_tokens_max = std::min(cparams.n_ctx, cparams.n_ubatch);
+    plan.n_tokens_decode = std::min(plan.n_tokens_max,
+            std::max(cparams.n_seq_max, sched_decode_outputs));
+    plan.n_tokens = plan.n_tokens_max;
+
+    if (cparams.phase_aware_workspace && !model.hparams.no_alloc) {
+        plan.n_tokens = n_tokens_req > plan.n_tokens_decode ? plan.n_tokens_max : plan.n_tokens_decode;
+        // Keep the prompt reservation for later prompt chunks that fit it.
+        if (sched_reserved_tokens > plan.n_tokens_decode &&
+                n_tokens_req > plan.n_tokens_decode && n_tokens_req <= sched_reserved_tokens) {
+            plan.n_tokens = sched_reserved_tokens;
+        }
+    }
+
+    return plan;
+}
+
+llama_context * llama_context::shared_workspace_peer() const {
+    return sched_buffer_owner != nullptr ? sched_buffer_owner : sched_buffer_borrower;
+}
+
+void llama_context::acquire_shared_workspace() {
+    llama_context * peer = shared_workspace_peer();
+    if (peer != nullptr && peer->workspace_in_flight) {
+        peer->synchronize();
+    }
+}
+
+void llama_context::prepare_sched_reserve(const sched_reserve_plan & plan) {
+    if (!sched || !cparams.phase_aware_workspace || model.hparams.no_alloc) {
+        return;
+    }
+
+    if (sched_reserved_tokens > plan.n_tokens) {
+        ggml_backend_sched_request_buffer_shrink(sched.get());
+    }
+
+    uint64_t generation = 0;
+    uint64_t shrink_generation = 0;
+    ggml_backend_sched_get_buffer_state(sched.get(), &generation, &shrink_generation);
+
+    // A backing generation change invalidates cached graph addresses.
+    if (generation != sched_buffer_generation) {
+        synchronize();
+        ggml_backend_sched_reset(sched.get());
+        if (gf_res_prev) {
+            gf_res_prev->reset();
+        }
+        sched_buffer_generation = generation;
+        sched_need_reserve = true;
+    }
+
+    if (shrink_generation != sched_shrink_generation) {
+        sched_shrink_generation = shrink_generation;
+        sched_need_reserve = true;
+    }
+}
+
+void llama_context::sched_reserve(uint32_t n_tokens_req) {
+    acquire_shared_workspace();
+
+    const bool sched_resizable = cparams.phase_aware_workspace && !model.hparams.no_alloc;
+    if (!sched_need_reserve && !sched_resizable) {
+        return;
+    }
+
+    const auto plan = make_sched_reserve_plan(n_tokens_req);
+    prepare_sched_reserve(plan);
+
+    if (!sched_need_reserve && sched_reserved_tokens == plan.n_tokens) {
         return;
     }
 
     sched_need_reserve = false;
 
-    LLAMA_LOG_INFO("%s: reserving ...\n", __func__);
+    const uint32_t n_tokens_max = plan.n_tokens_max;
+    const uint32_t n_tokens_tg  = plan.n_tokens_decode;
+    const uint32_t n_tokens     = plan.n_tokens;
+
+    if (sched_resizable) {
+        LLAMA_LOG_INFO("%s: reserving %s workspace (tokens = %u, previous = %u) ...\n",
+                __func__, n_tokens == n_tokens_tg ? "decode" : "prefill",
+                n_tokens, sched_reserved_tokens);
+    } else {
+        LLAMA_LOG_INFO("%s: reserving ...\n", __func__);
+    }
 
     synchronize();
 
     const int64_t t_start_us = ggml_time_us();
 
     const uint32_t n_seqs = cparams.n_seq_max;
-    const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
 
-    const size_t max_nodes = this->graph_max_nodes(n_tokens);
+    const size_t max_nodes = this->graph_max_nodes(n_tokens_max);
 
     LLAMA_LOG_DEBUG("%s: max_nodes = %zu\n", __func__, max_nodes);
 
-    gf_res_prev.reset(new llm_graph_result(max_nodes));
-    gf_res_reserve.reset(new llm_graph_result(max_nodes));
+    if (sched_resizable) {
+        if (!gf_res_prev) {
+            gf_res_prev.reset(new llm_graph_result(max_nodes));
+        } else {
+            gf_res_prev->reset();
+        }
+        if (!gf_res_reserve) {
+            gf_res_reserve.reset(new llm_graph_result(max_nodes));
+        } else {
+            gf_res_reserve->reset();
+        }
+    } else {
+        gf_res_prev.reset(new llm_graph_result(max_nodes));
+        gf_res_reserve.reset(new llm_graph_result(max_nodes));
+    }
 
-    sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, cparams.pipeline_parallel, cparams.op_offload));
+    auto create_sched = [&](bool pipeline_parallel) {
+        sched.reset(ggml_backend_sched_new(
+                backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(),
+                max_nodes, pipeline_parallel, cparams.op_offload));
+        if (sched_resizable) {
+            sched_buffers_shared = sched_buffer_owner != nullptr && sched_buffer_owner->get_sched() != nullptr &&
+                    ggml_backend_sched_set_resizable(sched.get(), sched_buffer_owner->get_sched());
+            if (!sched_buffers_shared) {
+                GGML_ASSERT(ggml_backend_sched_set_resizable(sched.get(), nullptr));
+            }
+            ggml_backend_sched_get_buffer_state(
+                    sched.get(), &sched_buffer_generation, &sched_shrink_generation);
+            LLAMA_LOG_INFO("%s: %s phase-aware compute backing\n", __func__,
+                    sched_buffers_shared ? "borrowing target" : "created");
+        }
+    };
+
+    if (!sched_resizable || !sched) {
+        create_sched(cparams.pipeline_parallel);
+    }
 
     llama_memory_context_ptr mctx;
     if (memory) {
@@ -645,10 +773,12 @@ void llama_context::sched_reserve() {
         auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get(),
                 model.hparams.no_alloc, model.hparams.no_alloc ? backend_buf_exp_size.data() : nullptr);
         if (!gf) {
-            if (cparams.pipeline_parallel) {
+            const bool can_recreate = !sched_resizable ||
+                    (sched_buffer_owner == nullptr && sched_buffer_borrower == nullptr);
+            if (cparams.pipeline_parallel && can_recreate) {
                 LLAMA_LOG_WARN("%s: compute buffer allocation failed, retrying without pipeline parallelism\n", __func__);
                 cparams.pipeline_parallel = false;
-                sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, false, cparams.op_offload));
+                create_sched(false);
                 gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
             }
             if (!gf) {
@@ -662,7 +792,8 @@ void llama_context::sched_reserve() {
 
     // reserve with tg (token generation) graph to get the number of splits and nodes
     {
-        auto * gf = graph_reserve(n_seqs, n_seqs, n_seqs, mctx.get(), model.hparams.no_alloc);
+        auto * gf = graph_reserve(n_seqs, n_seqs, n_seqs, mctx.get(),
+                model.hparams.no_alloc || sched_resizable);
         if (!gf) {
             throw std::runtime_error("failed to allocate compute tg buffers");
         }
@@ -677,7 +808,8 @@ void llama_context::sched_reserve() {
         //
         // auto * gf = graph_reserve(n_tokens, 1, n_tokens, mctx.get());
         //
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get(), model.hparams.no_alloc);
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get(),
+                model.hparams.no_alloc || sched_resizable);
         if (!gf) {
             throw std::runtime_error("failed to allocate compute pp buffers");
         }
@@ -710,16 +842,30 @@ void llama_context::sched_reserve() {
 
     const int64_t t_end_us = ggml_time_us();
 
-    LLAMA_LOG_INFO("%s: reserve took %.2f ms, sched copies = %d\n",
-            __func__, (t_end_us - t_start_us)/1000.0, ggml_backend_sched_get_n_copies(sched.get()));
+    if (sched_resizable) {
+        ggml_backend_sched_get_buffer_state(
+                sched.get(), &sched_buffer_generation, &sched_shrink_generation);
+    }
+    sched_reserved_tokens = n_tokens;
+
+    if (sched_resizable) {
+        LLAMA_LOG_INFO("%s: %s workspace reserve took %.2f ms, sched copies = %d\n",
+                __func__, n_tokens == n_tokens_tg ? "decode" : "prefill",
+                (t_end_us - t_start_us)/1000.0, ggml_backend_sched_get_n_copies(sched.get()));
+    } else {
+        LLAMA_LOG_INFO("%s: reserve took %.2f ms, sched copies = %d\n",
+                __func__, (t_end_us - t_start_us)/1000.0, ggml_backend_sched_get_n_copies(sched.get()));
+    }
 }
 
 void llama_context::synchronize() {
     if (!sched) {
+        workspace_in_flight = false;
         return;
     }
 
     ggml_backend_sched_synchronize(sched.get());
+    workspace_in_flight = false;
 
     // FIXME: if multiple single tokens are evaluated without a synchronization,
     // the stats will be added to the prompt evaluation stats
@@ -758,6 +904,71 @@ const llama_cparams & llama_context::get_cparams() const {
 
 ggml_backend_sched_t llama_context::get_sched() const {
     return sched.get();
+}
+
+bool llama_context::shares_workspace_with(const llama_context & other) const {
+    return sched_buffer_owner == &other || sched_buffer_borrower == &other;
+}
+
+int llama_context::attach_shared_workspace(llama_context & owner) {
+    if (this == &owner || cparams.ctx_type != LLAMA_CONTEXT_TYPE_MTP ||
+            !cparams.phase_aware_workspace || !owner.cparams.phase_aware_workspace ||
+            model.hparams.no_alloc || owner.model.hparams.no_alloc ||
+            sched_buffer_owner != nullptr || sched_buffer_borrower != nullptr ||
+            owner.sched_buffer_owner != nullptr || owner.sched_buffer_borrower != nullptr) {
+        return 0;
+    }
+
+    const bool compatible = std::any_of(backend_buft.begin(), backend_buft.end(), [&](ggml_backend_buffer_type_t buft) {
+        return std::find(owner.backend_buft.begin(), owner.backend_buft.end(), buft) != owner.backend_buft.end();
+    });
+    if (!compatible) {
+        return 0;
+    }
+
+    synchronize();
+    owner.synchronize();
+    sched.reset();
+    gf_res_prev.reset();
+    gf_res_reserve.reset();
+    sched_buffer_generation = 0;
+    sched_shrink_generation = 0;
+    sched_reserved_tokens = 0;
+    sched_need_reserve = true;
+
+    try {
+        const auto owner_plan = owner.make_sched_reserve_plan(0);
+        owner.sched_reserve(owner_plan.n_tokens_max);
+        owner.sched_reserve(0);
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: failed to preflight the target workspace: %s\n", __func__, err.what());
+        return -1;
+    }
+
+    sched_buffer_owner = &owner;
+    sched_decode_outputs = std::max(sched_decode_outputs, owner.sched_decode_outputs);
+
+    try {
+        sched_reserve(0);
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: failed to attach the draft workspace: %s\n", __func__, err.what());
+        sched.reset();
+        sched_buffer_owner = nullptr;
+        sched_buffers_shared = false;
+        sched_buffer_generation = 0;
+        sched_shrink_generation = 0;
+        sched_reserved_tokens = 0;
+        sched_need_reserve = true;
+        return -1;
+    }
+
+    if (!sched_buffers_shared) {
+        sched_buffer_owner = nullptr;
+        return 0;
+    }
+
+    owner.sched_buffer_borrower = this;
+    return 1;
 }
 
 uint32_t llama_context::n_ctx() const {
@@ -835,7 +1046,8 @@ bool llama_context::memory_update(bool optimize) {
         }
 
         const uint32_t n_seqs = cparams.n_seq_max;
-        const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
+        const uint32_t n_tokens = sched_reserved_tokens > 0 ? sched_reserved_tokens :
+                std::min(cparams.n_ctx, cparams.n_ubatch);
 
         const uint32_t n_outputs_max = std::min(n_tokens, cparams.n_outputs_max);
 
@@ -1356,6 +1568,7 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         // that the previous compute is still reading.
         if (cparams.pipeline_parallel) {
             ggml_backend_sched_synchronize(sched.get());
+            workspace_in_flight = false;
         }
 
         n_reused++;
@@ -1389,6 +1602,7 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         //const auto t_start_us = ggml_time_us();
 
         // FIXME this call causes a crash if any model inputs were not used in the graph and were therefore not allocated
+        acquire_shared_workspace();
         res->set_inputs(&ubatch);
 
         //LLAMA_LOG_INFO("graph set inputs time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
@@ -1444,12 +1658,15 @@ int llama_context::encode(const llama_batch & batch_inp) {
     }
     embd_seq.clear();
 
+    try {
+        sched_reserve(n_tokens);
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: failed to reserve compute workspace: %s\n", __func__, err.what());
+        return -2;
+    }
     if (t_compute_start_us == 0) {
         t_compute_start_us = ggml_time_us();
     }
-
-    sched_reserve();
-
     n_queued_tokens += n_tokens;
 
     // reserve output buffer
@@ -1731,14 +1948,18 @@ int llama_context::decode(const llama_batch & batch_inp) {
     }
     embd_seq.clear();
 
+    output_swaps.clear();
+
+    try {
+        sched_reserve(n_tokens_all);
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: failed to reserve compute workspace: %s\n", __func__, err.what());
+        return -2;
+    }
     if (t_compute_start_us == 0) {
         t_compute_start_us = ggml_time_us();
     }
     n_queued_tokens += n_tokens_all;
-
-    output_swaps.clear();
-
-    sched_reserve();
 
     bool did_optimize = false;
 
@@ -2503,6 +2724,9 @@ ggml_status llama_context::graph_compute(
         set_n_threads_fn.second(set_n_threads_fn.first, n_threads);
     }
 
+    if (shared_workspace_peer() != nullptr) {
+        workspace_in_flight = true;
+    }
     auto status = ggml_backend_sched_graph_compute_async(sched.get(), gf);
     if (status != GGML_STATUS_SUCCESS) {
         LLAMA_LOG_ERROR("%s: ggml_backend_sched_graph_compute_async failed with error %d\n", __func__, status);
@@ -3557,6 +3781,7 @@ llama_context_params llama_context_default_params() {
         /*.kv_unified                  =*/ false,
         /*.kv_cpu_pinned               =*/ false,
         /*.recurrent_state_offload     =*/ false,
+        /*.phase_aware_workspace       =*/ false,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,
@@ -4227,4 +4452,15 @@ llama_memory_breakdown llama_get_memory_breakdown(const struct llama_context * c
 
 llama_context * llama_get_ctx_other(struct llama_context * ctx) {
     return ctx->get_cparams().ctx_other;
+}
+
+int32_t llama_attach_shared_workspace(llama_context * borrower, llama_context * owner) {
+    if (borrower == nullptr || owner == nullptr) {
+        return 0;
+    }
+    return borrower->attach_shared_workspace(*owner);
+}
+
+bool llama_contexts_share_workspace(const llama_context * ctx_a, const llama_context * ctx_b) {
+    return ctx_a != nullptr && ctx_b != nullptr && ctx_a->shares_workspace_with(*ctx_b);
 }

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -265,6 +265,7 @@ public:
     bool set_sampler(llama_seq_id seq_id, llama_sampler * sampler);
 
 private:
+    void reset_sched_workspace();
     llama_context * shared_workspace_peer() const;
     void acquire_shared_workspace();
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -12,6 +12,7 @@
 #include "ggml-opt.h"
 
 #include <map>
+#include <memory>
 #include <vector>
 
 struct llama_model;
@@ -40,6 +41,12 @@ struct llama_memory_buffer {
 using llama_memory_buffers = std::map<ggml_backend_buffer_type_t, llama_memory_buffer>;
 
 struct llama_context {
+    struct sched_reserve_plan {
+        uint32_t n_tokens_max    = 0;
+        uint32_t n_tokens_decode = 0;
+        uint32_t n_tokens        = 0;
+    };
+
     // init scheduler and compute buffers, reserve worst-case graphs
     llama_context(
             const llama_model & model,
@@ -53,7 +60,11 @@ struct llama_context {
     //   - changing samplers
     //   - changing attention type
     //   - etc.
-    void sched_reserve();
+    void sched_reserve(uint32_t n_tokens = 0);
+    sched_reserve_plan make_sched_reserve_plan(uint32_t n_tokens) const;
+    void prepare_sched_reserve(const sched_reserve_plan & plan);
+    int attach_shared_workspace(llama_context & owner);
+    bool shares_workspace_with(const llama_context & other) const;
 
     void synchronize();
 
@@ -254,6 +265,9 @@ public:
     bool set_sampler(llama_seq_id seq_id, llama_sampler * sampler);
 
 private:
+    llama_context * shared_workspace_peer() const;
+    void acquire_shared_workspace();
+
     llm_graph_params graph_params(
                         llm_graph_result * res,
                       const llama_ubatch & ubatch,
@@ -342,8 +356,17 @@ private:
     std::vector<swap_info> output_swaps;
 
     ggml_backend_sched_ptr sched;
+    uint64_t sched_buffer_generation = 0;
+    uint64_t sched_shrink_generation = 0;
+    // Paired contexts must be serialized; do not execute or destroy them concurrently.
+    llama_context * sched_buffer_owner = nullptr;
+    llama_context * sched_buffer_borrower = nullptr;
+    bool sched_buffers_shared = false;
+    bool workspace_in_flight = false;
 
     bool sched_need_reserve = true;
+    uint32_t sched_reserved_tokens = 0;
+    uint32_t sched_decode_outputs = 0;
 
     ggml_backend_t backend_cpu = nullptr;
     std::vector<ggml_backend_ptr> backends;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -57,6 +57,7 @@ struct llama_cparams {
     bool pipeline_parallel;
     bool kv_cpu_pinned;
     bool recurrent_state_offload;
+    bool phase_aware_workspace;
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -115,6 +115,13 @@ LLAMA_API void llama_set_embeddings_layer_inp(struct llama_context * ctx, uint32
 LLAMA_API float * llama_get_embeddings_layer_inp(struct llama_context * ctx, uint32_t lid);
 
 LLAMA_API llama_context * llama_get_ctx_other(struct llama_context * ctx);
+// Returns 1 when shared, 0 for incompatible placement, and -1 with an empty borrower scheduler after failure.
+LLAMA_API int32_t llama_attach_shared_workspace(
+              struct llama_context * borrower,
+              struct llama_context * owner);
+LLAMA_API bool llama_contexts_share_workspace(
+        const struct llama_context * ctx_a,
+        const struct llama_context * ctx_b);
 
 //
 // model/context data extraction

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,6 +197,13 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
 
     llama_build_and_test(test-llama-archs.cpp)
 
+    llama_test(
+        test-llama-archs
+        NAME test-phase-aware-workspace
+        LABEL main
+        ARGS --test-phase-workspace
+    )
+
     set(MODEL_DIR "${CMAKE_CURRENT_BINARY_DIR}/test-models/")
     file(MAKE_DIRECTORY "${MODEL_DIR}")
 

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -15,11 +15,16 @@
 uint8_t * const alloc_base = (uint8_t *) 16;
 
 struct dummy_backend_context {
-    size_t max_buffer_size = 64;
-    size_t alignment       = 8;
+    size_t max_buffer_size        = 64;
+    size_t alignment              = 8;
+    bool   fail_alloc             = false;
+    bool   unique_alloc_addresses = false;
+    int    graph_compute_count    = 0;
 
     ggml_backend_buffer_i              buffer_interface;
     std::vector<ggml_backend_buffer_t> buffers;
+    std::vector<void *>                buffer_bases;
+    uintptr_t                          next_base = (uintptr_t) alloc_base;
 
     size_t allocated_total() const {
         size_t n = 0;
@@ -38,8 +43,13 @@ static const char * dummy_backend_buffer_type_get_name(ggml_backend_buffer_type_
 
 static ggml_backend_buffer_t dummy_backend_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
     dummy_backend_context * ctx    = (dummy_backend_context *) buft->context;
+    if (ctx->fail_alloc) {
+        return nullptr;
+    }
     ggml_backend_buffer_t & buffer = ctx->buffers.emplace_back();
     buffer                         = ggml_backend_buffer_init(buft, ctx->buffer_interface, ctx, size);
+    ctx->next_base += std::max<size_t>(size, 4096);
+    ctx->buffer_bases.push_back((void *) ctx->next_base);
     return buffer;
 }
 
@@ -64,11 +74,18 @@ static void dummy_backend_buffer_free_buffer(ggml_backend_buffer_t buffer) {
 
     auto i = std::find(ctx->buffers.begin(), ctx->buffers.end(), buffer);
     GGML_ASSERT(i != ctx->buffers.end());
+    ctx->buffer_bases.erase(ctx->buffer_bases.begin() + (i - ctx->buffers.begin()));
     ctx->buffers.erase(i);
 }
 
-static void * dummy_backend_buffer_get_base(ggml_backend_buffer_t) {
-    return alloc_base;
+static void * dummy_backend_buffer_get_base(ggml_backend_buffer_t buffer) {
+    dummy_backend_context * ctx = (dummy_backend_context *) buffer->context;
+    if (!ctx->unique_alloc_addresses) {
+        return alloc_base;
+    }
+    auto i = std::find(ctx->buffers.begin(), ctx->buffers.end(), buffer);
+    GGML_ASSERT(i != ctx->buffers.end());
+    return ctx->buffer_bases[i - ctx->buffers.begin()];
 }
 
 static ggml_status dummy_backend_buffer_init_tensor(ggml_backend_buffer_t, ggml_tensor *) {
@@ -83,18 +100,30 @@ static void dummy_backend_buffer_get_tensor(ggml_backend_buffer_t, const ggml_te
 
 static void dummy_backend_buffer_clear(ggml_backend_buffer_t, uint8_t) {}
 
-// dummy_backend (not really a full backend, just provides what gallocr needs)
+// dummy backend for gallocr and scheduler allocation tests
 
 struct dummy_backend {
     std::unique_ptr<dummy_backend_context> context;
+    std::unique_ptr<ggml_backend>          handle;
     ggml_backend_buffer_type               buffer_type;
 };
 
-static dummy_backend dummy_backend_init(size_t max_buffer_size, size_t alignment = 8) {
+static const char * dummy_backend_get_name(ggml_backend_t) {
+    return "dummy_backend";
+}
+
+static enum ggml_status dummy_backend_graph_compute(ggml_backend_t backend, ggml_cgraph *) {
+    dummy_backend_context * ctx = (dummy_backend_context *) backend->context;
+    ctx->graph_compute_count++;
+    return GGML_STATUS_SUCCESS;
+}
+
+static dummy_backend dummy_backend_init(size_t max_buffer_size, size_t alignment = 8, bool unique_alloc_addresses = false) {
     dummy_backend b{};
-    b.context                  = std::make_unique<dummy_backend_context>();
-    b.context->alignment       = alignment;
-    b.context->max_buffer_size = max_buffer_size;
+    b.context                         = std::make_unique<dummy_backend_context>();
+    b.context->alignment              = alignment;
+    b.context->max_buffer_size        = max_buffer_size;
+    b.context->unique_alloc_addresses = unique_alloc_addresses;
 
     b.context->buffer_interface.free_buffer   = dummy_backend_buffer_free_buffer;
     b.context->buffer_interface.get_base      = dummy_backend_buffer_get_base;
@@ -110,6 +139,12 @@ static dummy_backend dummy_backend_init(size_t max_buffer_size, size_t alignment
     b.buffer_type.iface.get_alignment = dummy_backend_buffer_type_get_alignment;
     b.buffer_type.iface.get_max_size  = dummy_backend_buffer_type_get_max_size;
     b.buffer_type.iface.is_host       = dummy_backend_buffer_type_is_host;
+
+    b.handle = std::make_unique<ggml_backend>();
+    b.handle->iface.get_name      = dummy_backend_get_name;
+    b.handle->iface.graph_compute = dummy_backend_graph_compute;
+    b.handle->device              = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    b.handle->context             = b.context.get();
     return b;
 }
 
@@ -583,6 +618,494 @@ static void test_reallocation() {
     }
 }
 
+static auto make_resizable_add_graph(int64_t n_elements) {
+    auto result = make_context();
+    ggml_tensor * a = make_input_1d(result.ctx, n_elements);
+    ggml_tensor * b = make_input_1d(result.ctx, n_elements);
+    ggml_tensor * out = ggml_add(result.ctx, a, b);
+    ggml_set_output(out);
+    ggml_build_forward_expand(result.graph, out);
+    return result;
+}
+
+static uint64_t gallocr_generation(ggml_gallocr_t alloc) {
+    uint64_t generation = 0;
+    uint64_t shrink_generation = 0;
+    ggml_gallocr_get_resizable_state(alloc, &generation, &shrink_generation);
+    return generation;
+}
+
+static uint64_t gallocr_shrink_generation(ggml_gallocr_t alloc) {
+    uint64_t generation = 0;
+    uint64_t shrink_generation = 0;
+    ggml_gallocr_get_resizable_state(alloc, &generation, &shrink_generation);
+    return shrink_generation;
+}
+
+static uint64_t sched_generation(ggml_backend_sched_t sched) {
+    uint64_t generation = 0;
+    uint64_t shrink_generation = 0;
+    ggml_backend_sched_get_buffer_state(sched, &generation, &shrink_generation);
+    return generation;
+}
+
+static void test_resizable_buffers_grow_shrink_grow() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+
+    auto small  = make_resizable_add_graph(4);
+    auto medium = make_resizable_add_graph(16);
+    auto large  = make_resizable_add_graph(24);
+
+    {
+        ggml_gallocr_ptr alloc(ggml_gallocr_new(&backend.buffer_type));
+        GGML_ASSERT(ggml_gallocr_set_resizable(alloc.get(), nullptr));
+
+        GGML_ASSERT(ggml_gallocr_reserve(alloc.get(), large.graph));
+        const size_t large_size = backend.context->allocated_total();
+        const uint64_t large_generation = gallocr_generation(alloc.get());
+        GGML_ASSERT(large_size > 0);
+
+        GGML_ASSERT(ggml_gallocr_reserve(alloc.get(), small.graph));
+        GGML_ASSERT(backend.context->allocated_total() == large_size);
+        GGML_ASSERT(gallocr_generation(alloc.get()) == large_generation);
+
+        ggml_gallocr_request_shrink(alloc.get());
+        GGML_ASSERT(ggml_gallocr_reserve(alloc.get(), small.graph));
+        const size_t small_size = backend.context->allocated_total();
+        const uint64_t small_generation = gallocr_generation(alloc.get());
+        GGML_ASSERT(small_size < large_size);
+        GGML_ASSERT(small_generation > large_generation);
+
+        GGML_ASSERT(ggml_gallocr_reserve(alloc.get(), medium.graph));
+        const size_t medium_size = backend.context->allocated_total();
+        const uint64_t medium_generation = gallocr_generation(alloc.get());
+        GGML_ASSERT(medium_size > small_size);
+        GGML_ASSERT(medium_size < large_size);
+        GGML_ASSERT(medium_generation > small_generation);
+
+        GGML_ASSERT(ggml_gallocr_reserve(alloc.get(), large.graph));
+        GGML_ASSERT(backend.context->allocated_total() == large_size);
+        GGML_ASSERT(gallocr_generation(alloc.get()) > medium_generation);
+        GGML_ASSERT(ggml_gallocr_alloc_graph(alloc.get(), large.graph));
+        check_all_allocated(large.graph);
+    }
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_fail_closed_on_allocation_failure() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4, /*unique_alloc_addresses*/ true);
+
+    auto small = make_resizable_add_graph(4);
+    auto large = make_resizable_add_graph(24);
+
+    {
+        ggml_gallocr_ptr alloc(ggml_gallocr_new(&backend.buffer_type));
+        GGML_ASSERT(ggml_gallocr_set_resizable(alloc.get(), nullptr));
+
+        GGML_ASSERT(ggml_gallocr_reserve(alloc.get(), small.graph));
+        GGML_ASSERT(ggml_gallocr_alloc_graph(alloc.get(), small.graph));
+        check_all_allocated(small.graph);
+
+        const uint64_t generation = gallocr_generation(alloc.get());
+        ggml_backend_buffer_t buffer = small.graph->nodes[0]->buffer;
+        GGML_ASSERT(buffer != nullptr);
+        void * base = ggml_backend_buffer_get_base(buffer);
+
+        backend.context->fail_alloc = true;
+        GGML_ASSERT(!ggml_gallocr_reserve(alloc.get(), large.graph));
+        const uint64_t failed_generation = gallocr_generation(alloc.get());
+        GGML_ASSERT(backend.context->allocated_total() == 0);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(alloc.get(), 0) == 0);
+        GGML_ASSERT(failed_generation > generation);
+        GGML_ASSERT(std::find(backend.context->buffer_bases.begin(), backend.context->buffer_bases.end(), base) == backend.context->buffer_bases.end());
+
+        backend.context->fail_alloc = false;
+        GGML_ASSERT(ggml_gallocr_reserve(alloc.get(), large.graph));
+        GGML_ASSERT(gallocr_generation(alloc.get()) > failed_generation);
+        GGML_ASSERT(backend.context->buffers.size() == 1);
+        GGML_ASSERT(ggml_backend_buffer_get_base(backend.context->buffers[0]) != base);
+        GGML_ASSERT(ggml_gallocr_alloc_graph(alloc.get(), large.graph));
+        check_all_allocated(large.graph);
+    }
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_multi_entry_allocation_failure() {
+    dummy_backend backend_a = dummy_backend_init(SIZE_MAX, /*align*/ 4, /*unique_alloc_addresses*/ true);
+    dummy_backend backend_b = dummy_backend_init(SIZE_MAX, /*align*/ 4, /*unique_alloc_addresses*/ true);
+
+    auto small = make_resizable_add_graph(4);
+    auto large = make_resizable_add_graph(24);
+
+    GGML_ASSERT(small.graph->n_leafs == 2 && small.graph->n_nodes == 1);
+    GGML_ASSERT(large.graph->n_leafs == 2 && large.graph->n_nodes == 1);
+    int leaf_buffer_ids[2] = { 0, 1 };
+    int node_buffer_ids[1] = { 0 };
+    ggml_backend_buffer_type_t bufts[2] = { &backend_a.buffer_type, &backend_b.buffer_type };
+
+    {
+        ggml_gallocr_ptr alloc(ggml_gallocr_new_n(bufts, 2));
+        GGML_ASSERT(ggml_gallocr_set_resizable(alloc.get(), nullptr));
+
+        GGML_ASSERT(ggml_gallocr_reserve_n(alloc.get(), small.graph, node_buffer_ids, leaf_buffer_ids));
+        GGML_ASSERT(ggml_gallocr_alloc_graph(alloc.get(), small.graph));
+        check_all_allocated(small.graph);
+
+        const size_t size_a_small = backend_a.context->allocated_total();
+        const size_t size_b_small = backend_b.context->allocated_total();
+        const uint64_t generation_small = gallocr_generation(alloc.get());
+        ggml_backend_buffer_t buffer_a_small = small.graph->nodes[0]->buffer;
+        ggml_backend_buffer_t buffer_b_small = small.graph->leafs[1]->buffer;
+        void * data_a_small = small.graph->nodes[0]->data;
+        void * data_b_small = small.graph->leafs[1]->data;
+        GGML_ASSERT(size_a_small > 0 && size_b_small > 0);
+        GGML_ASSERT(buffer_a_small != nullptr && buffer_b_small != nullptr);
+        GGML_ASSERT(data_a_small != nullptr && data_b_small != nullptr);
+        void * base_a_small = ggml_backend_buffer_get_base(buffer_a_small);
+        void * base_b_small = ggml_backend_buffer_get_base(buffer_b_small);
+
+        backend_b.context->fail_alloc = true;
+        GGML_ASSERT(!ggml_gallocr_reserve_n(alloc.get(), large.graph, node_buffer_ids, leaf_buffer_ids));
+        const size_t size_a_partial = backend_a.context->allocated_total();
+        const uint64_t generation_partial = gallocr_generation(alloc.get());
+        GGML_ASSERT(backend_a.context->buffers.size() == 1);
+        ggml_backend_buffer_t buffer_a_partial = backend_a.context->buffers[0];
+        GGML_ASSERT(size_a_partial > size_a_small);
+        GGML_ASSERT(backend_b.context->allocated_total() == 0);
+        GGML_ASSERT(generation_partial > generation_small);
+        GGML_ASSERT(ggml_backend_buffer_get_base(buffer_a_partial) != base_a_small);
+        GGML_ASSERT(std::find(backend_b.context->buffer_bases.begin(), backend_b.context->buffer_bases.end(), base_b_small) == backend_b.context->buffer_bases.end());
+        GGML_ASSERT(small.graph->nodes[0]->buffer == buffer_a_small);
+        GGML_ASSERT(small.graph->nodes[0]->data == data_a_small);
+
+        // Entry A published before entry B failed, so discard the graph with stale entry A addresses.
+        small.ctx_ptr.reset();
+        small.ctx = nullptr;
+        small.graph = nullptr;
+
+        backend_b.context->fail_alloc = false;
+        GGML_ASSERT(ggml_gallocr_reserve_n(alloc.get(), large.graph, node_buffer_ids, leaf_buffer_ids));
+        GGML_ASSERT(backend_b.context->buffers.size() == 1);
+        ggml_backend_buffer_t buffer_b_large = backend_b.context->buffers[0];
+        GGML_ASSERT(backend_a.context->allocated_total() == size_a_partial);
+        GGML_ASSERT(backend_b.context->allocated_total() > size_b_small);
+        GGML_ASSERT(gallocr_generation(alloc.get()) > generation_partial);
+        GGML_ASSERT(ggml_backend_buffer_get_base(buffer_b_large) != base_b_small);
+
+        GGML_ASSERT(ggml_gallocr_alloc_graph(alloc.get(), large.graph));
+        GGML_ASSERT(large.graph->nodes[0]->buffer == buffer_a_partial);
+        GGML_ASSERT(large.graph->nodes[0]->data != data_a_small);
+        GGML_ASSERT(large.graph->leafs[1]->buffer == buffer_b_large);
+        GGML_ASSERT(large.graph->leafs[1]->data != data_b_small);
+        check_all_allocated(large.graph);
+    }
+    GGML_ASSERT(backend_a.context->allocated_total() == 0);
+    GGML_ASSERT(backend_b.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_scheduler_allocation_failure() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4, /*unique_alloc_addresses*/ true);
+
+    auto small       = make_resizable_add_graph(4);
+    auto small_retry = make_resizable_add_graph(4);
+    auto large       = make_resizable_add_graph(24);
+    auto large_retry = make_resizable_add_graph(24);
+
+    ggml_backend_t backends[] = { backend.handle.get() };
+    ggml_backend_buffer_type_t bufts[] = { &backend.buffer_type };
+    {
+        ggml_backend_sched_ptr sched(ggml_backend_sched_new(backends, bufts, 1, 128, false, false));
+        GGML_ASSERT(ggml_backend_sched_set_resizable(sched.get(), nullptr));
+
+        GGML_ASSERT(ggml_backend_sched_graph_compute(sched.get(), small.graph) == GGML_STATUS_SUCCESS);
+        GGML_ASSERT(backend.context->graph_compute_count == 1);
+        const uint64_t generation = sched_generation(sched.get());
+        ggml_backend_buffer_t buffer = small.graph->nodes[0]->buffer;
+        GGML_ASSERT(buffer != nullptr);
+        void * base = ggml_backend_buffer_get_base(buffer);
+
+        ggml_backend_sched_reset(sched.get());
+        backend.context->fail_alloc = true;
+        GGML_ASSERT(ggml_backend_sched_graph_compute(sched.get(), large.graph) == GGML_STATUS_ALLOC_FAILED);
+        GGML_ASSERT(backend.context->graph_compute_count == 1);
+        const uint64_t failed_generation = sched_generation(sched.get());
+        GGML_ASSERT(backend.context->allocated_total() == 0);
+        GGML_ASSERT(failed_generation > generation);
+        GGML_ASSERT(std::find(backend.context->buffer_bases.begin(), backend.context->buffer_bases.end(), base) == backend.context->buffer_bases.end());
+
+        GGML_ASSERT(!ggml_backend_sched_reserve(sched.get(), small_retry.graph));
+        GGML_ASSERT(backend.context->graph_compute_count == 1);
+        GGML_ASSERT(backend.context->allocated_total() == 0);
+
+        ggml_backend_sched_reset(sched.get());
+        backend.context->fail_alloc = false;
+        GGML_ASSERT(ggml_backend_sched_graph_compute(sched.get(), large_retry.graph) == GGML_STATUS_SUCCESS);
+        GGML_ASSERT(backend.context->graph_compute_count == 2);
+        GGML_ASSERT(sched_generation(sched.get()) > failed_generation);
+    }
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_alias_duplicate_buffer_types() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+    auto [ctx, graph, ctx_ptr] = make_context();
+
+    ggml_tensor * a = make_input_with_size(ctx, 16);
+    ggml_tensor * b = make_input_with_size(ctx, 16);
+    ggml_tensor * out = ggml_add(ctx, a, b);
+    ggml_set_output(out);
+    ggml_build_forward_expand(graph, out);
+
+    GGML_ASSERT(graph->n_leafs == 2);
+    GGML_ASSERT(graph->n_nodes == 1);
+    int leaf_buffer_ids[2] = { 0, 1 };
+    int node_buffer_ids[1] = { 1 };
+    ggml_backend_buffer_type_t bufts[2] = { &backend.buffer_type, &backend.buffer_type };
+
+    {
+        ggml_gallocr_ptr alloc(ggml_gallocr_new_n(bufts, 2));
+        GGML_ASSERT(ggml_gallocr_set_resizable(alloc.get(), nullptr));
+        GGML_ASSERT(ggml_gallocr_reserve_n(alloc.get(), graph, node_buffer_ids, leaf_buffer_ids));
+
+        const size_t backing_size = ggml_gallocr_get_buffer_size(alloc.get(), 0);
+        GGML_ASSERT(backing_size > 0);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(alloc.get(), 1) == 0);
+        GGML_ASSERT(backend.context->allocated_total() == backing_size);
+        GGML_ASSERT(backend.context->buffers.size() == 1);
+        GGML_ASSERT(ggml_gallocr_alloc_graph(alloc.get(), graph));
+        check_all_allocated(graph);
+        check_no_overlap(graph);
+    }
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_owner_borrower_maximum() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4, /*unique_alloc_addresses*/ true);
+
+    auto owner_small     = make_resizable_add_graph(4);
+    auto owner_medium    = make_resizable_add_graph(16);
+    auto owner_large     = make_resizable_add_graph(24);
+    auto borrower_medium = make_resizable_add_graph(16);
+    auto borrower_large  = make_resizable_add_graph(24);
+
+    {
+        ggml_gallocr_ptr owner(ggml_gallocr_new(&backend.buffer_type));
+        ggml_gallocr_ptr borrower(ggml_gallocr_new(&backend.buffer_type));
+        GGML_ASSERT(ggml_gallocr_set_resizable(owner.get(), nullptr));
+        GGML_ASSERT(ggml_gallocr_set_resizable(borrower.get(), owner.get()));
+
+        GGML_ASSERT(ggml_gallocr_reserve(owner.get(), owner_medium.graph));
+        const size_t owner_medium_size = backend.context->allocated_total();
+        GGML_ASSERT(owner_medium_size > 0);
+
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_large.graph));
+        const size_t shared_large_size = backend.context->allocated_total();
+        const uint64_t shared_large_generation = gallocr_generation(owner.get());
+        GGML_ASSERT(shared_large_size > owner_medium_size);
+        GGML_ASSERT(backend.context->buffers.size() == 1);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(owner.get(), 0) == shared_large_size);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(borrower.get(), 0) == shared_large_size);
+        GGML_ASSERT(gallocr_generation(borrower.get()) == shared_large_generation);
+
+        const uint64_t shrink_generation = gallocr_shrink_generation(owner.get());
+        ggml_gallocr_request_shrink(owner.get());
+        GGML_ASSERT(gallocr_shrink_generation(owner.get()) > shrink_generation);
+        GGML_ASSERT(gallocr_shrink_generation(borrower.get()) == gallocr_shrink_generation(owner.get()));
+
+        GGML_ASSERT(ggml_gallocr_reserve(owner.get(), owner_small.graph));
+        GGML_ASSERT(backend.context->allocated_total() == shared_large_size);
+        GGML_ASSERT(gallocr_generation(owner.get()) == shared_large_generation);
+
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_medium.graph));
+        const size_t shared_medium_size = backend.context->allocated_total();
+        GGML_ASSERT(shared_medium_size < shared_large_size);
+        GGML_ASSERT(shared_medium_size > 0);
+        GGML_ASSERT(backend.context->buffers.size() == 1);
+        GGML_ASSERT(gallocr_generation(owner.get()) > shared_large_generation);
+
+        GGML_ASSERT(ggml_gallocr_reserve(owner.get(), owner_large.graph));
+        GGML_ASSERT(backend.context->allocated_total() == shared_large_size);
+        GGML_ASSERT(backend.context->buffers.size() == 1);
+        GGML_ASSERT(ggml_gallocr_alloc_graph(owner.get(), owner_large.graph));
+        check_all_allocated(owner_large.graph);
+        GGML_ASSERT(ggml_gallocr_alloc_graph(borrower.get(), borrower_medium.graph));
+        check_all_allocated(borrower_medium.graph);
+    }
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_owner_borrower_compatible_placement() {
+    dummy_backend backend_shared   = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+    dummy_backend backend_owner    = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+    dummy_backend backend_borrower = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+
+    auto owner_graph    = make_resizable_add_graph(16);
+    auto borrower_graph = make_resizable_add_graph(24);
+    int leaf_buffer_ids[2] = { 0, 1 };
+    int node_buffer_ids[1] = { 0 };
+
+    ggml_backend_buffer_type_t owner_bufts[2] = {
+        &backend_shared.buffer_type,
+        &backend_owner.buffer_type,
+    };
+    ggml_backend_buffer_type_t borrower_bufts[2] = {
+        &backend_shared.buffer_type,
+        &backend_borrower.buffer_type,
+    };
+
+    {
+        ggml_gallocr_ptr owner(ggml_gallocr_new_n(owner_bufts, 2));
+        ggml_gallocr_ptr borrower(ggml_gallocr_new_n(borrower_bufts, 2));
+        GGML_ASSERT(ggml_gallocr_set_resizable(owner.get(), nullptr));
+        GGML_ASSERT(ggml_gallocr_set_resizable(borrower.get(), owner.get()));
+
+        GGML_ASSERT(ggml_gallocr_reserve_n(owner.get(), owner_graph.graph, node_buffer_ids, leaf_buffer_ids));
+        GGML_ASSERT(ggml_gallocr_reserve_n(borrower.get(), borrower_graph.graph, node_buffer_ids, leaf_buffer_ids));
+
+        const size_t shared_size = backend_shared.context->allocated_total();
+        GGML_ASSERT(shared_size > 0);
+        GGML_ASSERT(backend_shared.context->buffers.size() == 1);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(owner.get(), 0) == shared_size);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(borrower.get(), 0) == shared_size);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(owner.get(), 1) == backend_owner.context->allocated_total());
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(borrower.get(), 1) == backend_borrower.context->allocated_total());
+
+        GGML_ASSERT(ggml_gallocr_alloc_graph(owner.get(), owner_graph.graph));
+        GGML_ASSERT(ggml_gallocr_alloc_graph(borrower.get(), borrower_graph.graph));
+        check_all_allocated(owner_graph.graph);
+        check_all_allocated(borrower_graph.graph);
+    }
+    GGML_ASSERT(backend_shared.context->allocated_total() == 0);
+    GGML_ASSERT(backend_owner.context->allocated_total() == 0);
+    GGML_ASSERT(backend_borrower.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_owner_borrower_allocation_failure() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4, /*unique_alloc_addresses*/ true);
+
+    auto owner_small    = make_resizable_add_graph(4);
+    auto borrower_small = make_resizable_add_graph(4);
+    auto owner_large    = make_resizable_add_graph(24);
+
+    {
+        ggml_gallocr_ptr owner(ggml_gallocr_new(&backend.buffer_type));
+        ggml_gallocr_ptr borrower(ggml_gallocr_new(&backend.buffer_type));
+        GGML_ASSERT(ggml_gallocr_set_resizable(owner.get(), nullptr));
+        GGML_ASSERT(ggml_gallocr_set_resizable(borrower.get(), owner.get()));
+
+        GGML_ASSERT(ggml_gallocr_reserve(owner.get(), owner_small.graph));
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_small.graph));
+        const uint64_t generation = gallocr_generation(owner.get());
+
+        backend.context->fail_alloc = true;
+        GGML_ASSERT(!ggml_gallocr_reserve(owner.get(), owner_large.graph));
+        const uint64_t failed_generation = gallocr_generation(owner.get());
+        GGML_ASSERT(failed_generation > generation);
+        GGML_ASSERT(gallocr_generation(borrower.get()) == failed_generation);
+        GGML_ASSERT(backend.context->allocated_total() == 0);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(owner.get(), 0) == 0);
+        GGML_ASSERT(ggml_gallocr_get_buffer_size(borrower.get(), 0) == 0);
+
+        backend.context->fail_alloc = false;
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_small.graph));
+        GGML_ASSERT(backend.context->allocated_total() > 0);
+        GGML_ASSERT(backend.context->buffers.size() == 1);
+        GGML_ASSERT(gallocr_generation(owner.get()) > failed_generation);
+        GGML_ASSERT(ggml_gallocr_alloc_graph(owner.get(), owner_large.graph));
+        check_all_allocated(owner_large.graph);
+    }
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_owner_borrower_scheduler_failure() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4, /*unique_alloc_addresses*/ true);
+
+    auto owner_small     = make_resizable_add_graph(4);
+    auto borrower_small  = make_resizable_add_graph(4);
+    auto owner_large     = make_resizable_add_graph(24);
+    auto owner_retry     = make_resizable_add_graph(24);
+    auto borrower_retry  = make_resizable_add_graph(4);
+
+    ggml_backend_t backends[] = { backend.handle.get() };
+    ggml_backend_buffer_type_t bufts[] = { &backend.buffer_type };
+    {
+        ggml_backend_sched_ptr owner(ggml_backend_sched_new(backends, bufts, 1, 128, false, false));
+        ggml_backend_sched_ptr borrower(ggml_backend_sched_new(backends, bufts, 1, 128, false, false));
+        GGML_ASSERT(ggml_backend_sched_set_resizable(owner.get(), nullptr));
+        GGML_ASSERT(ggml_backend_sched_set_resizable(borrower.get(), owner.get()));
+
+        GGML_ASSERT(ggml_backend_sched_graph_compute(owner.get(), owner_small.graph) == GGML_STATUS_SUCCESS);
+        GGML_ASSERT(ggml_backend_sched_graph_compute(borrower.get(), borrower_small.graph) == GGML_STATUS_SUCCESS);
+        const uint64_t generation = sched_generation(owner.get());
+
+        ggml_backend_sched_reset(owner.get());
+        backend.context->fail_alloc = true;
+        GGML_ASSERT(ggml_backend_sched_graph_compute(owner.get(), owner_large.graph) == GGML_STATUS_ALLOC_FAILED);
+        const uint64_t failed_generation = sched_generation(owner.get());
+        GGML_ASSERT(failed_generation > generation);
+        GGML_ASSERT(sched_generation(borrower.get()) == failed_generation);
+        GGML_ASSERT(backend.context->allocated_total() == 0);
+
+        ggml_backend_sched_reset(owner.get());
+        ggml_backend_sched_reset(borrower.get());
+        backend.context->fail_alloc = false;
+        GGML_ASSERT(ggml_backend_sched_reserve(borrower.get(), borrower_retry.graph));
+        GGML_ASSERT(sched_generation(owner.get()) > failed_generation);
+        GGML_ASSERT(backend.context->buffers.size() == 1);
+        GGML_ASSERT(ggml_backend_sched_graph_compute(borrower.get(), borrower_retry.graph) == GGML_STATUS_SUCCESS);
+        GGML_ASSERT(ggml_backend_sched_graph_compute(owner.get(), owner_retry.graph) == GGML_STATUS_SUCCESS);
+    }
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
+static void test_resizable_buffers_owner_borrower_teardown_order() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX, /*align*/ 4);
+
+    auto owner_graph       = make_resizable_add_graph(16);
+    auto borrower_graph    = make_resizable_add_graph(24);
+    auto owner_retry       = make_resizable_add_graph(4);
+    auto borrower_retry    = make_resizable_add_graph(4);
+
+    {
+        ggml_gallocr_ptr owner(ggml_gallocr_new(&backend.buffer_type));
+        ggml_gallocr_ptr borrower(ggml_gallocr_new(&backend.buffer_type));
+        GGML_ASSERT(ggml_gallocr_set_resizable(owner.get(), nullptr));
+        GGML_ASSERT(ggml_gallocr_set_resizable(borrower.get(), owner.get()));
+        GGML_ASSERT(ggml_gallocr_reserve(owner.get(), owner_graph.graph));
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_graph.graph));
+
+        owner.reset();
+        GGML_ASSERT(backend.context->allocated_total() > 0);
+        ggml_gallocr_request_shrink(borrower.get());
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_retry.graph));
+        GGML_ASSERT(ggml_gallocr_alloc_graph(borrower.get(), borrower_retry.graph));
+        borrower.reset();
+        GGML_ASSERT(backend.context->allocated_total() == 0);
+    }
+
+    {
+        ggml_gallocr_ptr owner(ggml_gallocr_new(&backend.buffer_type));
+        ggml_gallocr_ptr borrower(ggml_gallocr_new(&backend.buffer_type));
+        GGML_ASSERT(ggml_gallocr_set_resizable(owner.get(), nullptr));
+        GGML_ASSERT(ggml_gallocr_set_resizable(borrower.get(), owner.get()));
+        GGML_ASSERT(ggml_gallocr_reserve(owner.get(), owner_graph.graph));
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_graph.graph));
+
+        borrower.reset();
+        GGML_ASSERT(backend.context->allocated_total() > 0);
+        borrower.reset(ggml_gallocr_new(&backend.buffer_type));
+        GGML_ASSERT(ggml_gallocr_set_resizable(borrower.get(), owner.get()));
+        ggml_gallocr_request_shrink(owner.get());
+        GGML_ASSERT(ggml_gallocr_reserve(owner.get(), owner_retry.graph));
+        GGML_ASSERT(ggml_gallocr_reserve(borrower.get(), borrower_retry.graph));
+        GGML_ASSERT(ggml_gallocr_alloc_graph(owner.get(), owner_retry.graph));
+        GGML_ASSERT(ggml_gallocr_alloc_graph(borrower.get(), borrower_retry.graph));
+        borrower.reset();
+        owner.reset();
+        GGML_ASSERT(backend.context->allocated_total() == 0);
+    }
+}
+
 static void run(const char * name, void (*f)()) {
     printf("%s ", name);
     fflush(stdout);
@@ -604,5 +1127,15 @@ int main() {
     run("test_multiple_buffer_types", test_multiple_buffer_types);
     run("test_buffer_size_zero", test_buffer_size_zero);
     run("test_reallocation", test_reallocation);
+    run("test_resizable_buffers_grow_shrink_grow", test_resizable_buffers_grow_shrink_grow);
+    run("test_resizable_buffers_fail_closed_on_allocation_failure", test_resizable_buffers_fail_closed_on_allocation_failure);
+    run("test_resizable_buffers_multi_entry_allocation_failure", test_resizable_buffers_multi_entry_allocation_failure);
+    run("test_resizable_buffers_scheduler_allocation_failure", test_resizable_buffers_scheduler_allocation_failure);
+    run("test_resizable_buffers_alias_duplicate_buffer_types", test_resizable_buffers_alias_duplicate_buffer_types);
+    run("test_resizable_buffers_owner_borrower_maximum", test_resizable_buffers_owner_borrower_maximum);
+    run("test_resizable_buffers_owner_borrower_compatible_placement", test_resizable_buffers_owner_borrower_compatible_placement);
+    run("test_resizable_buffers_owner_borrower_allocation_failure", test_resizable_buffers_owner_borrower_allocation_failure);
+    run("test_resizable_buffers_owner_borrower_scheduler_failure", test_resizable_buffers_owner_borrower_scheduler_failure);
+    run("test_resizable_buffers_owner_borrower_teardown_order", test_resizable_buffers_owner_borrower_teardown_order);
     return 0;
 }

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -1,6 +1,7 @@
 #include "ggml-alloc.h"
 #include "../ggml/src/ggml-backend-impl.h"
 #include "ggml-cpp.h"
+#include "ggml-cpu.h"
 #include "../ggml/src/ggml-impl.h"
 #include "ggml.h"
 
@@ -143,7 +144,7 @@ static dummy_backend dummy_backend_init(size_t max_buffer_size, size_t alignment
     b.handle = std::make_unique<ggml_backend>();
     b.handle->iface.get_name      = dummy_backend_get_name;
     b.handle->iface.graph_compute = dummy_backend_graph_compute;
-    b.handle->device              = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    b.handle->device              = ggml_backend_reg_dev_get(ggml_backend_cpu_reg(), 0);
     b.handle->context             = b.context.get();
     return b;
 }

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -13,6 +13,22 @@
 #undef NDEBUG
 #include <cassert>
 
+static void set_test_env(const char * name, const char * value) {
+#ifdef _WIN32
+    assert(_putenv_s(name, value) == 0);
+#else
+    assert(setenv(name, value, true) == 0);
+#endif
+}
+
+static void unset_test_env(const char * name) {
+#ifdef _WIN32
+    assert(_putenv_s(name, "") == 0);
+#else
+    assert(unsetenv(name) == 0);
+#endif
+}
+
 static void test(void) {
     common_params params;
 
@@ -42,6 +58,14 @@ static void test(void) {
         const auto draft = common_base_params_to_speculative(base);
         assert(draft.n_outputs_max == 4);
         assert(draft.n_outputs_max_per_seq == 1);
+
+        base.n_batch = 16;
+        base.n_parallel = 2;
+        base.speculative.draft.n_max = 3;
+        base.phase_aware_workspace = true;
+        const auto phase_draft = common_base_params_to_speculative(base);
+        assert(phase_draft.n_outputs_max == 2);
+        assert(phase_draft.n_outputs_max_per_seq == 1);
     }
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");
@@ -259,6 +283,7 @@ static void test(void) {
         assert(!defaults.kv_cpu_pinned);
         assert(!defaults.recurrent_state_offload);
         assert(defaults.kv_gpu_layers == 0);
+        assert(!defaults.phase_aware_workspace);
 
         common_params placement_params;
         argv = {"binary_name", "-m", "model.gguf", "--no-kv-offload", "--kv-cpu-pinned", "--kv-gpu-layers", "4", "--recurrent-state-offload"};
@@ -278,6 +303,32 @@ static void test(void) {
         assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), placement_params, LLAMA_EXAMPLE_COMMON));
         assert(!placement_params.kv_cpu_pinned);
         assert(!placement_params.recurrent_state_offload);
+    }
+
+    {
+        unset_test_env("LLAMA_ARG_PHASE_AWARE_WORKSPACE");
+        common_params phase_params;
+        argv = {"binary_name", "-m", "model.gguf"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), phase_params, LLAMA_EXAMPLE_SERVER));
+        assert(!phase_params.phase_aware_workspace);
+
+        phase_params = common_params();
+        argv = {"binary_name", "-m", "model.gguf", "--phase-aware-workspace"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), phase_params, LLAMA_EXAMPLE_SERVER));
+        assert(phase_params.phase_aware_workspace);
+        assert(common_context_params_to_llama(phase_params).phase_aware_workspace);
+
+        phase_params = common_params();
+        argv = {"binary_name", "-m", "model.gguf", "--phase-aware-workspace", "--no-phase-aware-workspace"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), phase_params, LLAMA_EXAMPLE_SERVER));
+        assert(!phase_params.phase_aware_workspace);
+
+        set_test_env("LLAMA_ARG_PHASE_AWARE_WORKSPACE", "1");
+        phase_params = common_params();
+        argv = {"binary_name", "-m", "model.gguf"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), phase_params, LLAMA_EXAMPLE_SERVER));
+        assert(phase_params.phase_aware_workspace);
+        unset_test_env("LLAMA_ARG_PHASE_AWARE_WORKSPACE");
     }
 
     {

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "log.h"
 #include "ggml-backend.h"
+#include "../ggml/src/ggml-backend-impl.h"
 #include "ggml.h"
 #include "gguf.h"
 #include "ggml-cpp.h"
@@ -9,6 +10,8 @@
 
 // TODO: replace with #include "llama-ext.h" in the future
 #include "../src/llama-arch.h"
+#include "../src/llama-context.h"
+#include "../src/llama-ext.h"
 #include "../src/llama-model-saver.h"
 
 #include <cinttypes>
@@ -65,7 +68,7 @@ static void set_tensor_data(struct ggml_tensor * tensor, void * userdata) {
 }
 
 static void usage(char ** argv) {
-    printf("Usage: %s [-a/--arch arch] [-s/--seed seed] [-v/--verbose]\n", argv[0]);
+    printf("Usage: %s [-a/--arch arch] [-s/--seed seed] [-v/--verbose] [--test-phase-workspace]\n", argv[0]);
 }
 
 static std::vector<llama_token> get_tokens(const uint32_t n_tokens, const uint32_t n_vocab, const size_t seed){
@@ -79,7 +82,7 @@ static std::vector<llama_token> get_tokens(const uint32_t n_tokens, const uint32
     return ret;
 }
 
-static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
+static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe, const bool mtp = false) {
     gguf_context_ptr ret(gguf_init_empty());
     llama_model_saver ms(arch, ret.get());
     const uint32_t n_ctx = 128;
@@ -130,6 +133,9 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         n_vocab = 4096; // must be >= the hard-coded codec head size (3072)
     }
 
+    GGML_ASSERT(!mtp || arch == LLM_ARCH_QWEN35);
+    const uint32_t n_layer_all = n_layer + (mtp ? 1 : 0);
+
     uint32_t n_head_kv = n_head;
     if (arch == LLM_ARCH_QWEN3) {
         n_head_kv = 1; // MQA coverage
@@ -143,8 +149,11 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
     ms.add_kv(LLM_KV_CONTEXT_LENGTH,            n_ctx);
     ms.add_kv(LLM_KV_EMBEDDING_LENGTH,          n_embd);
     ms.add_kv(LLM_KV_FEATURES_LENGTH,           n_embd);
-    ms.add_kv(LLM_KV_BLOCK_COUNT,               n_layer);
+    ms.add_kv(LLM_KV_BLOCK_COUNT,               n_layer_all);
     ms.add_kv(LLM_KV_LEADING_DENSE_BLOCK_COUNT, uint32_t(1));
+    if (mtp) {
+        ms.add_kv(LLM_KV_NEXTN_PREDICT_LAYERS, uint32_t(1));
+    }
 
     if (arch == LLM_ARCH_NEMOTRON_H || arch == LLM_ARCH_NEMOTRON_H_MOE) {
         std::vector<uint32_t> n_ff_per_layer;
@@ -365,6 +374,462 @@ static std::pair<llama_model_ptr, llama_context_ptr> get_model_and_ctx(
         throw std::runtime_error("failed to create llama context");
     }
     return std::make_pair(std::move(model), std::move(lctx));
+}
+
+static bool phase_workspace_fail_alloc = false;
+static bool phase_workspace_fail_once = false;
+static int phase_workspace_alloc_failures = 0;
+static ggml_backend_buffer_t (*phase_workspace_alloc_buffer)(ggml_backend_buffer_type_t, size_t) = nullptr;
+static ggml_backend_t phase_workspace_sync_backends[2] = {};
+static void (*phase_workspace_synchronize[2])(ggml_backend_t) = {};
+static int phase_workspace_sync_calls[2] = {};
+
+static ggml_backend_buffer_t phase_workspace_cpu_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
+    if (phase_workspace_fail_alloc) {
+        phase_workspace_alloc_failures++;
+        if (phase_workspace_fail_once) {
+            phase_workspace_fail_alloc = false;
+        }
+        return nullptr;
+    }
+    return phase_workspace_alloc_buffer(buft, size);
+}
+
+static void phase_workspace_count_synchronize(ggml_backend_t backend) {
+    for (int i = 0; i < 2; ++i) {
+        if (phase_workspace_sync_backends[i] == backend) {
+            phase_workspace_sync_calls[i]++;
+            if (phase_workspace_synchronize[i] != nullptr) {
+                phase_workspace_synchronize[i](backend);
+            }
+            return;
+        }
+    }
+}
+
+static llama_context_ptr make_phase_workspace_context(
+        llama_model * model, llama_context_type type, llama_context * other = nullptr);
+
+static void test_phase_workspace_runtime_reserve(size_t seed) {
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_LLAMA, false);
+
+    llama_model_params model_params = llama_model_default_params();
+    model_params.progress_callback = silent_model_load_progress;
+    ggml_backend_dev_t devices[] = { nullptr };
+    model_params.devices = devices;
+
+    size_t tensor_seed = seed;
+    llama_model_ptr model(llama_model_init_from_user(gguf_ctx.get(), set_tensor_data, &tensor_seed, model_params));
+    GGML_ASSERT(model);
+
+    ggml_backend_buffer_type_t cpu_buft = ggml_backend_cpu_buffer_type();
+    phase_workspace_fail_alloc = false;
+    phase_workspace_fail_once = false;
+    phase_workspace_alloc_failures = 0;
+    phase_workspace_alloc_buffer = cpu_buft->iface.alloc_buffer;
+    cpu_buft->iface.alloc_buffer = phase_workspace_cpu_alloc_buffer;
+
+    llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 32;
+    ctx_params.n_batch = 32;
+    ctx_params.n_ubatch = 32;
+    ctx_params.n_seq_max = 1;
+    ctx_params.n_outputs_max = 0;
+    ctx_params.n_threads = 4;
+    ctx_params.n_threads_batch = 4;
+    ctx_params.no_perf = false;
+    ctx_params.phase_aware_workspace = true;
+
+    llama_context_ptr ctx(llama_init_from_model(model.get(), ctx_params));
+    GGML_ASSERT(ctx);
+    GGML_ASSERT(llama_n_batch(ctx.get()) == ctx_params.n_batch);
+    GGML_ASSERT(ctx->get_cparams().n_outputs_max == ctx_params.n_batch);
+
+    ggml_backend_sched_t sched = ctx->get_sched();
+    ggml_backend_t backend_cpu = nullptr;
+    for (int i = 0; i < ggml_backend_sched_get_n_backends(sched); ++i) {
+        ggml_backend_t backend = ggml_backend_sched_get_backend(sched, i);
+        if (ggml_backend_dev_type(ggml_backend_get_device(backend)) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+            backend_cpu = backend;
+            break;
+        }
+    }
+    GGML_ASSERT(backend_cpu != nullptr);
+    const size_t size_small = ggml_backend_sched_get_buffer_size(sched, backend_cpu);
+    GGML_ASSERT(size_small > 0);
+
+    llama_batch batch = llama_batch_init(16, 0, 1);
+    const std::vector<llama_token> tokens = get_tokens(16, llama_vocab_n_tokens(llama_model_get_vocab(model.get())), seed);
+    for (int32_t i = 0; i < 16; ++i) {
+        common_batch_add(batch, tokens[i], i, { 0 }, true);
+    }
+
+    phase_workspace_fail_alloc = true;
+    GGML_ASSERT(llama_decode(ctx.get(), batch) == -2);
+    GGML_ASSERT(phase_workspace_alloc_failures > 0);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == 0);
+
+    phase_workspace_fail_alloc = false;
+    const int64_t retry_start_us = ggml_time_us();
+    GGML_ASSERT(llama_decode(ctx.get(), batch) == 0);
+    llama_synchronize(ctx.get());
+    const int64_t retry_elapsed_us = ggml_time_us() - retry_start_us;
+    const llama_perf_context_data perf = llama_perf_context(ctx.get());
+    GGML_ASSERT(perf.n_p_eval == 16);
+    GGML_ASSERT(perf.t_p_eval_ms >= 0.0);
+    GGML_ASSERT(perf.t_p_eval_ms <= retry_elapsed_us*1e-3 + 0.001);
+    GGML_ASSERT(llama_get_logits_ith(ctx.get(), 0) != nullptr);
+    GGML_ASSERT(llama_get_logits_ith(ctx.get(), 15) != nullptr);
+    const size_t size_grown = ggml_backend_sched_get_buffer_size(sched, backend_cpu);
+    GGML_ASSERT(size_grown > size_small);
+
+    ctx->sched_reserve(ctx_params.n_ubatch);
+    const size_t size_prompt = ggml_backend_sched_get_buffer_size(sched, backend_cpu);
+    GGML_ASSERT(size_prompt == size_grown);
+
+    llama_batch_free(batch);
+    ctx.reset();
+
+    ctx_params.n_outputs_max = 4;
+    ctx.reset(llama_init_from_model(model.get(), ctx_params));
+    GGML_ASSERT(ctx);
+    sched = ctx->get_sched();
+    backend_cpu = nullptr;
+    for (int i = 0; i < ggml_backend_sched_get_n_backends(sched); ++i) {
+        ggml_backend_t backend = ggml_backend_sched_get_backend(sched, i);
+        if (ggml_backend_dev_type(ggml_backend_get_device(backend)) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+            backend_cpu = backend;
+            break;
+        }
+    }
+    GGML_ASSERT(backend_cpu != nullptr);
+    const size_t size_declared = ggml_backend_sched_get_buffer_size(sched, backend_cpu);
+    GGML_ASSERT(size_declared > 0);
+
+    int32_t pos = 0;
+    for (int32_t width = 1; width <= 4; width *= 2) {
+        llama_batch declared = llama_batch_init(width, 0, 1);
+        for (int32_t i = 0; i < width; ++i) {
+            common_batch_add(declared, tokens[i], pos++, { 0 }, true);
+        }
+        GGML_ASSERT(llama_decode(ctx.get(), declared) == 0);
+        llama_synchronize(ctx.get());
+        GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == size_declared);
+        llama_batch_free(declared);
+    }
+
+    ctx.reset();
+    cpu_buft->iface.alloc_buffer = phase_workspace_alloc_buffer;
+    phase_workspace_alloc_buffer = nullptr;
+}
+
+static void test_phase_workspace_late_pipeline_fallback(size_t seed) {
+    std::vector<ggml_backend_dev_t> devices;
+    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) {
+            continue;
+        }
+        ggml_backend_dev_props props;
+        ggml_backend_dev_get_props(dev, &props);
+        if (props.caps.async && props.caps.events) {
+            devices.push_back(dev);
+        }
+    }
+    if (devices.size() < 2) {
+        printf("test_phase_workspace_late_pipeline_fallback: skipped, two async GPU devices required\n");
+        return;
+    }
+
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_LLAMA, false);
+    llama_model_params model_params = llama_model_default_params();
+    model_params.progress_callback = silent_model_load_progress;
+    model_params.n_gpu_layers = 99;
+    ggml_backend_dev_t model_devices[] = { devices[0], devices[1], nullptr };
+    model_params.devices = model_devices;
+
+    size_t tensor_seed = seed;
+    llama_model_ptr model(llama_model_init_from_user(gguf_ctx.get(), set_tensor_data, &tensor_seed, model_params));
+    GGML_ASSERT(model);
+
+    llama_context_ptr ctx = make_phase_workspace_context(model.get(), LLAMA_CONTEXT_TYPE_DEFAULT);
+    GGML_ASSERT(ctx);
+    GGML_ASSERT(ggml_backend_sched_get_n_copies(ctx->get_sched()) > 1);
+
+    ggml_backend_buffer_type_t gpu_buft = nullptr;
+    for (int i = 0; i < ggml_backend_sched_get_n_backends(ctx->get_sched()); ++i) {
+        ggml_backend_t backend = ggml_backend_sched_get_backend(ctx->get_sched(), i);
+        if (ggml_backend_dev_type(ggml_backend_get_device(backend)) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+            gpu_buft = ggml_backend_get_default_buffer_type(backend);
+            break;
+        }
+    }
+    GGML_ASSERT(gpu_buft != nullptr);
+
+    phase_workspace_alloc_failures = 0;
+    phase_workspace_alloc_buffer = gpu_buft->iface.alloc_buffer;
+    phase_workspace_fail_once = true;
+    phase_workspace_fail_alloc = true;
+    gpu_buft->iface.alloc_buffer = phase_workspace_cpu_alloc_buffer;
+
+    llama_batch batch = llama_batch_init(16, 0, 1);
+    const std::vector<llama_token> tokens = get_tokens(16,
+            llama_vocab_n_tokens(llama_model_get_vocab(model.get())), seed);
+    for (int32_t i = 0; i < 16; ++i) {
+        common_batch_add(batch, tokens[i], i, { 0 }, i == 15);
+    }
+    GGML_ASSERT(llama_decode(ctx.get(), batch) == 0);
+    llama_synchronize(ctx.get());
+    GGML_ASSERT(phase_workspace_alloc_failures == 1);
+    GGML_ASSERT(ggml_backend_sched_get_n_copies(ctx->get_sched()) == 1);
+
+    gpu_buft->iface.alloc_buffer = phase_workspace_alloc_buffer;
+    phase_workspace_alloc_buffer = nullptr;
+    phase_workspace_fail_alloc = false;
+    phase_workspace_fail_once = false;
+    llama_batch_free(batch);
+}
+
+static llama_batch make_mtp_batch(
+        int32_t n_tokens, int32_t n_embd, int32_t pos, uint32_t n_vocab, size_t seed) {
+    llama_batch batch = llama_batch_init(n_tokens, n_embd, 1);
+    batch.token = (llama_token *) malloc(sizeof(llama_token) * n_tokens);
+    GGML_ASSERT(batch.token != nullptr);
+
+    const std::vector<llama_token> tokens = get_tokens(n_tokens, n_vocab, seed);
+    for (int32_t i = 0; i < n_tokens; ++i) {
+        common_batch_add(batch, tokens[i], pos + i, { 0 }, i == n_tokens - 1);
+        for (int32_t j = 0; j < n_embd; ++j) {
+            batch.embd[(size_t) i * n_embd + j] = (float) ((i + j) % 17) / 17.0f;
+        }
+    }
+    return batch;
+}
+
+static llama_context_ptr make_phase_workspace_context(
+        llama_model * model, llama_context_type type, llama_context * other) {
+    llama_context_params params = llama_context_default_params();
+    params.n_ctx = 32;
+    params.n_batch = 32;
+    params.n_ubatch = 32;
+    params.n_seq_max = 1;
+    params.n_outputs_max = type == LLAMA_CONTEXT_TYPE_MTP ? 1 : 4;
+    params.n_threads = 4;
+    params.n_threads_batch = 4;
+    params.ctx_type = type;
+    params.ctx_other = other;
+    params.phase_aware_workspace = true;
+    return llama_context_ptr(llama_init_from_model(model, params));
+}
+
+static void test_phase_workspace_mtp_lifecycle(size_t seed) {
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_QWEN35, false, true);
+
+    llama_model_params model_params = llama_model_default_params();
+    model_params.progress_callback = silent_model_load_progress;
+    model_params.load_mtp = true;
+    ggml_backend_dev_t devices[] = { nullptr };
+    model_params.devices = devices;
+
+    size_t tensor_seed = seed;
+    llama_model_ptr model(llama_model_init_from_user(gguf_ctx.get(), set_tensor_data, &tensor_seed, model_params));
+    GGML_ASSERT(model);
+
+    llama_context_ptr target = make_phase_workspace_context(model.get(), LLAMA_CONTEXT_TYPE_DEFAULT);
+    llama_context_ptr draft = make_phase_workspace_context(model.get(), LLAMA_CONTEXT_TYPE_MTP, target.get());
+    GGML_ASSERT(target && draft);
+    GGML_ASSERT(!llama_contexts_share_workspace(target.get(), draft.get()));
+
+    const uint32_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(model.get()));
+    const int32_t n_embd = llama_model_n_embd_out(model.get());
+    llama_batch target_batch = llama_batch_init(4, 0, 1);
+    const std::vector<llama_token> tokens = get_tokens(4, n_vocab, seed);
+    for (int32_t i = 0; i < 4; ++i) {
+        common_batch_add(target_batch, tokens[i], i, { 0 }, true);
+    }
+    llama_batch draft_batch = make_mtp_batch(4, n_embd, 0, n_vocab, seed + 1);
+
+    GGML_ASSERT(llama_decode(target.get(), target_batch) == 0);
+    GGML_ASSERT(llama_decode(draft.get(), draft_batch) == 0);
+    llama_synchronize(draft.get());
+    llama_synchronize(target.get());
+    llama_batch_free(draft_batch);
+    llama_batch_free(target_batch);
+
+    ggml_backend_t target_cpu = ggml_backend_sched_get_backend(target->get_sched(),
+            ggml_backend_sched_get_n_backends(target->get_sched()) - 1);
+    ggml_backend_buffer_type_t cpu_buft = ggml_backend_cpu_buffer_type();
+    phase_workspace_alloc_failures = 0;
+    phase_workspace_alloc_buffer = cpu_buft->iface.alloc_buffer;
+    phase_workspace_fail_once = true;
+    phase_workspace_fail_alloc = true;
+    cpu_buft->iface.alloc_buffer = phase_workspace_cpu_alloc_buffer;
+    GGML_ASSERT(llama_attach_shared_workspace(draft.get(), target.get()) == -1);
+    GGML_ASSERT(phase_workspace_alloc_failures == 1);
+    GGML_ASSERT(draft->get_sched() == nullptr);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(target->get_sched(), target_cpu) == 0);
+    cpu_buft->iface.alloc_buffer = phase_workspace_alloc_buffer;
+    phase_workspace_alloc_buffer = nullptr;
+    phase_workspace_fail_alloc = false;
+    phase_workspace_fail_once = false;
+
+    GGML_ASSERT(llama_attach_shared_workspace(draft.get(), target.get()) == 1);
+    GGML_ASSERT(llama_contexts_share_workspace(target.get(), draft.get()));
+    GGML_ASSERT(draft->make_sched_reserve_plan(4).n_tokens == 4);
+
+    ggml_backend_t draft_cpu = ggml_backend_sched_get_backend(draft->get_sched(),
+            ggml_backend_sched_get_n_backends(draft->get_sched()) - 1);
+    const size_t decode_size = ggml_backend_sched_get_buffer_size(target->get_sched(), target_cpu);
+    GGML_ASSERT(decode_size > 0);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(draft->get_sched(), draft_cpu) == decode_size);
+    draft->sched_reserve(4);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(draft->get_sched(), draft_cpu) == decode_size);
+
+    phase_workspace_sync_backends[0] = target_cpu;
+    phase_workspace_sync_backends[1] = draft_cpu;
+    phase_workspace_synchronize[0] = target_cpu->iface.synchronize;
+    phase_workspace_synchronize[1] = draft_cpu->iface.synchronize;
+    phase_workspace_sync_calls[0] = 0;
+    phase_workspace_sync_calls[1] = 0;
+    target_cpu->iface.synchronize = phase_workspace_count_synchronize;
+    draft_cpu->iface.synchronize = phase_workspace_count_synchronize;
+
+    llama_batch target_catchup = llama_batch_init(1, 0, 1);
+    common_batch_add(target_catchup, tokens[0], 4, { 0 }, true);
+    llama_batch draft_catchup = make_mtp_batch(1, n_embd, 4, n_vocab, seed + 2);
+    llama_batch target_reacquire = llama_batch_init(1, 0, 1);
+    common_batch_add(target_reacquire, tokens[1], 5, { 0 }, true);
+    GGML_ASSERT(llama_decode(target.get(), target_catchup) == 0);
+    GGML_ASSERT(llama_decode(draft.get(), draft_catchup) == 0);
+    GGML_ASSERT(phase_workspace_sync_calls[0] > 0);
+    const int draft_syncs_before_reacquire = phase_workspace_sync_calls[1];
+    GGML_ASSERT(llama_decode(target.get(), target_reacquire) == 0);
+    GGML_ASSERT(phase_workspace_sync_calls[1] == draft_syncs_before_reacquire + 1);
+    GGML_ASSERT(llama_get_logits_ith(target.get(), 0) != nullptr);
+    target_cpu->iface.synchronize = phase_workspace_synchronize[0];
+    draft_cpu->iface.synchronize = phase_workspace_synchronize[1];
+    memset(phase_workspace_sync_backends, 0, sizeof(phase_workspace_sync_backends));
+    memset(phase_workspace_synchronize, 0, sizeof(phase_workspace_synchronize));
+    memset(phase_workspace_sync_calls, 0, sizeof(phase_workspace_sync_calls));
+    llama_batch_free(target_reacquire);
+    llama_batch_free(draft_catchup);
+    llama_batch_free(target_catchup);
+
+    llama_batch draft_failure = make_mtp_batch(1, n_embd, 5, n_vocab, seed + 3);
+    GGML_ASSERT(llama_decode(draft.get(), draft_failure) == 0);
+    phase_workspace_alloc_failures = 0;
+    phase_workspace_alloc_buffer = cpu_buft->iface.alloc_buffer;
+    phase_workspace_fail_once = true;
+    phase_workspace_fail_alloc = true;
+    cpu_buft->iface.alloc_buffer = phase_workspace_cpu_alloc_buffer;
+    bool reserve_failed = false;
+    try {
+        target->sched_reserve(32);
+    } catch (const std::exception &) {
+        reserve_failed = true;
+    }
+    GGML_ASSERT(reserve_failed);
+    GGML_ASSERT(phase_workspace_alloc_failures == 1);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(target->get_sched(), target_cpu) == 0);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(draft->get_sched(), draft_cpu) == 0);
+    cpu_buft->iface.alloc_buffer = phase_workspace_alloc_buffer;
+    phase_workspace_alloc_buffer = nullptr;
+    phase_workspace_fail_alloc = false;
+    phase_workspace_fail_once = false;
+    llama_batch_free(draft_failure);
+
+    target->sched_reserve(32);
+    const size_t prompt_size = ggml_backend_sched_get_buffer_size(target->get_sched(), target_cpu);
+    GGML_ASSERT(prompt_size > decode_size);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(draft->get_sched(), draft_cpu) == prompt_size);
+
+    target->sched_reserve(0);
+    draft->sched_reserve(0);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(target->get_sched(), target_cpu) == decode_size);
+    target->sched_reserve(32);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(target->get_sched(), target_cpu) == prompt_size);
+
+    draft.reset();
+    draft = make_phase_workspace_context(model.get(), LLAMA_CONTEXT_TYPE_MTP, target.get());
+    GGML_ASSERT(draft);
+    GGML_ASSERT(!llama_contexts_share_workspace(target.get(), draft.get()));
+    GGML_ASSERT(llama_attach_shared_workspace(draft.get(), target.get()) == 1);
+
+    llama_batch teardown_batch = make_mtp_batch(1, n_embd, 0, n_vocab, seed + 4);
+    GGML_ASSERT(llama_decode(draft.get(), teardown_batch) == 0);
+    target.reset();
+    llama_batch_free(teardown_batch);
+    draft->sched_reserve(0);
+
+    target = make_phase_workspace_context(model.get(), LLAMA_CONTEXT_TYPE_DEFAULT);
+    GGML_ASSERT(target);
+    GGML_ASSERT(llama_attach_shared_workspace(draft.get(), target.get()) == 1);
+    target.reset();
+
+    llama_batch retry_batch = make_mtp_batch(1, n_embd, 4, n_vocab, seed + 2);
+    GGML_ASSERT(llama_decode(draft.get(), retry_batch) == 0);
+    llama_synchronize(draft.get());
+    llama_batch_free(retry_batch);
+    draft.reset();
+}
+
+static void test_phase_workspace_mismatched_placement(size_t seed) {
+    ggml_backend_dev_t gpu = nullptr;
+    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+            gpu = dev;
+            break;
+        }
+    }
+    if (gpu == nullptr) {
+        printf("test_phase_workspace_mismatched_placement: skipped, GPU device required\n");
+        return;
+    }
+
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_QWEN35, false, true);
+    llama_model_params target_params = llama_model_default_params();
+    target_params.progress_callback = silent_model_load_progress;
+    target_params.n_gpu_layers = 99;
+    target_params.load_mtp = true;
+    ggml_backend_dev_t target_devices[] = { gpu, nullptr };
+    target_params.devices = target_devices;
+
+    llama_model_params draft_params = llama_model_default_params();
+    draft_params.progress_callback = silent_model_load_progress;
+    draft_params.load_mtp = true;
+    ggml_backend_dev_t draft_devices[] = { nullptr };
+    draft_params.devices = draft_devices;
+
+    size_t target_seed = seed;
+    size_t draft_seed = seed;
+    llama_model_ptr target_model(llama_model_init_from_user(
+            gguf_ctx.get(), set_tensor_data, &target_seed, target_params));
+    llama_model_ptr draft_model(llama_model_init_from_user(
+            gguf_ctx.get(), set_tensor_data, &draft_seed, draft_params));
+    GGML_ASSERT(target_model && draft_model);
+
+    llama_context_ptr target = make_phase_workspace_context(target_model.get(), LLAMA_CONTEXT_TYPE_DEFAULT);
+    llama_context_ptr draft = make_phase_workspace_context(
+            draft_model.get(), LLAMA_CONTEXT_TYPE_MTP, target.get());
+    GGML_ASSERT(target && draft);
+    GGML_ASSERT(!llama_contexts_share_workspace(target.get(), draft.get()));
+
+    const uint32_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(target_model.get()));
+    const int32_t n_embd = llama_model_n_embd_out(draft_model.get());
+    llama_batch target_batch = llama_batch_init(1, 0, 1);
+    common_batch_add(target_batch, get_tokens(1, n_vocab, seed)[0], 0, { 0 }, true);
+    llama_batch draft_batch = make_mtp_batch(1, n_embd, 0, n_vocab, seed + 1);
+    GGML_ASSERT(llama_decode(target.get(), target_batch) == 0);
+    GGML_ASSERT(llama_decode(draft.get(), draft_batch) == 0);
+    llama_synchronize(draft.get());
+    llama_synchronize(target.get());
+    llama_batch_free(draft_batch);
+    llama_batch_free(target_batch);
+
+    const int32_t status = llama_attach_shared_workspace(draft.get(), target.get());
+    GGML_ASSERT(status >= 0);
+    GGML_ASSERT(llama_contexts_share_workspace(target.get(), draft.get()) == (status == 1));
 }
 
 static std::vector<float> get_logits(
@@ -750,6 +1215,7 @@ int main(int argc, char ** argv) {
     size_t seed = rd();
     ggml_log_level log_level = GGML_LOG_LEVEL_ERROR;
     std::string out;
+    bool test_phase_workspace = false;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-a") == 0 || strcmp(argv[i], "--arch") == 0) {
@@ -785,10 +1251,21 @@ int main(int argc, char ** argv) {
                 return 1;
             }
         }
+        if (strcmp(argv[i], "--test-phase-workspace") == 0) {
+            test_phase_workspace = true;
+            continue;
+        }
     }
     printf("%s: using seed %zu\n", __func__, seed);
 
     try {
+        if (test_phase_workspace) {
+            test_phase_workspace_runtime_reserve(seed);
+            test_phase_workspace_mtp_lifecycle(seed);
+            test_phase_workspace_mismatched_placement(seed);
+            test_phase_workspace_late_pipeline_fallback(seed);
+            return 0;
+        }
         if (!out.empty()) {
             return save_models(arch, seed, log_level, out);
         }

--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -2036,6 +2036,7 @@ int llama_perplexity(int argc, char ** argv) {
     }
     params.n_ctx = params.n_parallel * n_ctx;
     params.n_batch = std::min(params.n_batch, params.n_ctx);
+    params.n_outputs_max = params.n_batch;
 
     if (params.ppl_stride > 0) {
         LOG_INF("Will perform strided perplexity calculation -> adjusting context size from %d to %d\n",


### PR DESCRIPTION
## Overview

Adds an opt-in phase-aware workspace policy for target and integrated MTP execution. With `--phase-aware-workspace`, the target and draft schedulers share compatible allocator backing and resize it around prompt/decode phase requirements instead of retaining both prompt-sized workspaces for the full server lifetime.

Defaults are unchanged. The feature remains disabled unless explicitly requested.

## Implementation

- Extends ggml's graph allocator with resizable owner/borrower backing, generation tracking, fail-closed allocation handling, and placement compatibility checks.
- Keeps ownership and resize policy in `llama_context`; speculative scheduling requests phase transitions through a narrow context API.
- Preserves synchronization at the required target/draft handoff while avoiding redundant normal-path fences.
- Covers grow/shrink/grow, allocation failure and retry, owner/borrower lifetime, placement mismatch, target reacquisition, teardown/reload, parser/default-off behavior, and phase-workspace execution.
- Documents the resizable allocator contract next to the public allocator API.

## Scope

Final diff against current `llama/dev`: 18 files, +1877/-46. Production is +796/-34; the larger portion of the PR is focused regression coverage (+1081/-12). No VMM telemetry or live-context trimming code is included.

The final test-only commit makes the dummy allocator backend obtain its CPU device directly from the CPU registry. This removes an ambient backend-enumeration dependency exposed by Windows x64 OpenBLAS CI and does not alter production code.

## Validation

Fresh post-PR30 CUDA Release builds passed:

- `test-phase-aware-workspace`
- `test-arg-parser`
- `test-alloc`
- `git diff --check`

Matched Qwen3.8 27B integrated-MTP runs used q8 target/draft KV, `-ngl 40`, `-b 2048`, `-ub 2048`, deterministic sampling, clean server processes, and 50 ms VRAM/RSS sampling. Every comparison produced identical content; 32-token runs accepted 23/23 drafts and 128-token runs accepted 95/95.

Representative 16K, 12,288-prompt/128-generated bracket (2 samples per side): prompt +1.260%, decode -0.919%, wall -0.142%, loaded VRAM -1078 MiB, request-peak VRAM -460 MiB.

The earlier six-process comparison against pristine ggml-org `c060ca974` measured prompt +0.300%, decode -1.026%, and wall -0.084%; every paired 95% interval crossed zero.

At 128K, a clean sizing pair measured loaded VRAM 13,650 -> 11,124 MiB (-2526 MiB) and request peak 13,682 -> 12,330 MiB (-1352 MiB), with exact matching output. This shallow request is a sizing result, not filled-128K throughput evidence.

Fresh CI is required on the restacked head. In particular, it must confirm the Windows x64 OpenBLAS fixture correction.

## Requirements

- I have read and agree with the contributing guidelines.
- AI usage disclosure: YES. Codex assisted with implementation review, restacking, test-fixture diagnosis, validation automation, and evidence summarization. The repository owner reviewed and directed the work and remains responsible for the submitted changes.
