### PR TITLE
ggml-cuda : enable MMQ for cached MoE dispatch

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2240,7 +2240,7 @@ static void ggml_cuda_mul_mat_id_staged(ggml_backend_cuda_context & ctx, ggml_te
     dst->src[0] = &src0_synth;
     dst->src[2] = &ids_synth;
 
-    ggml_cuda_mul_mat_id_impl(ctx, dst, false);
+    ggml_cuda_mul_mat_id_impl(ctx, dst, true);
 
     dst->src[0] = orig_src0;
     dst->src[2] = orig_ids;
@@ -2509,7 +2509,7 @@ static void ggml_cuda_mul_mat_id_cached(ggml_backend_cuda_context & ctx, ggml_te
     dst->src[0] = &src0_synth;
     dst->src[2] = &ids_synth;
 
-    ggml_cuda_mul_mat_id_impl(ctx, dst, false);
+    ggml_cuda_mul_mat_id_impl(ctx, dst, true);
     ggml_cuda_moe_cache_mark_used(cache, stream);
 
     dst->src[0] = orig_src0;


### PR DESCRIPTION
## Overview

Enable the existing batched MMQ path for staged and cached CUDA MoE dispatch. This avoids the generic per-expert fallback during prefill without adding buffers or changing cache synchronization.

## Additional information

Performance with Qwen3.6-35B-A3B Q4_K_M:

- 188 slots at 8K: 2179.01 -> 4257.41 prompt tokens/s (+95.4%).
- 184 slots at 32K: 2304.73 -> 4527.58 prompt tokens/s (+96.4%).
- 48 slots at 8K: 1392.65 -> 1963.29 prompt tokens/s (+41.0%).
- 48 slots at 32K: 1487.13 -> 2092.86 prompt tokens/s (+40.7%).
- Candidate peak VRAM was 36 MiB lower in each direct comparison.

The acceptance comparison used untouched `dbeb350d1` and candidate with identical `-ngl all --moe-expert-cache-size 48 -fit off`, model, context, cache, corpus, and request settings.

- Frozen PPL: `1.0018 +/- 0.00011` -> `1.0020 +/- 0.00013`, a 0.0002 change or 1.17 combined standard errors.
- Varied PPL: `2.2851 +/- 0.10242` -> `2.2860 +/- 0.10226`, a 0.0009 change or 0.006 combined standard errors.
- The 1-token warm request and subsequent 128-token request had correct accounting at both contexts: 7997/31997 cached tokens, 4 evaluated tokens, and 128 returned token IDs.
- Candidate cache proof at 8K: `CUDA_MoE_Cached`, `is_cached=1`; 6012 misses/375 evictions for the warm request and 33129 misses/33006 evictions for the 128-token request.
- Candidate cache proof at 32K: 6591 misses/939 evictions for the warm request and 36258 misses/36150 evictions for the 128-token request.
- `test-moe-cache` passed.

Deterministic base and candidate sequences differ after the shared warm token. The first differences are returned-token index 11 at 8K and index 1 at 32K. This comes from the prefill kernel change: one-token Q4_K decode returns through MMVQ before the `use_mmq` flag is consulted, so decode dispatch is the same on both builds. The PPL results above show no material quality regression.

Pristine `d222767c7` is secondary evidence because it uses `-ngl auto`, while the feature uses all-GPU cache placement. PPL matched pristine at the reported precision. Exact cross-placement token parity is not expected without private-fork PR #30 (`47a1475bd`), which fixes placement-dependent Q8 KV quantization.

The existing `ggml_cuda_moe_cache_mark_used()` call remains after cached dispatch.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Codex implemented and validated the change under the private-fork owner authorization. The repository owner remains responsible for the submitted change.
