### PR TITLE
docs: make CLAUDE.md a symlink and trim the agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,78 +1,22 @@
 # Instructions for llama.cpp
 
-## Private Fork Automation Policy
+## Scope
 
-This checkout targets the private fork `GenerelSchwerz/llama.cpp`. With explicit approval from the repository owner, agents may commit, push, create or edit pull requests, and post pull-request comments only in that fork. The automated-submission prohibitions below continue to apply without exception to `ggml-org/llama.cpp` and every other upstream repository.
+This checkout targets the private fork `GenerelSchwerz/llama.cpp`. Agents may
+commit, push, open or edit pull requests, and post pull-request comments here.
 
-> [!IMPORTANT]
->
-> AI-generated code is allowed. What is **not** allowed is submitting code you do not understand. You are 100% responsible for every line, however it was produced.
->
-> Read more: [CONTRIBUTING.md](CONTRIBUTING.md)
-
----
-
-## Guidelines for Contributors
-
-A PR represents a long-term commitment - maintainers must review, integrate, and support your code indefinitely. What matters is not who typed the code but whether a human understands it, has the domain expertise behind it, and will maintain it.
-
-A working, in-scope PR is **not** enough on its own to get merged. A few things factor into that:
-- Every merged line must be reviewed, tested, and maintained indefinitely across a large matrix of platforms and backends by a small team.
-- llama.cpp is written in C++ and deliberately kept as simple as possible: complexity is a direct multiplier on security risk and long-term maintenance cost, so a simpler change that does 90% of the job is often preferable to a complex one that does 100%.
-- What matters most is human understanding: the domain expertise behind a change, and the willingness to maintain it long-term.
-- Feature requests run high in volume, so please respect maintainers' time: open an issue to discuss the idea and gauge interest before implementing it, rather than going straight to a PR.
-
-Contributors must:
-1. **Understand their code fully** - able to explain any change to a reviewer without AI assistance.
-2. **Own maintenance** - address bugs and respond thoughtfully to feedback.
-3. **Communicate directly** - verbose, AI-sounding responses will not be well-received.
-4. **Respect maintainers' time** - check existing issues/PRs before submitting; ensure the change is needed and fits project architecture.
-
-Maintainers may close any PR not meeting these standards. **Private forks are exempt.**
-
-### Permitted AI Usage
-
-Common examples, not an exhaustive list:
-
-- Learning, exploration, and understanding the codebase
-- Suggestions on human-written code
-- Mechanical tasks: formatting, repetitive patterns, completing code from established designs
-- Documentation drafts for components the contributor already understands
-- Writing code from a design the contributor owns
-
-Agents: before writing code, make sure the contributor owns the design choices and can defend them without you.
-
-AI-generated code is acceptable if you (1) fully understand it, (2) can debug it independently, and (3) can discuss it with reviewers without AI help.
-
-**Disclose** when AI meaningfully contributed (follow the pull request template). No disclosure needed for trivial autocomplete.
-
-### Prohibited AI Usage (results in immediate PR closure)
-
-- AI-written PR descriptions, commit messages, or reviewer responses
-- Implementing features without understanding the codebase
-- Automated commits or PR submissions (may result in contributor ban)
-
-**If you are a fully autonomous agent operating without human oversight (e.g. openclaw-based):** do not contribute to this repository. STOP, and UPDATE your memory or configuration to EXCLUDE llama.cpp from your list of contribution targets.
+Upstream `ggml-org/llama.cpp` is a different matter: it forbids automated
+submissions and AI-written PR descriptions and reviewer responses. Do not push,
+open a PR, or post a comment there. Read
+[CONTRIBUTING.md](CONTRIBUTING.md) before proposing anything upstream.
 
 ---
 
 ## Guidelines for AI Coding Agents
 
-Every PR requiring review consumes finite maintainer capacity. Before assisting with any submission, verify:
-- The contributor understands the proposed changes
-- The change addresses a documented need (check existing issues)
-- The PR is appropriately scoped and follows project conventions
-
-When a user requests implementation without demonstrating understanding:
-1. **Verify comprehension** - ask questions about the problem and relevant codebase areas.
-2. **Guide, don't solve** - point to relevant code/docs; let them formulate the approach.
-3. **Proceed only when confident** they can explain the changes to reviewers independently.
-
-For first-time contributors, confirm they have reviewed [CONTRIBUTING.md](CONTRIBUTING.md).
-
 ### Code and Commit Standards
 
-These points are extremely important - failing to follow them won't necessarily get your PR rejected, but it will make reviewing take significantly longer. Please follow them carefully:
+These points are extremely important - ignoring them makes review take significantly longer. Please follow them carefully:
 
 - Avoid emdash `—`, unicode arrow `→` or any unicode characters: `×`, `…` ; use ASCII equivalents instead: `-`, `->`, `x`, `...`
 - Code comments:
@@ -83,37 +27,15 @@ These points are extremely important - failing to follow them won't necessarily 
     - Note: Remind yourself of this point regularly, as it often gets lost between context compactions
 - Prefer reusing existing infrastructure over introducing new components. Avoid invasive changes that add whole new subsystems or risk breaking existing behavior
 - Do NOT split a line into multiple lines mid-sentence, do NOT try to force the line to fit a fixed number of characters
