### PR TITLE
llama : add live-context workspace sizing

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2440,6 +2440,16 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_PHASE_AWARE_WORKSPACE"));
     add_opt(common_arg(
+        {"--live-context-workspace"},
+        {"--no-live-context-workspace"},
+        string_format("for supported attention caches, grow the compute workspace reservation with the padded live "
+                      "physical KV extent instead of reserving the full context up front (default: %s)",
+                      params.live_context_workspace ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.live_context_workspace = value;
+        }
+    ).set_env("LLAMA_ARG_LIVE_CONTEXT_WORKSPACE"));
+    add_opt(common_arg(
         {"--kv-gpu-layers"}, "N",
         string_format("with --no-kv-offload, keep the first N independently owned attention KV layers device-resident "
                       "for standard and direct hybrid caches. Unsupported specialized caches ignore this option "

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1747,6 +1747,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.recurrent_state_offload = params.recurrent_state_offload;
     cparams.kv_gpu_layers     = (uint32_t) std::max(0, params.kv_gpu_layers);
     cparams.phase_aware_workspace = params.phase_aware_workspace;
+    cparams.live_context_workspace = params.live_context_workspace;
     cparams.no_perf           = params.no_perf;
     cparams.op_offload        = !params.no_op_offload;
     cparams.swa_full          = params.swa_full;

--- a/common/common.h
+++ b/common/common.h
@@ -583,6 +583,7 @@ struct common_params {
     bool recurrent_state_offload = false; // offload recurrent state independently of attention KV storage
     int32_t kv_gpu_layers  = 0;     // with no_kv_offload, keep this many attention KV layers device-resident
     bool phase_aware_workspace = false; // resize compute schedulers between prompt and generation phases
+    bool live_context_workspace = false; // size supported attention workspaces from the padded live KV extent
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1170,6 +1170,7 @@ struct ggml_cuda_pool {
 
     virtual void * alloc(size_t size, size_t * actual_size) = 0;
     virtual void free(void * ptr, size_t size) = 0;
+    virtual size_t trim() { return 0; }
 };
 
 template<typename T>

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -566,7 +566,9 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
                 CU_CHECK(cuMemUnmap(mapping.first, mapping.second));
             }
 #else
-            CU_CHECK(cuMemUnmap(pool_addr, pool_size));
+            if (pool_size > 0) {
+                CU_CHECK(cuMemUnmap(pool_addr, pool_size));
+            }
 #endif
             CU_CHECK(cuMemAddressFree(pool_addr, CUDA_POOL_VMM_MAX_SIZE));
         }
@@ -685,8 +687,60 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         // all deallocations must be in reverse order of the allocations
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
     }
+
+    size_t trim() override {
+        if (pool_addr == 0 || pool_size == 0) {
+            return 0;
+        }
+
+#if defined(GGML_USE_HIP)
+        if (pool_used != 0) {
+            return 0;
+        }
+        ggml_cuda_set_device(device);
+        for (std::pair<CUdeviceptr, size_t> & mapping : mappings) {
+            CU_CHECK(cuMemUnmap(mapping.first, mapping.second));
+        }
+        mappings.clear();
+        const size_t released = pool_size;
+        pool_size = 0;
+#else
+        const size_t keep_size = granularity*((pool_used + granularity - 1)/granularity);
+        if (keep_size >= pool_size) {
+            return 0;
+        }
+        const size_t released = pool_size - keep_size;
+        ggml_cuda_set_device(device);
+        CU_CHECK(cuMemUnmap(pool_addr + keep_size, released));
+        pool_size = keep_size;
+#endif
+        return released;
+    }
 };
 #endif // defined(GGML_USE_VMM)
