### PR TITLE
ggml-cuda: reuse cached experts during overflow staging

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2181,7 +2181,8 @@ static ggml_cuda_moe_ids_cache_key ggml_cuda_moe_ids_cache_make_key(const ggml_t
 static void ggml_cuda_mul_mat_id_staged(ggml_backend_cuda_context & ctx, ggml_tensor * dst,
                                         const std::vector<char> & ids_host_bytes,
                                         bool is_decode,
-                                        bool overflow) {
+                                        bool overflow,
+                                        ggml_cuda_moe_cache * cache) {
     const int64_t op_start_us = ggml_time_us();
     ggml_tensor * src0 = dst->src[0];
     ggml_tensor * ids  = dst->src[2];
@@ -2221,14 +2222,27 @@ static void ggml_cuda_mul_mat_id_staged(ggml_backend_cuda_context & ctx, ggml_te
     ggml_cuda_pool_alloc<char> scratch_experts(ctx.pool(), (size_t)n_unique * expert_stride);
 
     const char * src_base = (const char *)src0->data;
-    char       * dst_base = (char *)scratch_experts.get();
-    for (int i = 0; i < n_unique; ++i) {
-        const int32_t eid = unique_experts[i];
-        CUDA_CHECK(cudaMemcpyAsync(
-            dst_base + (size_t)i * expert_stride,
-            src_base + (size_t)eid * expert_stride,
-            expert_stride,
-            cudaMemcpyHostToDevice, stream));
+    bool cache_staged = false;
+    if (overflow && cache) {
+        std::vector<const void *> host_ptrs;
+        host_ptrs.reserve(n_unique);
+        for (int32_t eid : unique_experts) {
+            host_ptrs.push_back(src_base + (size_t)eid * expert_stride);
+        }
+        cache_staged = ggml_cuda_moe_cache_copy_to_staging(
+            cache, host_ptrs.data(), n_unique, expert_stride, scratch_experts.get(), stream);
+    }
+
+    if (!cache_staged) {
+        char * dst_base = (char *)scratch_experts.get();
+        for (int i = 0; i < n_unique; ++i) {
+            const int32_t eid = unique_experts[i];
+            CUDA_CHECK(cudaMemcpyAsync(
+                dst_base + (size_t)i * expert_stride,
+                src_base + (size_t)eid * expert_stride,
+                expert_stride,
+                cudaMemcpyHostToDevice, stream));
+        }
     }
 
     const size_t ids_total_elems = (size_t)ids_ne0 * ids_ne1 * ids_ne2;
@@ -2384,7 +2398,7 @@ static void ggml_cuda_mul_mat_id_cached(ggml_backend_cuda_context & ctx, ggml_te
     }
 
     if (cache == nullptr) {
-        ggml_cuda_mul_mat_id_staged(ctx, dst, *ids_host_bytes, is_decode, false);
+        ggml_cuda_mul_mat_id_staged(ctx, dst, *ids_host_bytes, is_decode, false, nullptr);
         return;
     }
 
@@ -2431,7 +2445,7 @@ static void ggml_cuda_mul_mat_id_cached(ggml_backend_cuda_context & ctx, ggml_te
     if (overflow) {
         // More unique experts than the cache can hold simultaneously.
         // Stage so no slot gets overwritten mid-op.
-        ggml_cuda_mul_mat_id_staged(ctx, dst, *ids_host_bytes, is_decode, true);
+        ggml_cuda_mul_mat_id_staged(ctx, dst, *ids_host_bytes, is_decode, true, cache);
         return;
     }
 
@@ -2495,7 +2509,7 @@ static void ggml_cuda_mul_mat_id_cached(ggml_backend_cuda_context & ctx, ggml_te
     if (any_cache_failure) {
         // Cache had an internal failure (e.g., cudaMemcpyAsync error mid-op).
         // Fall back so we still produce correct output.
-        ggml_cuda_mul_mat_id_staged(ctx, dst, *ids_host_bytes, is_decode, false);
+        ggml_cuda_mul_mat_id_staged(ctx, dst, *ids_host_bytes, is_decode, false, nullptr);
         return;
     }
     const uint64_t acquire_time_us = (uint64_t) (ggml_time_us() - acquire_start_us);

--- a/ggml/src/ggml-cuda/moe-cache.cu
+++ b/ggml/src/ggml-cuda/moe-cache.cu
@@ -686,11 +686,10 @@ struct ggml_cuda_moe_cache {
 
     void *   slot_pool_d;            // device alloc, n_slots * slot_size_bytes
 
-    // Dedicated copy stream so H2D acquires can pipeline with the compute
-    // stream's kernel work. The dispatch hook records `copy_done` after all
-    // acquires for an op finish, then makes the compute stream wait on it.
+    // Dedicated copy stream for cache fills, prefetches, and staging copies.
     cudaStream_t copy_stream;
     cudaEvent_t  compute_done;
+    cudaEvent_t  stage_done;
 
     // Per-slot state.
     std::vector<const void *> slot_to_host;  // [n_slots], nullptr if empty
@@ -804,6 +803,7 @@ struct ggml_cuda_moe_cache * ggml_cuda_moe_cache_init(
     c->slot_pool_d     = nullptr;
     c->copy_stream     = nullptr;
     c->compute_done    = nullptr;
+    c->stage_done      = nullptr;
     c->access_counter  = 0;
     c->source_is_mmap  = source_is_mmap;
     c->l2_budget_bytes = l2_budget_bytes;
@@ -830,6 +830,17 @@ struct ggml_cuda_moe_cache * ggml_cuda_moe_cache_init(
     err = cudaEventCreateWithFlags(&c->compute_done, cudaEventDisableTiming);
     if (err != cudaSuccess) {
         fprintf(stderr, "moe-cache: cudaEventCreate failed: %s\n", cudaGetErrorString(err));
+        cudaStreamDestroy(c->copy_stream);
+        cudaFree(c->slot_pool_d);
+        delete c;
+        cudaSetDevice(prev_device);
+        return nullptr;
+    }
+
+    err = cudaEventCreateWithFlags(&c->stage_done, cudaEventDisableTiming);
+    if (err != cudaSuccess) {
+        fprintf(stderr, "moe-cache: cudaEventCreate failed: %s\n", cudaGetErrorString(err));
+        cudaEventDestroy(c->compute_done);
         cudaStreamDestroy(c->copy_stream);
         cudaFree(c->slot_pool_d);
         delete c;
@@ -883,6 +894,9 @@ void ggml_cuda_moe_cache_free(struct ggml_cuda_moe_cache * cache) {
     }
     if (cache->compute_done) {
         cudaEventDestroy(cache->compute_done);
+    }
+    if (cache->stage_done) {
+        cudaEventDestroy(cache->stage_done);
     }
     if (cache->slot_pool_d) {
         cudaFree(cache->slot_pool_d);
@@ -1158,6 +1172,50 @@ int ggml_cuda_moe_cache_acquire(
     }
 
     return lru_slot;
+}
+
+extern "C"
+bool ggml_cuda_moe_cache_copy_to_staging(
+    struct ggml_cuda_moe_cache * cache,
+    const void * const * host_srcs,
+    int                  n_host_srcs,
+    size_t               byte_count,
+    void *               dst,
+    cudaStream_t         compute_stream) {
+
+    if (!cache || !host_srcs || n_host_srcs <= 0 || byte_count == 0 || !dst || !compute_stream) {
+        return false;
+    }
+    for (int i = 0; i < n_host_srcs; ++i) {
+        if (!host_srcs[i]) {
+            return false;
+        }
+    }
+
+    std::lock_guard<std::mutex> lk(cache->mu);
+    if (byte_count > cache->slot_size_bytes) {
+        return false;
+    }
+
+    CUDA_CHECK(cudaEventRecord(cache->compute_done, compute_stream));
+    CUDA_CHECK(cudaStreamWaitEvent(cache->copy_stream, cache->compute_done, 0));
+
+    for (int i = 0; i < n_host_srcs; ++i) {
+        const auto it = cache->host_to_slot.find(host_srcs[i]);
+        const bool resident = it != cache->host_to_slot.end();
+        const void * src = resident ?
+            (const char *)cache->slot_pool_d + (size_t)it->second * cache->slot_size_bytes : host_srcs[i];
+        CUDA_CHECK(cudaMemcpyAsync(
+            (char *)dst + (size_t)i * byte_count,
+            src,
+            byte_count,
+            resident ? cudaMemcpyDeviceToDevice : cudaMemcpyHostToDevice,
+            cache->copy_stream));
+    }
+
+    CUDA_CHECK(cudaEventRecord(cache->stage_done, cache->copy_stream));
+    CUDA_CHECK(cudaStreamWaitEvent(compute_stream, cache->stage_done, 0));
+    return true;
 }
 
 extern "C"

--- a/ggml/src/ggml-cuda/moe-cache.cuh
+++ b/ggml/src/ggml-cuda/moe-cache.cuh
@@ -66,6 +66,16 @@ int ggml_cuda_moe_cache_acquire(
     bool         is_decode,
     bool         is_prefetch);
 
+// Copy host slabs into consecutive staging slots, using resident cache slots when available.
+// Returns false without enqueuing work if the arguments are invalid.
+bool ggml_cuda_moe_cache_copy_to_staging(
+    struct ggml_cuda_moe_cache * cache,
+    const void * const * host_srcs,
+    int                  n_host_srcs,
+    size_t               byte_count,
+    void *               dst,
+    cudaStream_t         compute_stream);
+
 void ggml_cuda_moe_record_op_stats(
     bool     is_decode,
     bool     staged,

--- a/tests/test-moe-cache.cpp
+++ b/tests/test-moe-cache.cpp
@@ -9,6 +9,7 @@
 //   4. No expert is ever resident in two slots simultaneously.
 //   5. Hit rate for a Zipf-ish access pattern is non-trivial (>40%).
 //   6. Registry keys distinguish tensors that have the same name.
+//   7. Cache-assisted staging orders mixed D2D and H2D copies after prior compute.
 //
 // The workload is a synthetic stand-in for MoE routing: most tokens land on a
 // hot subset of experts. Real Gemma 4 / Mixtral / Qwen3 routing has stronger
@@ -19,13 +20,16 @@
 #include <cuda_runtime.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <random>
+#include <thread>
 #include <vector>
 
 #define CHECK(cond) do { \
@@ -59,6 +63,19 @@ static int sample_zipf(std::mt19937 & rng, int n, double s) {
     double r = u(rng);
     auto it = std::lower_bound(cdf.begin(), cdf.end(), r);
     return (int)(it - cdf.begin());
+}
+
+struct host_barrier {
+    std::atomic<bool> entered{false};
+    std::atomic<bool> released{false};
+};
+
+static void CUDART_CB wait_on_host_barrier(void * data) {
+    auto * barrier = static_cast<host_barrier *>(data);
+    barrier->entered.store(true, std::memory_order_release);
+    while (!barrier->released.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
 }
 
 int main(int argc, char ** argv) {
@@ -154,6 +171,62 @@ int main(int argc, char ** argv) {
     CHECK(hits + misses == (uint64_t)(N_ACCESS + N_EXPERTS));
 
     ggml_cuda_moe_cache_free(cache);
+
+    auto * staging_cache = ggml_cuda_moe_cache_init(dev, SLOT_BYTES, 1, false, 0, 0);
+    CHECK(staging_cache != nullptr);
+    cudaStream_t staging_copy_stream = ggml_cuda_moe_cache_copy_stream(staging_cache);
+    CHECK(staging_copy_stream != nullptr);
+
+    const void * resident_src = host_experts;
+    const void * nonresident_src = host_experts + N_FLOATS;
+    CHECK(ggml_cuda_moe_cache_acquire(
+        staging_cache, resident_src, SLOT_BYTES, staging_copy_stream, false, false, false) == 0);
+    CUDA_OK(cudaStreamSynchronize(staging_copy_stream));
+
+    cudaStream_t compute_stream = nullptr;
+    CUDA_OK(cudaStreamCreateWithFlags(&compute_stream, cudaStreamNonBlocking));
+    void * staging_dst = nullptr;
+    CUDA_OK(cudaMalloc(&staging_dst, 2 * SLOT_BYTES));
+    const void * staging_srcs[] = {resident_src, nonresident_src};
+    std::vector<float> staging_readback(2 * N_FLOATS);
+
+    for (int repeat = 0; repeat < 2; ++repeat) {
+        float nonresident_value = 100.0f + repeat;
+        std::fill_n(host_experts + N_FLOATS, N_FLOATS, nonresident_value);
+
+        host_barrier barrier;
+        CUDA_OK(cudaLaunchHostFunc(compute_stream, wait_on_host_barrier, &barrier));
+        while (!barrier.entered.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+
+        CHECK(ggml_cuda_moe_cache_copy_to_staging(
+            staging_cache, staging_srcs, 2, SLOT_BYTES, staging_dst, compute_stream));
+        cudaError_t staging_copy_status = cudaErrorNotReady;
+        for (int attempt = 0; attempt < 100 && staging_copy_status == cudaErrorNotReady; ++attempt) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            staging_copy_status = cudaStreamQuery(staging_copy_stream);
+        }
+        CHECK(staging_copy_status == cudaErrorNotReady);
+
+        barrier.released.store(true, std::memory_order_release);
+        CUDA_OK(cudaStreamSynchronize(compute_stream));
+        CUDA_OK(cudaStreamSynchronize(staging_copy_stream));
+        CUDA_OK(cudaMemcpy(staging_readback.data(), staging_dst, 2 * SLOT_BYTES, cudaMemcpyDeviceToHost));
+        for (int j = 0; j < N_FLOATS; ++j) {
+            CHECK(staging_readback[j] == 0.0f);
+            CHECK(staging_readback[N_FLOATS + j] == nonresident_value);
+        }
+    }
+
+    CHECK(!ggml_cuda_moe_cache_copy_to_staging(
+        staging_cache, staging_srcs, 2, SLOT_BYTES + 1, staging_dst, compute_stream));
+    CHECK(cudaStreamQuery(staging_copy_stream) == cudaSuccess);
+    CHECK(cudaStreamQuery(compute_stream) == cudaSuccess);
+
+    CUDA_OK(cudaFree(staging_dst));
+    CUDA_OK(cudaStreamDestroy(compute_stream));
+    ggml_cuda_moe_cache_free(staging_cache);
 
     auto * registry_cache_a = ggml_cuda_moe_cache_get_or_create_for_tensor(
         dev, host_experts, SLOT_BYTES, 1, 1, "duplicate.name");


### PR DESCRIPTION
Stacked on #42. Reuse resident expert-cache slabs when an MoE operation exceeds cache capacity, while staging nonresident slabs from host memory. Add stream ordering and focused mixed D2D/H2D regression coverage. Validation: exact 8K/32K tokens and matched-parent PPL; cache48 prefill +2.15% at 8K and +1.95% at 32K with equal VRAM; Compute Sanitizer reports zero errors.