### PR TITLE
ggml-cuda: skip duplicate decode sibling prefetch

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2392,7 +2392,7 @@ static void ggml_cuda_mul_mat_id_cached(ggml_backend_cuda_context & ctx, ggml_te
     //    on the OTHER two tensors' caches *now* so they're warm by the time
     //    their dispatch arrives. Each sibling cache has its own copy stream,
     //    so these run in parallel with our own acquires below.
-    if (src0->name[0]) {
+    if ((!is_decode || !ids_cache_hit) && src0->name[0]) {
         static const char * const kinds[3] = {"_up_", "_gate_", "_down_"};
         const char * this_name = src0->name;
         const char * this_kind = nullptr;


### PR DESCRIPTION
## Summary

Skip redundant sibling prefetch passes during single-token MoE decode after the routing-ID cache identifies later siblings. Preserve existing prefill behavior.

## Validation

- `test-moe-cache`: passed
- Untouched `dbeb350d1` and candidate PPL: `1.0018 +/- 0.00011`
- Deterministic raw token IDs and token accounting matched base at 8K and 32K
- Cache misses, evictions, H2D copies, and VRAM matched base
- 48-slot decode: +0.24% at 8K, +0.49% at 32K
- Equal-VRAM decode: neutral at 8K/188 slots and 32K/184 slots
- Combined with routing-ID reuse at `0c5347236`, prefill telemetry matched base and 48-slot decode was +0.31% at 8K and +0.15% at 32K
- All server lifecycles stopped cleanly

AI assistance: Codex assisted with implementation, profiling, and validation.