+
+static uint64_t ggml_backend_cuda_trim_transient_pools(ggml_backend_t backend) {
+    auto * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
+
+    for (int device = 0; device < GGML_CUDA_MAX_DEVICES; ++device) {
+        for (int stream = 0; stream < GGML_CUDA_MAX_STREAMS; ++stream) {
+            if (cuda_ctx->streams[device][stream] != nullptr) {
+                ggml_cuda_set_device(device);
+                CUDA_CHECK(cudaStreamSynchronize(cuda_ctx->streams[device][stream]));
+            }
+        }
+    }
+
+    uint64_t released = 0;
+    for (int device = 0; device < GGML_CUDA_MAX_DEVICES; ++device) {
+        for (int stream = 0; stream < GGML_CUDA_MAX_STREAMS; ++stream) {
+            if (cuda_ctx->pools[device][stream] != nullptr) {
+                released += cuda_ctx->pools[device][stream]->trim();
+            }
+        }
+    }
+    return released;
+}
 
 std::unique_ptr<ggml_cuda_pool> ggml_backend_cuda_context::new_pool_for_device(int                  device,
                                                                                [[maybe_unused]] int stream_no) {
@@ -5608,6 +5662,9 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     }
     if (strcmp(name, "ggml_backend_flash_attn_causal_prefix_supported") == 0) {
         return (void *)ggml_backend_cuda_flash_attn_causal_prefix_supported;
+    }
+    if (strcmp(name, "ggml_backend_cuda_trim_transient_pools") == 0) {
+        return (void *)ggml_backend_cuda_trim_transient_pools;
     }
     return nullptr;
 }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -722,6 +722,7 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
 static uint64_t ggml_backend_cuda_trim_transient_pools(ggml_backend_t backend) {
     auto * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
 
+    // Pool frees precede this call, but kernels and copies are asynchronous.
     for (int device = 0; device < GGML_CUDA_MAX_DEVICES; ++device) {
         for (int stream = 0; stream < GGML_CUDA_MAX_STREAMS; ++stream) {
             if (cuda_ctx->streams[device][stream] != nullptr) {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -705,7 +705,7 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         const size_t released = pool_size;
         pool_size = 0;
 #else
-        const size_t keep_size = granularity*((pool_used + granularity - 1)/granularity);
+        const size_t keep_size = granularity * ((pool_used + granularity - 1) / granularity);
         if (keep_size >= pool_size) {
             return 0;
         }

--- a/include/llama.h
+++ b/include/llama.h
@@ -402,6 +402,7 @@ extern "C" {
         bool kv_cpu_pinned;           // use pinned host buffers for CPU-resident KV cache storage when available
         bool recurrent_state_offload; // offload recurrent state independently of attention KV storage
         bool phase_aware_workspace;   // resize this context's compute scheduler between prompt processing and token generation
+        bool live_context_workspace;  // grow supported attention workspace plans with the padded live physical KV extent
 
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -700,8 +700,10 @@ llama_context::sched_reserve_plan llama_context::make_sched_reserve_plan(
             std::max(cparams.n_seq_max, sched_decode_outputs));
     plan.n_tokens = plan.n_tokens_max;
 
-    plan.n_kv_capacity = memory ? memory->get_attn_reserve_capacity() : 0;
-    plan.live_kv = cparams.live_context_workspace && !model.hparams.no_alloc && plan.n_kv_capacity > 0;
+    if (cparams.live_context_workspace && !model.hparams.no_alloc && memory) {
+        plan.n_kv_capacity = memory->get_attn_reserve_capacity();
+        plan.live_kv = plan.n_kv_capacity > 0;
+    }
 
     if (plan.live_kv) {
         const uint32_t required = n_kv_req > 0 ? n_kv_req :
@@ -783,6 +785,12 @@ void llama_context::prepare_sched_reserve(const sched_reserve_plan & plan) {
 
 void llama_context::sched_reserve(uint32_t n_tokens_req, uint32_t n_kv_req) {
     acquire_shared_workspace();
+
+    const bool sched_resizable_requested = (cparams.phase_aware_workspace || cparams.live_context_workspace) &&
+            !model.hparams.no_alloc;
+    if (!sched_need_reserve && !sched_resizable_requested) {
+        return;
+    }
 
     const auto plan = make_sched_reserve_plan(n_tokens_req, n_kv_req);
     const bool sched_resizable = (cparams.phase_aware_workspace || plan.live_kv) && !model.hparams.no_alloc;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -147,6 +147,7 @@ llama_context::llama_context(
     cparams.offload_attn_compute    = params.offload_kqv || (params.op_offload && params.kv_cpu_pinned);
     cparams.kv_gpu_layers           = params.kv_gpu_layers;
     cparams.phase_aware_workspace   = params.phase_aware_workspace;
+    cparams.live_context_workspace  = params.live_context_workspace;
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
 
@@ -530,7 +531,9 @@ llama_context::~llama_context() {
 
             const size_t size_exp = backend_buf_exp_size[i];
             const size_t size_act = ggml_backend_sched_get_buffer_size(sched.get(), backend);
-            if (cparams.phase_aware_workspace) {
+            const bool live_context_workspace = cparams.live_context_workspace && memory &&
+                    memory->get_attn_reserve_capacity() > 0;
+            if (cparams.phase_aware_workspace || live_context_workspace) {
                 LLAMA_LOG_DEBUG("%s: %10s resizable compute backing size is %8.4f MiB (last observed %8.4f MiB)\n",
                         __func__, ggml_backend_buft_name(buft),
                         size_act / (1024.0*1024.0), size_exp / (1024.0*1024.0));
@@ -677,12 +680,38 @@ void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint3
     }
 }
 
-llama_context::sched_reserve_plan llama_context::make_sched_reserve_plan(uint32_t n_tokens_req) const {
+static uint32_t llama_workspace_kv_growth_bound(uint32_t required, uint32_t capacity) {
+    GGML_ASSERT(capacity > 0);
+    required = std::max(1u, std::min(required, capacity));
+
+    uint32_t result = std::min(256u, capacity);
+    while (result < required) {
+        result = uint32_t(std::min<uint64_t>(capacity, uint64_t(result)*2));
+    }
+    return result;
+}
+
+llama_context::sched_reserve_plan llama_context::make_sched_reserve_plan(
+        uint32_t n_tokens_req,
+        uint32_t n_kv_req) const {
     sched_reserve_plan plan;
     plan.n_tokens_max = std::min(cparams.n_ctx, cparams.n_ubatch);
     plan.n_tokens_decode = std::min(plan.n_tokens_max,
             std::max(cparams.n_seq_max, sched_decode_outputs));
     plan.n_tokens = plan.n_tokens_max;
+
+    plan.n_kv_capacity = memory ? memory->get_attn_reserve_capacity() : 0;
+    plan.live_kv = cparams.live_context_workspace && !model.hparams.no_alloc && plan.n_kv_capacity > 0;
+
+    if (plan.live_kv) {
+        const uint32_t required = n_kv_req > 0 ? n_kv_req :
+                sched_reserved_kv > 0 ? sched_reserved_kv : std::min(256u, plan.n_kv_capacity);
+        plan.n_kv = llama_workspace_kv_growth_bound(required, plan.n_kv_capacity);
+
+        if (sched_reserved_kv > plan.n_kv && plan.n_kv >= sched_reserved_kv/2) {
+            plan.n_kv = sched_reserved_kv;
+        }
+    }
 
     if (cparams.phase_aware_workspace && !model.hparams.no_alloc) {
         plan.n_tokens = n_tokens_req > plan.n_tokens_decode ? plan.n_tokens_max : plan.n_tokens_decode;
@@ -710,6 +739,7 @@ void llama_context::reset_sched_workspace() {
     sched_buffers_shared = false;
     workspace_in_flight = false;
     sched_reserved_tokens = 0;
+    sched_reserved_kv = 0;
     sched_need_reserve = true;
 }
 
@@ -721,11 +751,12 @@ void llama_context::acquire_shared_workspace() {
 }
 
 void llama_context::prepare_sched_reserve(const sched_reserve_plan & plan) {
-    if (!sched || !cparams.phase_aware_workspace || model.hparams.no_alloc) {
+    if (!sched || (!cparams.phase_aware_workspace && !plan.live_kv) || model.hparams.no_alloc) {
         return;
     }
 
-    if (sched_reserved_tokens > plan.n_tokens) {
+    if (sched_reserved_tokens > plan.n_tokens ||
+            (plan.live_kv && sched_reserved_kv > plan.n_kv)) {
         ggml_backend_sched_request_buffer_shrink(sched.get());
     }
 
@@ -750,18 +781,19 @@ void llama_context::prepare_sched_reserve(const sched_reserve_plan & plan) {
     }
 }
 
-void llama_context::sched_reserve(uint32_t n_tokens_req) {
+void llama_context::sched_reserve(uint32_t n_tokens_req, uint32_t n_kv_req) {
     acquire_shared_workspace();
 
-    const bool sched_resizable = cparams.phase_aware_workspace && !model.hparams.no_alloc;
+    const auto plan = make_sched_reserve_plan(n_tokens_req, n_kv_req);
+    const bool sched_resizable = (cparams.phase_aware_workspace || plan.live_kv) && !model.hparams.no_alloc;
     if (!sched_need_reserve && !sched_resizable) {
         return;
     }
 
-    const auto plan = make_sched_reserve_plan(n_tokens_req);
     prepare_sched_reserve(plan);
 
-    if (!sched_need_reserve && sched_reserved_tokens == plan.n_tokens) {
+    if (!sched_need_reserve && sched_reserved_tokens == plan.n_tokens &&
+            (!plan.live_kv || sched_reserved_kv == plan.n_kv)) {
         return;
     }
 
@@ -770,8 +802,15 @@ void llama_context::sched_reserve(uint32_t n_tokens_req) {
     const uint32_t n_tokens_max = plan.n_tokens_max;
     const uint32_t n_tokens_tg  = plan.n_tokens_decode;
     const uint32_t n_tokens     = plan.n_tokens;
+    const uint32_t n_kv_capacity = plan.n_kv_capacity;
+    const uint32_t n_kv          = plan.n_kv;
+    const bool live_kv            = plan.live_kv;
 
-    if (sched_resizable) {
+    if (live_kv) {
+        LLAMA_LOG_INFO("%s: reserving %s workspace (tokens = %u, previous = %u, kv = %u, previous = %u) ...\n",
+                __func__, n_tokens == n_tokens_tg ? "decode" : "prefill",
+                n_tokens, sched_reserved_tokens, n_kv, sched_reserved_kv);
+    } else if (sched_resizable) {
         LLAMA_LOG_INFO("%s: reserving %s workspace (tokens = %u, previous = %u) ...\n",
                 __func__, n_tokens == n_tokens_tg ? "decode" : "prefill",
                 n_tokens, sched_reserved_tokens);
@@ -818,8 +857,9 @@ void llama_context::sched_reserve(uint32_t n_tokens_req) {
             }
             ggml_backend_sched_get_buffer_state(
                     sched.get(), &sched_buffer_generation, &sched_shrink_generation);
-            LLAMA_LOG_INFO("%s: %s phase-aware compute backing\n", __func__,
-                    sched_buffers_shared ? "borrowing target" : "created");
+            LLAMA_LOG_INFO("%s: %s %s compute backing\n", __func__,
+                    sched_buffers_shared ? "borrowing target" : "created",
+                    cparams.phase_aware_workspace ? "phase-aware" : "live-context");
         }
     };
 
@@ -829,8 +869,14 @@ void llama_context::sched_reserve(uint32_t n_tokens_req) {
 
     llama_memory_context_ptr mctx;
     if (memory) {
-        LLAMA_LOG_DEBUG("%s: reserving full memory module\n", __func__);
-        mctx = memory->init_full();
+        if (live_kv) {
+            LLAMA_LOG_DEBUG("%s: reserving bounded memory module (n_kv = %u, capacity = %u)\n",
+                    __func__, n_kv, n_kv_capacity);
+            mctx = memory->init_reserve(n_kv);
+        } else {
+            LLAMA_LOG_DEBUG("%s: reserving full memory module\n", __func__);
+            mctx = memory->init_full();
+        }
         if (!mctx) {
             throw std::runtime_error("failed to initialize memory module");
         }
@@ -931,8 +977,14 @@ void llama_context::sched_reserve(uint32_t n_tokens_req) {
                 sched.get(), &sched_buffer_generation, &sched_shrink_generation);
     }
     sched_reserved_tokens = n_tokens;
+    sched_reserved_kv = live_kv ? n_kv : 0;
 
-    if (sched_resizable) {
+    if (live_kv) {
+        LLAMA_LOG_INFO("%s: %s workspace reserve took %.2f ms (kv = %u), sched copies = %d\n",
+                __func__, n_tokens == n_tokens_tg ? "decode" : "prefill",
+                (t_end_us - t_start_us)/1000.0, n_kv,
+                ggml_backend_sched_get_n_copies(sched.get()));
+    } else if (sched_resizable) {
         LLAMA_LOG_INFO("%s: %s workspace reserve took %.2f ms, sched copies = %d\n",
                 __func__, n_tokens == n_tokens_tg ? "decode" : "prefill",
                 (t_end_us - t_start_us)/1000.0, ggml_backend_sched_get_n_copies(sched.get()));
@@ -976,6 +1028,29 @@ void llama_context::synchronize() {
 
     n_queued_tokens = 0;
     t_compute_start_us = 0;
+}
+
+uint64_t llama_context::trim_transient_memory() {
+    const bool live_context_workspace = cparams.live_context_workspace && memory &&
+            memory->get_attn_reserve_capacity() > 0 && !model.hparams.no_alloc;
+    if (!live_context_workspace) {
+        return 0;
+    }
+
+    synchronize();
+
+    using trim_fn = uint64_t (*)(ggml_backend_t);
+    uint64_t released = 0;
+    for (ggml_backend_t backend : backend_ptrs) {
+        ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+        ggml_backend_reg_t reg = dev != nullptr ? ggml_backend_dev_backend_reg(dev) : nullptr;
+        auto * fn = reg != nullptr ? (trim_fn) ggml_backend_reg_get_proc_address(
+                reg, "ggml_backend_cuda_trim_transient_pools") : nullptr;
+        if (fn != nullptr) {
+            released += fn(backend);
+        }
+    }
+    return released;
 }
 
 const llama_model & llama_context::get_model() const {
@@ -1081,6 +1156,10 @@ bool llama_context::recurrent_sparse_snapshots_supported() const {
 }
 
 bool llama_context::memory_update(bool optimize) {
+    return memory_update(optimize, 0);
+}
+
+bool llama_context::memory_update(bool optimize, uint32_t n_tokens_req) {
     if (!memory) {
         return false;
     }
@@ -1105,6 +1184,10 @@ bool llama_context::memory_update(bool optimize) {
                 }
         }
 
+        if (n_tokens_req > 0) {
+            sched_reserve(n_tokens_req);
+        }
+
         // reset the previous graph result to make sure that it won't be reused
         // TODO: change the mctx->apply() to return information if a graph reserve is needed
         //       reset the graph result only if the memory module did reset the scheduler
@@ -1117,7 +1200,10 @@ bool llama_context::memory_update(bool optimize) {
 
     // if the memory module did any computation, we have to reserve a new worst-case graph
     {
-        const auto mctx = memory->init_full();
+        const uint32_t n_kv_capacity = memory->get_attn_reserve_capacity();
+        const bool live_kv = cparams.live_context_workspace && !model.hparams.no_alloc &&
+                n_kv_capacity > 0 && sched_reserved_kv > 0;
+        const auto mctx = live_kv ? memory->init_reserve(sched_reserved_kv) : memory->init_full();
         if (!mctx) {
             throw std::runtime_error("failed to initialize memory context");
         }
@@ -2027,11 +2113,16 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     output_swaps.clear();
 
-    try {
-        sched_reserve(n_tokens_all);
-    } catch (const std::exception & err) {
-        LLAMA_LOG_ERROR("%s: failed to reserve compute workspace: %s\n", __func__, err.what());
-        return -2;
+    const bool live_exact_batch_plan = cparams.live_context_workspace && memory &&
+            memory->get_attn_reserve_capacity() > 0 && !model.hparams.no_alloc;
+
+    if (!live_exact_batch_plan) {
+        try {
+            sched_reserve(n_tokens_all);
+        } catch (const std::exception & err) {
+            LLAMA_LOG_ERROR("%s: failed to reserve compute workspace: %s\n", __func__, err.what());
+            return -2;
+        }
     }
     if (t_compute_start_us == 0) {
         t_compute_start_us = ggml_time_us();
@@ -2041,7 +2132,16 @@ int llama_context::decode(const llama_batch & batch_inp) {
     bool did_optimize = false;
 
     // handle any pending shifts/copies
-    memory_update(false);
+    try {
+        if (live_exact_batch_plan) {
+            memory_update(false, n_tokens_all);
+        } else {
+            memory_update(false);
+        }
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: failed to update memory: %s\n", __func__, err.what());
+        return -2;
+    }
 
     llama_memory_context_ptr mctx;
 
@@ -2066,7 +2166,15 @@ int llama_context::decode(const llama_batch & batch_inp) {
                     if (!did_optimize) {
                         did_optimize = true;
 
-                        if (memory_update(true)) {
+                        bool optimized;
+                        try {
+                            optimized = live_exact_batch_plan ?
+                                    memory_update(true, n_tokens_all) : memory_update(true);
+                        } catch (const std::exception & err) {
+                            LLAMA_LOG_ERROR("%s: failed to optimize memory: %s\n", __func__, err.what());
+                            return -2;
+                        }
+                        if (optimized) {
                             LLAMA_LOG_DEBUG("%s: retrying batch size %d after cache optimization\n", __func__, balloc->get_n_tokens());
 
                             continue;
@@ -2086,6 +2194,15 @@ int llama_context::decode(const llama_batch & batch_inp) {
         }
 
         break;
+    }
+
+    if (live_exact_batch_plan) {
+        try {
+            sched_reserve(n_tokens_all, mctx->get_attn_reserve_n_kv());
+        } catch (const std::exception & err) {
+            LLAMA_LOG_ERROR("%s: failed to reserve live-context workspace: %s\n", __func__, err.what());
+            return -2;
+        }
     }
 
     // reserve output buffer
@@ -3861,6 +3978,7 @@ llama_context_params llama_context_default_params() {
         /*.kv_cpu_pinned               =*/ false,
         /*.recurrent_state_offload     =*/ false,
         /*.phase_aware_workspace       =*/ false,
+        /*.live_context_workspace      =*/ false,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,
@@ -4553,4 +4671,8 @@ int32_t llama_attach_shared_workspace(llama_context * borrower, llama_context * 
 
 bool llama_contexts_share_workspace(const llama_context * ctx_a, const llama_context * ctx_b) {
     return ctx_a != nullptr && ctx_b != nullptr && ctx_a->shares_workspace_with(*ctx_b);
+}
+
+uint64_t llama_trim_transient_memory(llama_context * ctx) {
+    return ctx != nullptr ? ctx->trim_transient_memory() : 0;
 }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -428,6 +428,13 @@ llama_context::llama_context(
 
         memory.reset(model.create_memory(params_mem, cparams));
 
+        if (cparams.live_context_workspace && hparams.no_alloc) {
+            cparams.live_context_workspace = false;
+        } else if (cparams.live_context_workspace && (!memory || memory->get_attn_reserve_capacity() == 0)) {
+            LLAMA_LOG_WARN("%s: live-context workspace sizing unsupported; using full-context reserve\n", __func__);
+            cparams.live_context_workspace = false;
+        }
+
         if (!cparams.offload_kqv && cparams.kv_gpu_layers > 0) {
             if (memory && memory->get_supports_partial_kv()) {
                 cparams.offload_attn_compute = cparams.offload_attn_compute || cparams.op_offload;
@@ -531,9 +538,7 @@ llama_context::~llama_context() {
 
             const size_t size_exp = backend_buf_exp_size[i];
             const size_t size_act = ggml_backend_sched_get_buffer_size(sched.get(), backend);
-            const bool live_context_workspace = cparams.live_context_workspace && memory &&
-                    memory->get_attn_reserve_capacity() > 0;
-            if (cparams.phase_aware_workspace || live_context_workspace) {
+            if (cparams.phase_aware_workspace || cparams.live_context_workspace) {
                 LLAMA_LOG_DEBUG("%s: %10s resizable compute backing size is %8.4f MiB (last observed %8.4f MiB)\n",
                         __func__, ggml_backend_buft_name(buft),
                         size_act / (1024.0*1024.0), size_exp / (1024.0*1024.0));
@@ -686,7 +691,7 @@ static uint32_t llama_workspace_kv_growth_bound(uint32_t required, uint32_t capa
 
     uint32_t result = std::min(256u, capacity);
     while (result < required) {
-        result = uint32_t(std::min<uint64_t>(capacity, uint64_t(result)*2));
+        result = uint32_t(std::min<uint64_t>(capacity, uint64_t(result) * 2));
     }
     return result;
 }
@@ -700,17 +705,24 @@ llama_context::sched_reserve_plan llama_context::make_sched_reserve_plan(
             std::max(cparams.n_seq_max, sched_decode_outputs));
     plan.n_tokens = plan.n_tokens_max;
 
-    if (cparams.live_context_workspace && !model.hparams.no_alloc && memory) {
+    if (cparams.live_context_workspace) {
+        GGML_ASSERT(memory);
         plan.n_kv_capacity = memory->get_attn_reserve_capacity();
-        plan.live_kv = plan.n_kv_capacity > 0;
+        GGML_ASSERT(plan.n_kv_capacity > 0);
+        plan.live_kv = true;
     }
 
     if (plan.live_kv) {
-        const uint32_t required = n_kv_req > 0 ? n_kv_req :
-                sched_reserved_kv > 0 ? sched_reserved_kv : std::min(256u, plan.n_kv_capacity);
+        uint32_t required = n_kv_req;
+        if (required == 0) {
+            required = sched_reserved_kv;
+        }
+        if (required == 0) {
+            required = std::min(256u, plan.n_kv_capacity);
+        }
         plan.n_kv = llama_workspace_kv_growth_bound(required, plan.n_kv_capacity);
 
-        if (sched_reserved_kv > plan.n_kv && plan.n_kv >= sched_reserved_kv/2) {
+        if (sched_reserved_kv > plan.n_kv && plan.n_kv >= sched_reserved_kv / 2) {
             plan.n_kv = sched_reserved_kv;
         }
     }
@@ -1039,9 +1051,7 @@ void llama_context::synchronize() {
 }
 
 uint64_t llama_context::trim_transient_memory() {
-    const bool live_context_workspace = cparams.live_context_workspace && memory &&
-            memory->get_attn_reserve_capacity() > 0 && !model.hparams.no_alloc;
-    if (!live_context_workspace) {
+    if (!cparams.live_context_workspace) {
         return 0;
     }
 
@@ -1163,10 +1173,6 @@ bool llama_context::recurrent_sparse_snapshots_supported() const {
     return memory && memory->recurrent_sparse_snapshots_supported() && recurrent_sparse_snapshot_ops_supported;
 }
 
-bool llama_context::memory_update(bool optimize) {
-    return memory_update(optimize, 0);
-}
-
 bool llama_context::memory_update(bool optimize, uint32_t n_tokens_req) {
     if (!memory) {
         return false;
@@ -1208,9 +1214,7 @@ bool llama_context::memory_update(bool optimize, uint32_t n_tokens_req) {
 
     // if the memory module did any computation, we have to reserve a new worst-case graph
     {
-        const uint32_t n_kv_capacity = memory->get_attn_reserve_capacity();
-        const bool live_kv = cparams.live_context_workspace && !model.hparams.no_alloc &&
-                n_kv_capacity > 0 && sched_reserved_kv > 0;
+        const bool live_kv = cparams.live_context_workspace && sched_reserved_kv > 0;
         const auto mctx = live_kv ? memory->init_reserve(sched_reserved_kv) : memory->init_full();
         if (!mctx) {
             throw std::runtime_error("failed to initialize memory context");
@@ -2121,8 +2125,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     output_swaps.clear();
 
-    const bool live_exact_batch_plan = cparams.live_context_workspace && memory &&
-            memory->get_attn_reserve_capacity() > 0 && !model.hparams.no_alloc;
+    const bool live_exact_batch_plan = cparams.live_context_workspace;
 
     if (!live_exact_batch_plan) {
         try {
@@ -2141,11 +2144,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     // handle any pending shifts/copies
     try {
-        if (live_exact_batch_plan) {
-            memory_update(false, n_tokens_all);
-        } else {
-            memory_update(false);
-        }
+        memory_update(false, live_exact_batch_plan ? n_tokens_all : 0);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: failed to update memory: %s\n", __func__, err.what());
         return -2;
@@ -2176,8 +2175,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
                         bool optimized;
                         try {
-                            optimized = live_exact_batch_plan ?
-                                    memory_update(true, n_tokens_all) : memory_update(true);
+                            optimized = memory_update(true, live_exact_batch_plan ? n_tokens_all : 0);
                         } catch (const std::exception & err) {
                             LLAMA_LOG_ERROR("%s: failed to optimize memory: %s\n", __func__, err.what());
                             return -2;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -91,8 +91,7 @@ struct llama_context {
     bool recurrent_sparse_snapshots_supported() const;
 
     // return true if the memory was updated
-    bool memory_update(bool optimize);
-    bool memory_update(bool optimize, uint32_t n_tokens_req);
+    bool memory_update(bool optimize, uint32_t n_tokens_req = 0);
 
     enum llama_pooling_type pooling_type() const;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -45,6 +45,9 @@ struct llama_context {
         uint32_t n_tokens_max    = 0;
         uint32_t n_tokens_decode = 0;
         uint32_t n_tokens        = 0;
+        uint32_t n_kv_capacity   = 0;
+        uint32_t n_kv            = 0;
+        bool live_kv             = false;
     };
 
     // init scheduler and compute buffers, reserve worst-case graphs
@@ -60,11 +63,12 @@ struct llama_context {
     //   - changing samplers
     //   - changing attention type
     //   - etc.
-    void sched_reserve(uint32_t n_tokens = 0);
-    sched_reserve_plan make_sched_reserve_plan(uint32_t n_tokens) const;
+    void sched_reserve(uint32_t n_tokens = 0, uint32_t n_kv = 0);
+    sched_reserve_plan make_sched_reserve_plan(uint32_t n_tokens, uint32_t n_kv = 0) const;
     void prepare_sched_reserve(const sched_reserve_plan & plan);
     int attach_shared_workspace(llama_context & owner);
     bool shares_workspace_with(const llama_context & other) const;
+    uint64_t trim_transient_memory();
 
     void synchronize();
 
@@ -88,6 +92,7 @@ struct llama_context {
 
     // return true if the memory was updated
     bool memory_update(bool optimize);
+    bool memory_update(bool optimize, uint32_t n_tokens_req);
 
     enum llama_pooling_type pooling_type() const;
 
@@ -370,6 +375,7 @@ private:
 
     bool sched_need_reserve = true;
     uint32_t sched_reserved_tokens = 0;
+    uint32_t sched_reserved_kv = 0;
     uint32_t sched_decode_outputs = 0;
 
     bool recurrent_sparse_snapshot_ops_supported = false;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -59,6 +59,7 @@ struct llama_cparams {
     bool kv_cpu_pinned;
     bool recurrent_state_offload;
     bool phase_aware_workspace;
+    bool live_context_workspace;
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -127,6 +127,8 @@ LLAMA_API bool llama_contexts_share_workspace(
         const struct llama_context * ctx_a,
         const struct llama_context * ctx_b);
 
+LLAMA_API uint64_t llama_trim_transient_memory(struct llama_context * ctx);
+
 //
 // model/context data extraction
 //

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -127,6 +127,7 @@ LLAMA_API bool llama_contexts_share_workspace(
         const struct llama_context * ctx_a,
         const struct llama_context * ctx_b);
 
+// Synchronize the context and ask capable backends to release cached transient physical mappings. This is a no-op unless live-context sizing is effective.
 LLAMA_API uint64_t llama_trim_transient_memory(struct llama_context * ctx);
 
 //

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -248,6 +248,14 @@ llama_memory_context_ptr llama_kv_cache_iswa::init_full() {
     return std::make_unique<llama_kv_cache_iswa_context>(this);
 }
 
+llama_memory_context_ptr llama_kv_cache_iswa::init_reserve(uint32_t n_kv) {
+    return std::make_unique<llama_kv_cache_iswa_context>(this, n_kv);
+}
+
+uint32_t llama_kv_cache_iswa::get_attn_reserve_capacity() const {
+    return std::max(kv_base->get_attn_reserve_capacity(), kv_swa->get_attn_reserve_capacity());
+}
+
 llama_memory_context_ptr llama_kv_cache_iswa::init_update(llama_context * lctx, bool optimize) {
     return std::make_unique<llama_kv_cache_iswa_context>(this, lctx, optimize);
 }
@@ -292,6 +300,14 @@ llama_kv_cache_iswa_context::llama_kv_cache_iswa_context(
         llama_kv_cache_iswa * kv) :
     ctx_base(kv->get_base()->init_full()),
     ctx_swa (kv->get_swa ()->init_full()),
+    status(llama_memory_status_combine(ctx_base->get_status(), ctx_swa->get_status())) {
+}
+
+llama_kv_cache_iswa_context::llama_kv_cache_iswa_context(
+        llama_kv_cache_iswa * kv,
+        uint32_t n_kv) :
+    ctx_base(kv->get_base()->init_reserve(n_kv)),
+    ctx_swa (kv->get_swa ()->init_reserve(n_kv)),
     status(llama_memory_status_combine(ctx_base->get_status(), ctx_swa->get_status())) {
 }
 
@@ -350,6 +366,10 @@ const llama_ubatch & llama_kv_cache_iswa_context::get_ubatch() const {
     assert(status == LLAMA_MEMORY_STATUS_SUCCESS);
 
     return ubatches[i_next];
+}
+
+uint32_t llama_kv_cache_iswa_context::get_attn_reserve_n_kv() const {
+    return std::max(ctx_base->get_attn_reserve_n_kv(), ctx_swa->get_attn_reserve_n_kv());
 }
 
 const llama_kv_cache_context * llama_kv_cache_iswa_context::get_base() const {

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -63,6 +63,10 @@ public:
 
     llama_memory_context_ptr init_full() override;
 
+    llama_memory_context_ptr init_reserve(uint32_t n_kv) override;
+
+    uint32_t get_attn_reserve_capacity() const override;
+
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
@@ -110,6 +114,10 @@ public:
     llama_kv_cache_iswa_context(
             llama_kv_cache_iswa * kv);
 
+    llama_kv_cache_iswa_context(
+            llama_kv_cache_iswa * kv,
+            uint32_t n_kv);
+
     // used to create an update context
     llama_kv_cache_iswa_context(
             llama_kv_cache_iswa * kv,
@@ -134,6 +142,7 @@ public:
 
     llama_memory_status  get_status() const override;
     const llama_ubatch & get_ubatch() const override;
+    uint32_t get_attn_reserve_n_kv() const override;
 
     //
     // llama_kv_cache_iswa_context specific API

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -833,6 +833,14 @@ llama_memory_context_ptr llama_kv_cache::init_full() {
     return std::make_unique<llama_kv_cache_context>(this);
 }
 
+llama_memory_context_ptr llama_kv_cache::init_reserve(uint32_t n_kv) {
+    return std::make_unique<llama_kv_cache_context>(this, n_kv);
+}
+
+uint32_t llama_kv_cache::get_attn_reserve_capacity() const {
+    return get_size();
+}
+
 llama_memory_context_ptr llama_kv_cache::init_update(llama_context * lctx, bool optimize) {
     GGML_UNUSED(optimize);
 
@@ -1341,6 +1349,25 @@ uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
     }
 
     return result;
+}
+
+uint32_t llama_kv_cache::get_reserve_n_kv(const slot_info_vec_t & sinfos) const {
+    uint32_t result = 0;
+
+    for (const auto & sinfo : sinfos) {
+        for (uint32_t s = 0; s < sinfo.n_stream(); ++s) {
+            const uint32_t strm = sinfo.strm[s];
+            GGML_ASSERT(strm < v_cells.size());
+            result = std::max(result, v_cells[strm].used_max_p1());
+            for (const uint32_t idx : sinfo.idxs[s]) {
+                GGML_ASSERT(idx < v_cells[strm].size());
+                result = std::max(result, idx + 1);
+            }
+        }
+    }
+
+    const uint32_t n_pad_cur = std::max(n_pad, 256u);
+    return std::min(get_size(), std::max(n_pad_cur, GGML_PAD(result, n_pad_cur)));
 }
 
 ggml_tensor * llama_kv_cache::get_k(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const {
@@ -2756,8 +2783,14 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
 llama_kv_cache_context::llama_kv_cache_context(llama_memory_status status) : status(status) {}
 
 llama_kv_cache_context::llama_kv_cache_context(
-        llama_kv_cache * kv) : status(LLAMA_MEMORY_STATUS_SUCCESS), kv(kv) {
-    n_kv = kv->get_size();
+        llama_kv_cache * kv) : llama_kv_cache_context(kv, kv->get_size()) {
+}
+
+llama_kv_cache_context::llama_kv_cache_context(
+        llama_kv_cache * kv,
+        uint32_t n_kv) : status(LLAMA_MEMORY_STATUS_SUCCESS), kv(kv) {
+    this->n_kv = std::max(1u, std::min(n_kv, kv->get_size()));
+    reserve_n_kv = this->n_kv;
 
     const uint32_t n_stream = kv->get_n_stream();
 
@@ -2786,6 +2819,7 @@ llama_kv_cache_context::llama_kv_cache_context(
         llama_kv_cache * kv,
         llama_kv_cache::slot_info_vec_t sinfos,
         std::vector<llama_ubatch> ubatches) : status(LLAMA_MEMORY_STATUS_SUCCESS), kv(kv), sinfos(std::move(sinfos)), ubatches(std::move(ubatches)) {
+    reserve_n_kv = kv->get_reserve_n_kv(this->sinfos);
 }
 
 llama_kv_cache_context::~llama_kv_cache_context() = default;
@@ -2824,6 +2858,10 @@ const llama_ubatch & llama_kv_cache_context::get_ubatch() const {
     assert(status == LLAMA_MEMORY_STATUS_SUCCESS);
 
     return ubatches[i_cur];
+}
+
+uint32_t llama_kv_cache_context::get_attn_reserve_n_kv() const {
+    return reserve_n_kv;
 }
 
 uint32_t llama_kv_cache_context::get_n_kv() const {

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -128,6 +128,10 @@ public:
 
     llama_memory_context_ptr init_full() override;
 
+    llama_memory_context_ptr init_reserve(uint32_t n_kv) override;
+
+    uint32_t get_attn_reserve_capacity() const override;
+
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
@@ -176,6 +180,7 @@ public:
     //
 
     uint32_t get_n_kv(const slot_info & sinfo) const;
+    uint32_t get_reserve_n_kv(const slot_info_vec_t & sinfos) const;
 
     // get views of the current state of the cache
     ggml_tensor * get_k(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const;
@@ -357,6 +362,10 @@ public:
     llama_kv_cache_context(
             llama_kv_cache * kv);
 
+    llama_kv_cache_context(
+            llama_kv_cache * kv,
+            uint32_t n_kv);
+
     // used to create an update context
     llama_kv_cache_context(
             llama_kv_cache * kv,
@@ -381,6 +390,7 @@ public:
 
     llama_memory_status  get_status() const override;
     const llama_ubatch & get_ubatch() const override;
+    uint32_t get_attn_reserve_n_kv() const override;
 
     //
     // llama_kv_cache_context specific API
@@ -464,5 +474,6 @@ private:
 
     // a heuristic, to avoid attending the full cache if it is not yet utilized
     // as the cache gets filled, the benefit from this heuristic disappears
-    int32_t n_kv;
+    int32_t n_kv = 0;
+    uint32_t reserve_n_kv = 0;
 };

--- a/src/llama-memory-hybrid-iswa.cpp
+++ b/src/llama-memory-hybrid-iswa.cpp
@@ -133,6 +133,14 @@ llama_memory_context_ptr llama_memory_hybrid_iswa::init_full() {
     return std::make_unique<llama_memory_hybrid_iswa_context>(this);
 }
 
+llama_memory_context_ptr llama_memory_hybrid_iswa::init_reserve(uint32_t n_kv) {
+    return std::make_unique<llama_memory_hybrid_iswa_context>(this, mem_attn->init_reserve(n_kv));
+}
+
+uint32_t llama_memory_hybrid_iswa::get_attn_reserve_capacity() const {
+    return mem_attn->get_attn_reserve_capacity();
+}
+
 llama_memory_context_ptr llama_memory_hybrid_iswa::init_update(llama_context * lctx, bool optimize) {
     return std::make_unique<llama_memory_hybrid_iswa_context>(this, lctx, optimize);
 }
@@ -225,6 +233,14 @@ llama_memory_hybrid_iswa_context::llama_memory_hybrid_iswa_context(llama_memory_
 }
 
 llama_memory_hybrid_iswa_context::llama_memory_hybrid_iswa_context(
+              llama_memory_hybrid_iswa * mem,
+        llama_memory_context_ptr          ctx_attn) :
+    ctx_attn(std::move(ctx_attn)),
+    ctx_recr(mem->get_mem_recr()->init_full()),
+    status(llama_memory_status_combine(this->ctx_attn->get_status(), ctx_recr->get_status())) {
+}
+
+llama_memory_hybrid_iswa_context::llama_memory_hybrid_iswa_context(
         llama_memory_hybrid_iswa * mem,
                    llama_context * lctx,
                             bool   optimize) :
@@ -276,6 +292,10 @@ llama_memory_status llama_memory_hybrid_iswa_context::get_status() const {
 const llama_ubatch & llama_memory_hybrid_iswa_context::get_ubatch() const {
     assert(status == LLAMA_MEMORY_STATUS_SUCCESS);
     return ubatches[i_next];
+}
+
+uint32_t llama_memory_hybrid_iswa_context::get_attn_reserve_n_kv() const {
+    return ctx_attn->get_attn_reserve_n_kv();
 }
 
 const llama_kv_cache_iswa_context * llama_memory_hybrid_iswa_context::get_attn() const {

--- a/src/llama-memory-hybrid-iswa.h
+++ b/src/llama-memory-hybrid-iswa.h
@@ -55,6 +55,10 @@ public:
 
     llama_memory_context_ptr init_full() override;
 
+    llama_memory_context_ptr init_reserve(uint32_t n_kv) override;
+
+    uint32_t get_attn_reserve_capacity() const override;
+
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
@@ -101,6 +105,10 @@ public:
     // init full
     explicit llama_memory_hybrid_iswa_context(llama_memory_hybrid_iswa * mem);
 
+    llama_memory_hybrid_iswa_context(
+              llama_memory_hybrid_iswa * mem,
+        llama_memory_context_ptr          ctx_attn);
+
     // init update
     explicit llama_memory_hybrid_iswa_context(
         llama_memory_hybrid_iswa * mem,
@@ -121,6 +129,7 @@ public:
 
     llama_memory_status  get_status() const override;
     const llama_ubatch & get_ubatch() const override;
+    uint32_t get_attn_reserve_n_kv() const override;
 
     //
     // llama_memory_hybrid_iswa_context

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -128,6 +128,14 @@ llama_memory_context_ptr llama_memory_hybrid::init_full() {
     return std::make_unique<llama_memory_hybrid_context>(this);
 }
 
+llama_memory_context_ptr llama_memory_hybrid::init_reserve(uint32_t n_kv) {
+    return std::make_unique<llama_memory_hybrid_context>(this, mem_attn->init_reserve(n_kv));
+}
+
+uint32_t llama_memory_hybrid::get_attn_reserve_capacity() const {
+    return mem_attn->get_attn_reserve_capacity();
+}
+
 llama_memory_context_ptr llama_memory_hybrid::init_update(llama_context * lctx, bool optimize) {
     return std::make_unique<llama_memory_hybrid_context>(this, lctx, optimize);
 }
@@ -228,6 +236,14 @@ llama_memory_hybrid_context::llama_memory_hybrid_context(llama_memory_hybrid * m
 }
 
 llama_memory_hybrid_context::llama_memory_hybrid_context(
+              llama_memory_hybrid * mem,
+        llama_memory_context_ptr   ctx_attn) :
+    ctx_attn(std::move(ctx_attn)),
+    ctx_recr(mem->get_mem_recr()->init_full()),
+    status(llama_memory_status_combine(this->ctx_attn->get_status(), ctx_recr->get_status())) {
+}
+
+llama_memory_hybrid_context::llama_memory_hybrid_context(
         llama_memory_hybrid * mem,
               llama_context * lctx,
                        bool   optimize) :
@@ -278,6 +294,10 @@ llama_memory_status llama_memory_hybrid_context::get_status() const {
 const llama_ubatch & llama_memory_hybrid_context::get_ubatch() const {
     assert(status == LLAMA_MEMORY_STATUS_SUCCESS);
     return ubatches[i_next];
+}
+
+uint32_t llama_memory_hybrid_context::get_attn_reserve_n_kv() const {
+    return ctx_attn->get_attn_reserve_n_kv();
 }
 
 const llama_kv_cache_context * llama_memory_hybrid_context::get_attn() const {

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -55,6 +55,10 @@ public:
 
     llama_memory_context_ptr init_full() override;
 
+    llama_memory_context_ptr init_reserve(uint32_t n_kv) override;
+
+    uint32_t get_attn_reserve_capacity() const override;
+
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
@@ -108,6 +112,10 @@ public:
     // init full
     explicit llama_memory_hybrid_context(llama_memory_hybrid * mem);
 
+    llama_memory_hybrid_context(
+              llama_memory_hybrid * mem,
+        llama_memory_context_ptr   ctx_attn);
+
     // init update
     explicit llama_memory_hybrid_context(
         llama_memory_hybrid * mem,
@@ -127,6 +135,7 @@ public:
 
     llama_memory_status  get_status() const override;
     const llama_ubatch & get_ubatch() const override;
+    uint32_t get_attn_reserve_n_kv() const override;
 
     //
     // llama_memory_hybrid_context

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -71,6 +71,7 @@ struct llama_memory_context_i {
     // get the status of the memory context - used for error handling and checking if any updates would be applied
     virtual llama_memory_status get_status() const = 0;
 
+    // Maximum physical attention-KV extent needed by every ubatch prepared in this context. Zero means the memory type does not expose a bounded view.
     virtual uint32_t get_attn_reserve_n_kv() const { return 0; }
 };
 
@@ -101,6 +102,7 @@ struct llama_memory_i {
     // simulate full cache, used for allocating worst-case compute buffers
     virtual llama_memory_context_ptr init_full() = 0;
 
+    // Simulate an attention cache whose graph-visible physical extent is bounded by n_kv. Unsupported memory types retain full reservation.
     virtual llama_memory_context_ptr init_reserve(uint32_t n_kv) {
         GGML_UNUSED(n_kv);
         return init_full();

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -70,6 +70,8 @@ struct llama_memory_context_i {
 
     // get the status of the memory context - used for error handling and checking if any updates would be applied
     virtual llama_memory_status get_status() const = 0;
+
+    virtual uint32_t get_attn_reserve_n_kv() const { return 0; }
 };
 
 using llama_memory_context_ptr = std::unique_ptr<llama_memory_context_i>;
@@ -98,6 +100,14 @@ struct llama_memory_i {
 
     // simulate full cache, used for allocating worst-case compute buffers
     virtual llama_memory_context_ptr init_full() = 0;
+
+    virtual llama_memory_context_ptr init_reserve(uint32_t n_kv) {
+        GGML_UNUSED(n_kv);
+        return init_full();
+    }
+
+    // Nonzero only when init_reserve() implements a bounded attention layout.
+    virtual uint32_t get_attn_reserve_capacity() const { return 0; }
 
     // prepare for any pending memory updates, such as shifts, copies, etc.
     // status == LLAMA_MEMORY_STATUS_NO_UPDATE if there is nothing to update

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,6 +206,13 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
         ARGS --test-phase-workspace
     )
 
+    llama_test(
+        test-llama-archs
+        NAME test-live-context-workspace
+        LABEL main
+        ARGS --test-live-context-workspace
+    )
+
     set(MODEL_DIR "${CMAKE_CURRENT_BINARY_DIR}/test-models/")
     file(MAKE_DIRECTORY "${MODEL_DIR}")
 

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -318,6 +318,7 @@ static void test(void) {
         assert(!defaults.recurrent_state_offload);
         assert(defaults.kv_gpu_layers == 0);
         assert(!defaults.phase_aware_workspace);
+        assert(!defaults.live_context_workspace);
 
         common_params placement_params;
         argv = {"binary_name", "-m", "model.gguf", "--no-kv-offload", "--kv-cpu-pinned", "--kv-gpu-layers", "4", "--recurrent-state-offload"};
@@ -363,6 +364,35 @@ static void test(void) {
         assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), phase_params, LLAMA_EXAMPLE_SERVER));
         assert(phase_params.phase_aware_workspace);
         unset_test_env("LLAMA_ARG_PHASE_AWARE_WORKSPACE");
+    }
+
+    {
+        unset_test_env("LLAMA_ARG_LIVE_CONTEXT_WORKSPACE");
+        common_params live_params;
+        argv = {"binary_name", "-m", "model.gguf"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), live_params, LLAMA_EXAMPLE_SERVER));
+        assert(!live_params.live_context_workspace);
+        assert(!common_context_params_to_llama(live_params).live_context_workspace);
+
+        live_params = common_params();
+        argv = {"binary_name", "-m", "model.gguf", "--live-context-workspace"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), live_params, LLAMA_EXAMPLE_SERVER));
+        assert(live_params.live_context_workspace);
+        assert(!live_params.phase_aware_workspace);
+        assert(common_context_params_to_llama(live_params).live_context_workspace);
+
+        live_params = common_params();
+        argv = {"binary_name", "-m", "model.gguf", "--live-context-workspace", "--no-live-context-workspace"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), live_params, LLAMA_EXAMPLE_SERVER));
+        assert(!live_params.live_context_workspace);
+
+        set_test_env("LLAMA_ARG_LIVE_CONTEXT_WORKSPACE", "1");
+        live_params = common_params();
+        argv = {"binary_name", "-m", "model.gguf"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), live_params, LLAMA_EXAMPLE_SERVER));
+        assert(live_params.live_context_workspace);
+        assert(!live_params.phase_aware_workspace);
+        unset_test_env("LLAMA_ARG_LIVE_CONTEXT_WORKSPACE");
     }
 
     {

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -444,6 +444,7 @@ static void test_live_context_workspace_reserve(size_t seed) {
     ctx_params.n_outputs_max = 1;
     ctx_params.n_threads = 4;
     ctx_params.n_threads_batch = 4;
+    ctx_params.phase_aware_workspace = true;
     ctx_params.live_context_workspace = true;
 
     llama_context_ptr ctx(llama_init_from_model(model.get(), ctx_params));
@@ -482,6 +483,51 @@ static void test_live_context_workspace_reserve(size_t seed) {
     const auto contraction = ctx->make_sched_reserve_plan(1, 256);
     GGML_ASSERT(contraction.n_kv == 256);
     ctx->sched_reserve(1, 256);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == size_256);
+
+    const uint32_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(model.get()));
+    const std::vector<llama_token> tokens = get_tokens(10*ctx_params.n_batch, n_vocab, seed);
+    int32_t pos = 0;
+    for (int32_t chunk = 0; chunk < 9; ++chunk) {
+        llama_batch batch = llama_batch_init(ctx_params.n_batch, 0, 1);
+        for (int32_t i = 0; i < (int32_t) ctx_params.n_batch; ++i) {
+            common_batch_add(batch, tokens[pos], pos, { 0 }, i + 1 == (int32_t) ctx_params.n_batch);
+            ++pos;
+        }
+        GGML_ASSERT(llama_decode(ctx.get(), batch) == 0);
+        llama_synchronize(ctx.get());
+        llama_batch_free(batch);
+    }
+
+    const auto runtime_high = ctx->make_sched_reserve_plan(ctx_params.n_batch);
+    GGML_ASSERT(runtime_high.n_tokens == ctx_params.n_batch);
+    GGML_ASSERT(runtime_high.n_kv == 1024);
+
+    GGML_ASSERT(llama_memory_seq_rm(llama_get_memory(ctx.get()), 0, 0, 512));
+    llama_memory_seq_add(llama_get_memory(ctx.get()), 0, 512, pos, -512);
+
+    llama_batch shifted = llama_batch_init(1, 0, 1);
+    common_batch_add(shifted, tokens[pos], pos - 512, { 0 }, true);
+    GGML_ASSERT(llama_decode(ctx.get(), shifted) == 0);
+    llama_synchronize(ctx.get());
+    llama_batch_free(shifted);
+
+    // Logical positions are compacted, but live rows at the physical tail still require the high reserve.
+    const auto physical_high = ctx->make_sched_reserve_plan(0);
+    GGML_ASSERT(physical_high.n_tokens == 1);
+    GGML_ASSERT(physical_high.n_kv == 1024);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) > size_256);
+
+    llama_memory_clear(llama_get_memory(ctx.get()), false);
+    llama_batch short_batch = llama_batch_init(1, 0, 1);
+    common_batch_add(short_batch, tokens[0], 0, { 0 }, true);
+    GGML_ASSERT(llama_decode(ctx.get(), short_batch) == 0);
+    llama_synchronize(ctx.get());
+    llama_batch_free(short_batch);
+
+    const auto runtime_contraction = ctx->make_sched_reserve_plan(0);
+    GGML_ASSERT(runtime_contraction.n_tokens == 1);
+    GGML_ASSERT(runtime_contraction.n_kv == 256);
     GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == size_256);
     GGML_ASSERT(llama_trim_transient_memory(ctx.get()) == 0);
 }

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -424,6 +424,68 @@ static void phase_workspace_count_synchronize(ggml_backend_t backend) {
 static llama_context_ptr make_phase_workspace_context(
         llama_model * model, llama_context_type type, llama_context * other = nullptr);
 
+static void test_live_context_workspace_reserve(size_t seed) {
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_LLAMA, false);
+
+    llama_model_params model_params = llama_model_default_params();
+    model_params.progress_callback = silent_model_load_progress;
+    ggml_backend_dev_t devices[] = { nullptr };
+    model_params.devices = devices;
+
+    size_t tensor_seed = seed;
+    llama_model_ptr model(llama_model_init_from_user(gguf_ctx.get(), set_tensor_data, &tensor_seed, model_params));
+    GGML_ASSERT(model);
+
+    llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 1024;
+    ctx_params.n_batch = 64;
+    ctx_params.n_ubatch = 64;
+    ctx_params.n_seq_max = 1;
+    ctx_params.n_outputs_max = 1;
+    ctx_params.n_threads = 4;
+    ctx_params.n_threads_batch = 4;
+    ctx_params.live_context_workspace = true;
+
+    llama_context_ptr ctx(llama_init_from_model(model.get(), ctx_params));
+    GGML_ASSERT(ctx);
+
+    ggml_backend_sched_t sched = ctx->get_sched();
+    ggml_backend_t backend_cpu = nullptr;
+    for (int i = 0; i < ggml_backend_sched_get_n_backends(sched); ++i) {
+        ggml_backend_t backend = ggml_backend_sched_get_backend(sched, i);
+        if (ggml_backend_dev_type(ggml_backend_get_device(backend)) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+            backend_cpu = backend;
+            break;
+        }
+    }
+    GGML_ASSERT(backend_cpu != nullptr);
+
+    const auto initial = ctx->make_sched_reserve_plan(1, 1);
+    GGML_ASSERT(initial.live_kv);
+    GGML_ASSERT(initial.n_kv_capacity == ctx_params.n_ctx);
+    GGML_ASSERT(initial.n_kv == 256);
+    const size_t size_256 = ggml_backend_sched_get_buffer_size(sched, backend_cpu);
+
+    ctx->sched_reserve(1, 257);
+    const size_t size_512 = ggml_backend_sched_get_buffer_size(sched, backend_cpu);
+    GGML_ASSERT(size_512 > size_256);
+
+    const auto half_bin = ctx->make_sched_reserve_plan(1, 256);
+    GGML_ASSERT(half_bin.n_kv == 512);
+    ctx->sched_reserve(1, 256);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == size_512);
+
+    ctx->sched_reserve(1, 513);
+    const size_t size_1024 = ggml_backend_sched_get_buffer_size(sched, backend_cpu);
+    GGML_ASSERT(size_1024 > size_512);
+
+    const auto contraction = ctx->make_sched_reserve_plan(1, 256);
+    GGML_ASSERT(contraction.n_kv == 256);
+    ctx->sched_reserve(1, 256);
+    GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == size_256);
+    GGML_ASSERT(llama_trim_transient_memory(ctx.get()) == 0);
+}
+
 static void test_phase_workspace_runtime_reserve(size_t seed) {
     gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_LLAMA, false);
 
@@ -1214,6 +1276,7 @@ int main(int argc, char ** argv) {
     ggml_log_level log_level = GGML_LOG_LEVEL_ERROR;
     std::string out;
     bool test_phase_workspace = false;
+    bool test_live_context_workspace = false;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-a") == 0 || strcmp(argv[i], "--arch") == 0) {
@@ -1253,6 +1316,10 @@ int main(int argc, char ** argv) {
             test_phase_workspace = true;
             continue;
         }
+        if (strcmp(argv[i], "--test-live-context-workspace") == 0) {
+            test_live_context_workspace = true;
+            continue;
+        }
     }
     printf("%s: using seed %zu\n", __func__, seed);
 
@@ -1262,6 +1329,10 @@ int main(int argc, char ** argv) {
             test_phase_workspace_mtp_lifecycle(seed);
             test_phase_workspace_mismatched_placement(seed);
             test_phase_workspace_late_pipeline_fallback(seed);
+            return 0;
+        }
+        if (test_live_context_workspace) {
+            test_live_context_workspace_reserve(seed);
             return 0;
         }
         if (!out.empty()) {

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -68,7 +68,7 @@ static void set_tensor_data(struct ggml_tensor * tensor, void * userdata) {
 }
 
 static void usage(char ** argv) {
-    printf("Usage: %s [-a/--arch arch] [-s/--seed seed] [-v/--verbose] [--test-phase-workspace]\n", argv[0]);
+    printf("Usage: %s [-a/--arch arch] [-s/--seed seed] [-v/--verbose] [--test-phase-workspace] [--test-live-context-workspace]\n", argv[0]);
 }
 
 static std::vector<llama_token> get_tokens(const uint32_t n_tokens, const uint32_t n_vocab, const size_t seed){
@@ -424,9 +424,8 @@ static void phase_workspace_count_synchronize(ggml_backend_t backend) {
 static llama_context_ptr make_phase_workspace_context(
         llama_model * model, llama_context_type type, llama_context * other = nullptr);
 
-static void test_live_context_workspace_reserve(size_t seed) {
-    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_LLAMA, false);
-
+static llama_model_ptr make_live_context_workspace_model(llm_arch arch, size_t seed) {
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(arch, false);
     llama_model_params model_params = llama_model_default_params();
     model_params.progress_callback = silent_model_load_progress;
     ggml_backend_dev_t devices[] = { nullptr };
@@ -435,7 +434,10 @@ static void test_live_context_workspace_reserve(size_t seed) {
     size_t tensor_seed = seed;
     llama_model_ptr model(llama_model_init_from_user(gguf_ctx.get(), set_tensor_data, &tensor_seed, model_params));
     GGML_ASSERT(model);
+    return model;
+}
 
+static llama_context_params make_live_context_workspace_params() {
     llama_context_params ctx_params = llama_context_default_params();
     ctx_params.n_ctx = 1024;
     ctx_params.n_batch = 64;
@@ -444,11 +446,18 @@ static void test_live_context_workspace_reserve(size_t seed) {
     ctx_params.n_outputs_max = 1;
     ctx_params.n_threads = 4;
     ctx_params.n_threads_batch = 4;
-    ctx_params.phase_aware_workspace = true;
+    ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
     ctx_params.live_context_workspace = true;
+    return ctx_params;
+}
+
+static void test_live_context_workspace_reserve(size_t seed) {
+    llama_model_ptr model = make_live_context_workspace_model(LLM_ARCH_LLAMA, seed);
+    llama_context_params ctx_params = make_live_context_workspace_params();
 
     llama_context_ptr ctx(llama_init_from_model(model.get(), ctx_params));
     GGML_ASSERT(ctx);
+    GGML_ASSERT(!ctx->get_cparams().phase_aware_workspace);
 
     ggml_backend_sched_t sched = ctx->get_sched();
     ggml_backend_t backend_cpu = nullptr;
@@ -486,7 +495,7 @@ static void test_live_context_workspace_reserve(size_t seed) {
     GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == size_256);
 
     const uint32_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(model.get()));
-    const std::vector<llama_token> tokens = get_tokens(10*ctx_params.n_batch, n_vocab, seed);
+    const std::vector<llama_token> tokens = get_tokens(10 * ctx_params.n_batch, n_vocab, seed);
     int32_t pos = 0;
     for (int32_t chunk = 0; chunk < 9; ++chunk) {
         llama_batch batch = llama_batch_init(ctx_params.n_batch, 0, 1);
@@ -514,7 +523,7 @@ static void test_live_context_workspace_reserve(size_t seed) {
 
     // Logical positions are compacted, but live rows at the physical tail still require the high reserve.
     const auto physical_high = ctx->make_sched_reserve_plan(0);
-    GGML_ASSERT(physical_high.n_tokens == 1);
+    GGML_ASSERT(physical_high.n_tokens == ctx_params.n_batch);
     GGML_ASSERT(physical_high.n_kv == 1024);
     GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) > size_256);
 
@@ -526,10 +535,60 @@ static void test_live_context_workspace_reserve(size_t seed) {
     llama_batch_free(short_batch);
 
     const auto runtime_contraction = ctx->make_sched_reserve_plan(0);
-    GGML_ASSERT(runtime_contraction.n_tokens == 1);
+    GGML_ASSERT(runtime_contraction.n_tokens == ctx_params.n_batch);
     GGML_ASSERT(runtime_contraction.n_kv == 256);
     GGML_ASSERT(ggml_backend_sched_get_buffer_size(sched, backend_cpu) == size_256);
     GGML_ASSERT(llama_trim_transient_memory(ctx.get()) == 0);
+}
+
+static void test_live_context_workspace_iswa_reserve(size_t seed) {
+    llama_model_ptr model = make_live_context_workspace_model(LLM_ARCH_GEMMA4, seed);
+    llama_context_params ctx_params = make_live_context_workspace_params();
+
+    llama_context_ptr ctx(llama_init_from_model(model.get(), ctx_params));
+    GGML_ASSERT(ctx);
+    GGML_ASSERT(!ctx->get_cparams().phase_aware_workspace);
+
+    const auto initial = ctx->make_sched_reserve_plan(1, 1);
+    GGML_ASSERT(initial.live_kv);
+    GGML_ASSERT(initial.n_kv_capacity == ctx_params.n_ctx);
+    GGML_ASSERT(initial.n_kv == 256);
+
+    const uint32_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(model.get()));
+    const std::vector<llama_token> tokens = get_tokens(9 * ctx_params.n_batch, n_vocab, seed);
+    int32_t pos = 0;
+    for (int32_t chunk = 0; chunk < 9; ++chunk) {
+        llama_batch batch = llama_batch_init(ctx_params.n_batch, 0, 1);
+        for (int32_t i = 0; i < (int32_t) ctx_params.n_batch; ++i) {
+            common_batch_add(batch, tokens[pos], pos, { 0 }, i + 1 == (int32_t) ctx_params.n_batch);
+            ++pos;
+        }
+        GGML_ASSERT(llama_decode(ctx.get(), batch) == 0);
+        llama_synchronize(ctx.get());
+        llama_batch_free(batch);
+    }
+
+    const auto runtime = ctx->make_sched_reserve_plan(ctx_params.n_batch);
+    GGML_ASSERT(runtime.n_kv == 1024);
+
+    llama_memory_clear(llama_get_memory(ctx.get()), false);
+    llama_batch short_batch = llama_batch_init(1, 0, 1);
+    common_batch_add(short_batch, tokens[0], 0, { 0 }, true);
+    GGML_ASSERT(llama_decode(ctx.get(), short_batch) == 0);
+    llama_synchronize(ctx.get());
+    llama_batch_free(short_batch);
+
+    const auto contraction = ctx->make_sched_reserve_plan(0);
+    GGML_ASSERT(contraction.n_kv == 256);
+}
+
+static void test_live_context_workspace_unsupported(size_t seed) {
+    llama_model_ptr model = make_live_context_workspace_model(LLM_ARCH_MAMBA, seed);
+    llama_context_params ctx_params = make_live_context_workspace_params();
+
+    llama_context_ptr ctx(llama_init_from_model(model.get(), ctx_params));
+    GGML_ASSERT(ctx);
+    GGML_ASSERT(!ctx->get_cparams().live_context_workspace);
 }
 
 static void test_phase_workspace_runtime_reserve(size_t seed) {
@@ -1379,6 +1438,8 @@ int main(int argc, char ** argv) {
         }
         if (test_live_context_workspace) {
             test_live_context_workspace_reserve(seed);
+            test_live_context_workspace_iswa_reserve(seed);
+            test_live_context_workspace_unsupported(seed);
             return 0;
         }
         if (!out.empty()) {

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -48,6 +48,7 @@
 | `--yarn-beta-slow N` | YaRN: high correction dim or alpha (default: -1.00)<br/>(env: LLAMA_ARG_YARN_BETA_SLOW) |
 | `--yarn-beta-fast N` | YaRN: low correction dim or beta (default: -1.00)<br/>(env: LLAMA_ARG_YARN_BETA_FAST) |
 | `-kvo, --kv-offload, -nkvo, --no-kv-offload` | whether to enable KV cache offloading (default: enabled)<br/>(env: LLAMA_ARG_KV_OFFLOAD) |
+| `--live-context-workspace, --no-live-context-workspace` | for supported attention caches, grow the compute workspace reservation with the padded live physical KV extent instead of reserving the full context up front (default: disabled)<br/>(env: LLAMA_ARG_LIVE_CONTEXT_WORKSPACE) |
 | `--repack, -nr, --no-repack` | whether to enable weight repacking (default: enabled)<br/>(env: LLAMA_ARG_REPACK) |
 | `--no-host` | bypass host buffer allowing extra buffers to be used<br/>(env: LLAMA_ARG_NO_HOST) |
 | `-ctk, --cache-type-k TYPE` | KV cache data type for K<br/>allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1<br/>(default: f16)<br/>(env: LLAMA_ARG_CACHE_TYPE_K) |

--- a/tools/completion/README.md
+++ b/tools/completion/README.md
@@ -131,6 +131,7 @@ llama-completion.exe -m models\gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
 | `--yarn-beta-slow N` | YaRN: high correction dim or alpha (default: -1.00)<br/>(env: LLAMA_ARG_YARN_BETA_SLOW) |
 | `--yarn-beta-fast N` | YaRN: low correction dim or beta (default: -1.00)<br/>(env: LLAMA_ARG_YARN_BETA_FAST) |
 | `-kvo, --kv-offload, -nkvo, --no-kv-offload` | whether to enable KV cache offloading (default: enabled)<br/>(env: LLAMA_ARG_KV_OFFLOAD) |
+| `--live-context-workspace, --no-live-context-workspace` | for supported attention caches, grow the compute workspace reservation with the padded live physical KV extent instead of reserving the full context up front (default: disabled)<br/>(env: LLAMA_ARG_LIVE_CONTEXT_WORKSPACE) |
 | `--repack, -nr, --no-repack` | whether to enable weight repacking (default: enabled)<br/>(env: LLAMA_ARG_REPACK) |
 | `--no-host` | bypass host buffer allowing extra buffers to be used<br/>(env: LLAMA_ARG_NO_HOST) |
 | `-ctk, --cache-type-k TYPE` | KV cache data type for K<br/>allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1<br/>(default: f16)<br/>(env: LLAMA_ARG_CACHE_TYPE_K) |

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -66,6 +66,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--yarn-beta-slow N` | YaRN: high correction dim or alpha (default: -1.00)<br/>(env: LLAMA_ARG_YARN_BETA_SLOW) |
 | `--yarn-beta-fast N` | YaRN: low correction dim or beta (default: -1.00)<br/>(env: LLAMA_ARG_YARN_BETA_FAST) |
 | `-kvo, --kv-offload, -nkvo, --no-kv-offload` | whether to enable KV cache offloading (default: enabled)<br/>(env: LLAMA_ARG_KV_OFFLOAD) |
+| `--live-context-workspace, --no-live-context-workspace` | for supported attention caches, grow the compute workspace reservation with the padded live physical KV extent instead of reserving the full context up front (default: disabled)<br/>(env: LLAMA_ARG_LIVE_CONTEXT_WORKSPACE) |
 | `--repack, -nr, --no-repack` | whether to enable weight repacking (default: enabled)<br/>(env: LLAMA_ARG_REPACK) |
 | `--no-host` | bypass host buffer allowing extra buffers to be used<br/>(env: LLAMA_ARG_NO_HOST) |
 | `-ctk, --cache-type-k TYPE` | KV cache data type for K<br/>allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1<br/>(default: f16)<br/>(env: LLAMA_ARG_CACHE_TYPE_K) |

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1262,8 +1262,25 @@ private:
 
             SLT_TRC(slot, "new slot, n_ctx = %d\n", slot.n_ctx);
 
-            slot.callback_on_release = [this](int id_slot) {
+            const bool trim_live_context = params_base.live_context_workspace;
+            slot.callback_on_release = [this, trim_live_context](int id_slot) {
                 queue_tasks.pop_deferred_task(id_slot);
+
+                if (!trim_live_context) {
+                    return;
+                }
+
+                const bool all_idle = std::all_of(slots.begin(), slots.end(),
+                    [](const server_slot & item) { return !item.is_processing(); });
+                if (all_idle) {
+                    const uint64_t target_released = llama_trim_transient_memory(ctx_tgt);
+                    const uint64_t draft_released = llama_trim_transient_memory(ctx_dft);
+                    if (target_released + draft_released > 0) {
+                        SRV_TRC("trimmed transient backend pools: target %.2f MiB, draft %.2f MiB\n",
+                                target_released/1024.0/1024.0,
+                                draft_released/1024.0/1024.0);
+                    }
+                }
             };
 
             slot.callback_on_reset = [this](const server_slot & slot) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1277,8 +1277,8 @@ private:
                     const uint64_t draft_released = llama_trim_transient_memory(ctx_dft);
                     if (target_released + draft_released > 0) {
                         SRV_TRC("trimmed transient backend pools: target %.2f MiB, draft %.2f MiB\n",
-                                target_released/1024.0/1024.0,
-                                draft_released/1024.0/1024.0);
+                                target_released / 1024.0 / 1024.0,
+                                draft_released / 1024.0 / 1024.0);
                     }
                 }
             };


### PR DESCRIPTION
## Overview

Add default-off live-context attention workspace sizing and safe idle transient-memory trimming.

The scheduler reserves attention workspace from the highest physical KV row required by the prepared batch instead of always reserving the full configured context. Power-of-two bins starting at 256 rows and half-bin hysteresis avoid per-token graph reservation. Unsupported memory types keep the full reservation.

The CUDA VMM allocator can unmap an unused tail at an existing safe boundary. The server requests this trim only after all slots become idle.

This is the narrow live-context part of Bee PR8. Bee-specific KVarN, telemetry, compact masks, stage pools, and experiment infrastructure are not included.

## KV contraction behavior

The reserve is based on physical KV occupancy, not logical token count. The standard KV implementation takes the maximum of every live `used_max_p1()` and every physical row planned by `init_batch`, then pads and caps that extent.

`memory_update` runs before the new batch has physical rows, so an update graph keeps the current safe reserve. After `init_batch` has selected all rows, decode publishes the exact batch bound and can contract automatically. A one-bin drop is held by half-bin hysteresis; larger drops such as 1024 to 256 contract. If live cells remain near the physical tail after a context shift or sequence removal, the reserve correctly remains high even when their logical positions are small. Existing cache reuse or defragmentation must lower that physical high row before contraction is useful; this change does not add a forced defragmentation pass or per-token synchronization.

The focused runtime test now covers phase-aware plus live sizing through real decode, a pending position shift, logical compaction with high physical rows, and automatic contraction on the first short batch after the physical rows are cleared. It is registered as `test-live-context-workspace` in CTest.

## Integration

- Public context option: `--live-context-workspace` and `LLAMA_ARG_LIVE_CONTEXT_WORKSPACE`
- Default-off path keeps the existing post-initialization early return and does not query memory reserve capabilities
- PR30 pinned host-Q8 stores remain cache storage only; graph workspace sizing uses the existing memory abstraction
- PR36 phase-aware target/MTP sharing continues to own scheduler backing and coalesces live KV requests through the same resizable allocator
- PR37 capped MTP remains unchanged
- CUDA/HIP VMM trim synchronizes backend streams before unmapping; HIP only drops a fully idle pool

## Validation

Completed locally:

- Full Release CPU build
- Full Release CUDA build for `sm_120a`
- `test-live-context-workspace`, `test-phase-aware-workspace`, `test-alloc`, and `test-arg-parser`
- Focused live-context test using the CUDA-linked build
- Existing allocator and save/load-state coverage from the initial implementation pass
- Complete local CPU CTest: 63/64 passed. The only failure was `test-tokenizers-ggml-vocabs`, where the external clone contained Git LFS pointer text instead of GGUF payloads; all generated-model, architecture, state, allocator, parser, and workspace tests passed.

The allocator test now uses its own minimal CPU-type device instead of linking a non-exported static CPU registry. This fixes the inherited Windows shared/OpenBLAS link failure seen on PR36 and on the first PR40 CI run while keeping the fixture independent of dynamically loaded backends.

## GPU evidence

One run per exploratory cell on an RTX 5070 Ti (16303 MiB). All comparable cells used `-b 2048 -ub 2048`, pinned-host `Q8_0/Q8_0` KV, no KV offload, recurrent-state offload, zero KV GPU layers, phase-aware workspace off, MTP off, seed 1234, and 500 ms `nvidia-smi` sampling. Prompt processing used 512-token chunks and generation used 64 tokens. Model SHA256: `ca5c3fab5c68a00a7c4fc04a0467946e2069f3cdb073601e7158ae7977e73f6c`.

### Shallow context

Context 8192, actual prompt 4661 tokens:

| Build | Startup / peak / idle MiB | Prompt tok/s | Generation tok/s |
| --- | ---: | ---: | ---: |
| untouched `llama/dev` | 13808 / 13848 / 13848 | 1737.4588 | 40.2013 |
| candidate, option off | 13808 / 13848 / 13848 | 1737.3233 | 40.4280 |
| candidate, live | 13856 / 13896 / 13856 | 1690.7650 | 40.3687 |
| current Bee, live | 13920 / 13964 / 13924 | 1673.0251 | 40.1666 |

Default-off matched baseline VRAM exactly; prompt throughput changed by -0.008% and generation by +0.564%. The opt-in shallow cell exposed a 48 MiB VMM floor and a -2.680% single-run prompt result versus candidate-off; generation changed by -0.147%. Candidate-live was 64-68 MiB below Bee and measured +1.060% prompt and +0.503% generation throughput versus Bee.

### 128K context

Context 131072, actual prompt 128565 tokens:

| Build | Startup / peak / idle MiB | Prompt tok/s | Generation tok/s |
| --- | ---: | ---: | ---: |
| untouched `llama/dev` | 15040 / 15080 / 15080 | 993.5476 | 8.34091 |
| candidate, live | 13856 / 15080 / 15040 | 988.7799 | 8.49773 |
| current Bee, live | 13920 / 15148 / 15108 | 988.2091 | 8.34440 |

Candidate-live reduced startup reservation by 1184 MiB. Peak matched baseline only after growth reached the full physical requirement. Versus baseline, prompt throughput changed by -0.480% and generation by +1.880%. Versus Bee, candidate-live used 64-68 MiB less and measured +0.058% prompt and +1.837% generation throughput.

Observed candidate growth was 13856 -> 13976 -> 14040 -> 14296 -> 15080 MiB.

### 128K lifecycle contraction

Context 131072 with a 32564-token request followed by two 83-token requests:

- Baseline: startup 15040 MiB; long-request peak and idle 15080 MiB; each short request peaked and idled at 15082 MiB.
- Candidate-live: startup 13856 MiB; long-request peak 14040 MiB; first idle 14000 MiB; first short peak 14000 MiB; post-short idle 13858 MiB; second short peak 13868 MiB and idle 13858 MiB.
- Candidate savings were 1184 MiB at startup, 1040 MiB at the long peak, 1082 MiB at the first short peak, 1224 MiB after contraction, and 1214 MiB at the second short peak.
- Long-request throughput changed by -0.546% prompt and +1.413% generation versus baseline.

### Output equivalence

The harness streamed text fragments rather than complete token-ID arrays. Concatenated streamed text was byte-identical across comparable builds:

- Shallow baseline, candidate-off, candidate-live, and Bee: `66613d77c70208df7d187042faaa3b2aedb901f1c3fb5f782213634e44bd1c0e`
- 128K baseline, candidate-live, and Bee: `d4fa919302a14a85203e8fc203c11e1f85a8e9c6455f52fc5902da4f7de75cb4`
- Lifecycle long request, baseline and candidate-live: `4037ee5db7c68cdf5760b3e1eef8c5f23c703f44e7e50f5927413e423df3ace8`
- Each lifecycle short request, baseline and candidate-live: `f129416a36bcf6e2771bafcf95fb26648619e01609be5ed33926f8cdfc60586d`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Codex assisted with implementation, tests, benchmarking, and private-fork submission. The repository owner directed the design and explicitly approved private-fork automation.