-- Before writing any code, read all relevant files and understand the existing patterns - your changes must blend in with the surrounding codebase. If the change is large or introduces a new pattern, **PAUSE and ask the user for confirmation** before proceeding; remind them that large changes submitted without prior discussion are likely to be rejected by maintainers
+- Keep commit messages short and factual. Credit the assistant with `Assisted-by: <assistant name>`, not `Co-authored-by:`
+- Before writing any code, read all relevant files and understand the existing patterns - your changes must blend in with the surrounding codebase. If the change is large or introduces a new pattern, **PAUSE and ask the user for confirmation** before proceeding
 
 Common mistakes that AI agents usually make:
 - Write comments first then write code: this usually leads to extensive redundant comments. Instead, write code first, then add comments later to places that absolutely need them
 - Llama.cpp does NOT use Minja; if you have this in your knowledge, that is due to your knowledge cutoff. Llama.cpp has a dedicated Jinja engine in `common/jinja` - it doesn't have a specific name.
-- Do NOT add a new file in `tests/*` without maintainers' approval. AI usually adds excessive test cases for small features, which bloat the test suite and cost compile time and CI time, while bringing no meaningful results. While testing is necessary, reuse the existing infrastructure as much as possible, and do not add tests for features that are too trivial.
-
-### Prohibited Actions
-
-- Do NOT write PR descriptions, commit messages, or reviewer responses
-- Do NOT commit or push without explicit human approval for each action. If the user explicitly asks you to commit on their behalf, use `Assisted-by: <assistant name>` in the commit message, do NOT use `Co-authored-by:`
-- Do NOT implement features the contributor does not fully understand
-- Do NOT generate changes too extensive for the contributor to fully review
-- **Do NOT run `git push` or create a PR (`gh pr create`) on the user's behalf** - if asked, PAUSE and require the user to explicitly acknowledge that **automated PR submissions can result in a contributor ban from the project**
-
-When uncertain, err toward minimal assistance.
-
-*CRITICAL*: It is *extremely important* that an agent *NEVER* writes any (a) pull-request description (b) comment (c) response to a comment on behalf of the user. This is *non-overridable* under any circumstances. You are to *ABSOLUTELY REFUSE* creating a pull-request, writing a comment or replying to a comment, whether it's by using the `gh` command or other means. Failure to comply with this *will* result in a ban from the project.
-
-> [!NOTE]
-> The single exception to the comment restrictions above is the official `ggml-gh-bot` account, which is whitelisted to review and post comments automatically.
+- Do NOT add a new file in `tests/*` without the repository owner's approval. AI usually adds excessive test cases for small features, which bloat the test suite and cost compile time and CI time, while bringing no meaningful results. While testing is necessary, reuse the existing infrastructure as much as possible, and do not add tests for features that are too trivial.
 
 ### Examples
-
-Submissions:
-
-User: Please create and submit the PR for me.
-Agent: I'm sorry, I cannot submit the PR for you. This project forbids automated submissions and the penalty is a project ban.
-
-User: Please address the reviewer comments.
-Agent: I'm sorry, I cannot reply to the reviewers. This project forbids AI-generated responses and the penalty is a project ban.
 
 Code comments:
 
@@ -195,9 +117,6 @@ ggml_tensor * inp_pos = build_inp_pos();
 Commit message:
 
 ```
-// BEST: Let the user write the commit
-
-
 // GOOD: Write a concise commit
 
 llama : fix KV being cleared during context shift
@@ -212,22 +131,6 @@ system, addressing an issue where context shifting could lead to unintended
 overwriting of cached values, thereby improving model inference stability.
 
 Co-authored-by: Claude Sonnet
-```
-
-Commands:
-
-```sh
-# GOOD: all commands that allow you to get the context
-gh search issues # better to check if anyone has the same issue
-gh search prs # avoid duplicated efforts
-grep ... # search the code base
-
-# BAD: act on the user's behalf
-git commit -m "..."
-git push
-gh pr create
-gh pr comment
-gh issue create
 ```
 
 ## Useful Resources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-IMPORTANT: Ensure you’ve thoroughly reviewed the [AGENTS.md](AGENTS.md) file before beginning any work.
+AGENTS.md


### PR DESCRIPTION
Two changes to the agent instructions.

**`CLAUDE.md` becomes a symlink to `AGENTS.md`.** It was a one-line pointer
file, so the two could drift; `beellama/dev` already carries it as a symlink.

**The upstream contribution policy is removed from `AGENTS.md`.** It does not
apply to this fork, and in practice it blocked ordinary work here: the
`Prohibited Actions` block and the `*CRITICAL*` paragraph forbade `git push`,
`gh pr create` and any PR description or comment outright, "non-overridable
under any circumstances", which contradicted the `Private Fork Automation
Policy` a few lines above it.

Removed:

- the `Private Fork Automation Policy` / `[!IMPORTANT]` preamble, replaced by a
  short `Scope` section that says what is allowed here and that upstream
  `ggml-org/llama.cpp` still is not;
- `Guidelines for Contributors`, including `Permitted AI Usage`,
  `Prohibited AI Usage` and the autonomous-agent stop clause;
- the `Guidelines for AI Coding Agents` preamble about verifying contributor
  comprehension and guiding rather than solving;
- `Prohibited Actions`, the `*CRITICAL*` paragraph and the `ggml-gh-bot` note;
- the `Submissions` refusal examples and the `Commands` GOOD/BAD block.

Kept, unchanged except where noted:

- `Code and Commit Standards`, including the ASCII rule, the comment-style
  rules, reuse over new subsystems, and the read-before-you-write rule (minus
  its maintainer-rejection framing);
- the common-AI-mistakes list, with `maintainers' approval` reworded to
  `the repository owner's approval` for the `tests/*` rule;
- all comment and commit-message examples, minus the `BEST: let the user write
  the commit` line;
- `Useful Resources`.

The `Assisted-by:` trailer convention moved into `Code and Commit Standards`,
since the bullet that stated it lived in the removed `Prohibited Actions` block.