### PR TITLE
completion : allow the prompt to be processed under its own split mode

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -898,6 +898,12 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         throw std::invalid_argument("error: --prompt-cache-all not supported in interactive mode yet\n");
     }
 
+    // the switch reloads the model, so it needs a moment where nothing is generating, and it carries
+    // one sequence. neither holds once several sequences share the context
+    if (params.prefill_split_mode >= 0 && params.n_parallel != 1) {
+        throw std::invalid_argument("error: --prefill-split-mode requires --parallel 1\n");
+    }
+
     const bool skip_model_download =
         // server will call common_params_handle_models() later, so we skip it here
         ctx_arg.ex == LLAMA_EXAMPLE_SERVER ||
@@ -2922,7 +2928,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 throw std::invalid_argument("invalid value");
             }
         }
-    ).set_env("LLAMA_ARG_PREFILL_SPLIT_MODE"));
+    ).set_env("LLAMA_ARG_PREFILL_SPLIT_MODE").set_examples({LLAMA_EXAMPLE_COMPLETION}));
     add_opt(common_arg(
         {"-ts", "--tensor-split"}, "N0,N1,N2,...",
         "fraction of the model to offload to each GPU, comma-separated list of proportions, e.g. 3,1",

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2904,6 +2904,26 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_SPLIT_MODE"));
     add_opt(common_arg(
+        {"-psm", "--prefill-split-mode"}, "{none,layer,row,tensor}",
+        "split mode to process the prompt under, before switching to --split-mode to generate. The model is "
+        "reloaded once between the two phases and the cache is carried over. A large batch pays for the "
+        "collective a tensor split needs and a single token does not, so the two phases can prefer different "
+        "modes (default: use --split-mode throughout)",
+        [](common_params & params, const std::string & value) {
+            if (value == "none") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_NONE;
+            } else if (value == "layer") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_LAYER;
+            } else if (value == "row") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_ROW;
+            } else if (value == "tensor") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_TENSOR;
+            } else {
+                throw std::invalid_argument("invalid value");
+            }
+        }
+    ).set_env("LLAMA_ARG_PREFILL_SPLIT_MODE"));
+    add_opt(common_arg(
         {"-ts", "--tensor-split"}, "N0,N1,N2,...",
         "fraction of the model to offload to each GPU, comma-separated list of proportions, e.g. 3,1",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -494,6 +494,7 @@ struct common_params {
     std::vector<size_t> fit_params_target = std::vector<size_t>(llama_max_devices(), 1024 * 1024*1024);
 
     enum llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER; // how to split the model across GPUs
+    int32_t prefill_split_mode = -1; // split mode to process the prompt under, -1 to use split_mode throughout
     enum llama_load_mode  load_mode  = LLAMA_LOAD_MODE_AUTO; // how to load the model
 
     enum llama_lazy_mode lazy_mode = LLAMA_LAZY_MODE_AUTO; // on-demand reading of tensors marked by the arch

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1700,9 +1700,15 @@ static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_bac
     std::vector<ggml_backend_buffer_t> bufs;
     bufs.reserve(n_simple_bufts);
     for (size_t i = 0; i < n_simple_bufts; i++) {
-        bufs.push_back(ggml_backend_buft_alloc_buffer(ggml_backend_meta_buft_simple_buft(buft, i), size));
-        GGML_ASSERT(bufs.back() != nullptr);
-        max_size = std::max(max_size, ggml_backend_buffer_get_size(bufs.back()));
+        ggml_backend_buffer_t buf = ggml_backend_buft_alloc_buffer(ggml_backend_meta_buft_simple_buft(buft, i), size);
+        if (buf == nullptr) {
+            for (ggml_backend_buffer_t b : bufs) {
+                ggml_backend_buffer_free(b);
+            }
+            return nullptr;
+        }
+        bufs.push_back(buf);
+        max_size = std::max(max_size, ggml_backend_buffer_get_size(buf));
     }
     ggml_backend_meta_buffer_context * buf_ctx = new ggml_backend_meta_buffer_context(stc_static, stc_compute_0, stc_compute_1, bufs);
 
@@ -1757,7 +1763,10 @@ struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struc
                 t->buffer = meta_buf_ctx->bufs[i].get();
             }
         }
-        GGML_ASSERT(meta_buf_ctx->bufs[i]);
+        if (meta_buf_ctx->bufs[i] == nullptr) {
+            ggml_backend_buffer_free(meta_buf);
+            return nullptr;
+        }
         meta_buf->size = std::max(meta_buf->size, ggml_backend_buffer_get_size(meta_buf_ctx->bufs[i].get()));
     }
     return meta_buf;

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -140,6 +140,15 @@ int llama_completion(int argc, char ** argv) {
     // load the model and apply lora adapter, if any
     LOG_INF("%s: load the model and apply lora adapter, if any\n", __func__);
 
+    // the prompt and the generation want different things from a multi-GPU split, so the prompt may
+    // be processed under a mode of its own and the model reloaded once in between
+    const llama_split_mode split_mode_gen = params.split_mode;
+    bool split_mode_switch_pending = false;
+    if (params.prefill_split_mode >= 0 && (llama_split_mode) params.prefill_split_mode != params.split_mode) {
+        params.split_mode = (llama_split_mode) params.prefill_split_mode;
+        split_mode_switch_pending = true;
+    }
+
     auto llama_init = common_init_from_params(params);
 
     ctx   = llama_init->context();
@@ -663,6 +672,48 @@ int llama_completion(int argc, char ** argv) {
 
         embd.clear();
 
+        // All of the prompt but its last token is in the cache now, so move the cache to host
+        // memory, reload the model under the generation split mode and put it back. The last token
+        // is left for the reloaded model to decode, which is what produces the logits to sample
+        // from. The reload frees the old model first, the two never hold device memory at once.
+        if (split_mode_switch_pending && n_consumed >= (int) embd_inp.size() - 1) {
+            split_mode_switch_pending = false;
+
+            const size_t state_size = llama_state_seq_get_size(ctx, 0);
+            std::vector<uint8_t> state(state_size);
+            if (llama_state_seq_get_data(ctx, state.data(), state_size, 0) != state_size) {
+                LOG_ERR("%s: failed to read the sequence state before the split mode switch\n", __func__);
+                return 1;
+            }
+            LOG_INF("%s: switching split mode for generation, carrying %.2f MiB of state\n",
+                    __func__, state_size/1024.0/1024.0);
+
+            llama_init.reset(); // free the device memory before asking for it again
+            ctx = nullptr; model = nullptr; smpl = nullptr;
+
+            params.split_mode = split_mode_gen;
+            llama_init = common_init_from_params(params);
+            ctx   = llama_init->context();
+            model = llama_init->model();
+            smpl  = llama_init->sampler(0);
+            if (ctx == NULL) {
+                LOG_ERR("%s: failed to reload the model under the generation split mode\n", __func__);
+                return 1;
+            }
+            mem   = llama_get_memory(ctx);
+            vocab = llama_model_get_vocab(model);
+            chat_templates = common_chat_templates_init(model, params.chat_template);
+
+            if (llama_state_seq_set_data(ctx, state.data(), state_size, 0) != state_size) {
+                LOG_ERR("%s: failed to restore the sequence state after the split mode switch\n", __func__);
+                return 1;
+            }
+            // the new sampler has not seen the prompt, so the repetition penalties would start empty
+            for (int i = 0; i < n_consumed; i++) {
+                common_sampler_accept(smpl, embd_inp[i], /* accept_grammar= */ false);
+            }
+        }
+
         if ((int) embd_inp.size() <= n_consumed && !is_interacting) {
 
             const llama_token id = common_sampler_sample(smpl, ctx, -1);
@@ -687,7 +738,8 @@ int llama_completion(int argc, char ** argv) {
         } else {
             // some user input remains from prompt or interaction, forward it to processing
             LOG_DBG("embd_inp.size(): %d, n_consumed: %d\n", (int) embd_inp.size(), n_consumed);
-            while ((int) embd_inp.size() > n_consumed) {
+            const int n_prompt_avail = (int) embd_inp.size() - (split_mode_switch_pending ? 1 : 0);
+            while (n_prompt_avail > n_consumed) {
                 embd.push_back(embd_inp[n_consumed]);
 
                 // push the prompt in the sampling context in order to apply repetition penalties later

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -144,9 +144,15 @@ int llama_completion(int argc, char ** argv) {
     // be processed under a mode of its own and the model reloaded once in between
     const llama_split_mode split_mode_gen = params.split_mode;
     bool split_mode_switch_pending = false;
+    std::vector<float> tensor_split_arg;
+    std::vector<llama_model_tensor_buft_override> tensor_buft_overrides_arg;
     if (params.prefill_split_mode >= 0 && (llama_split_mode) params.prefill_split_mode != params.split_mode) {
         params.split_mode = (llama_split_mode) params.prefill_split_mode;
         split_mode_switch_pending = true;
+        // the fit writes the placement it found back into these, and a placement that suits one
+        // split mode does not suit the other. keep the arguments so the second load can fit again
+        tensor_split_arg.assign(std::begin(params.tensor_split), std::end(params.tensor_split));
+        tensor_buft_overrides_arg = params.tensor_buft_overrides;
     }
 
     auto llama_init = common_init_from_params(params);
@@ -691,13 +697,31 @@ int llama_completion(int argc, char ** argv) {
             llama_init.reset(); // free the device memory before asking for it again
             ctx = nullptr; model = nullptr; smpl = nullptr;
 
-            params.split_mode = split_mode_gen;
-            llama_init = common_init_from_params(params);
+            auto load_under = [&](llama_split_mode sm) {
+                params.split_mode = sm;
+                params.n_ctx      = n_ctx; // both phases must agree, the state is restored into the second one
+                std::copy(tensor_split_arg.begin(), tensor_split_arg.end(), params.tensor_split);
+                params.tensor_buft_overrides = tensor_buft_overrides_arg;
+                return common_init_from_params(params);
+            };
+
+            llama_init = load_under(split_mode_gen);
+            if (llama_init->context() == NULL) {
+                // the generation split mode does not fit on the devices. the prompt is still in the
+                // state we just read, so finish the request under the mode that already fit
+                LOG_WRN("%s: the generation split mode does not fit, generating under the prefill split mode\n", __func__);
+                llama_init.reset(); // release what the failed attempt still holds before retrying
+                llama_init = load_under((llama_split_mode) params.prefill_split_mode);
+            }
             ctx   = llama_init->context();
             model = llama_init->model();
             smpl  = llama_init->sampler(0);
             if (ctx == NULL) {
                 LOG_ERR("%s: failed to reload the model under the generation split mode\n", __func__);
+                return 1;
+            }
+            if ((int) llama_n_ctx(ctx) != n_ctx) {
+                LOG_ERR("%s: the reloaded context is %d tokens, expected %d\n", __func__, (int) llama_n_ctx(ctx), n_ctx);
                 return 1;
             }
             mem   = llama_get_memory(ctx);


### PR DESCRIPTION
Processes the prompt under one split mode and generates under another, because the two phases
do not want the same thing from a multi-GPU split.

## Why

Tensor parallelism splits every layer across the devices and pays for a collective per layer.
The cost of that collective scales with the batch, the benefit does not: at a batch of one
there is almost nothing to exchange and both devices work on the same token, while at a
prompt-sized batch the exchange dominates. A layer split is the mirror image - no collective
at all, but the devices run one after the other, so a single token gets no parallelism.

Measured on an RTX 4070 + RTX 3060, `Qwen3.8-27B-UD-Q5_K_M`, a 58.3k-token prompt at
`-c 65536` with a q8_0 device-resident cache:

| `-sm` | prefill | generation |
| --- | ---: | ---: |
| `tensor -ts 50,50` | 507.92 t/s | **19.76 t/s** |
| `layer` | **807.57 t/s** | 14.80 t/s |

Layer prefills 59% faster, tensor generates 34% faster.

Prefill wants the layer split, generation wants the tensor split, and the gap is large in
both directions. Nothing in the design forces one choice for a whole request.

## What this does

`--prefill-split-mode` (`-psm`) takes the same values as `--split-mode`. The prompt is
processed under it, then the model is reloaded under `--split-mode` and the cache is carried
across, so generation runs under the other mode.

It is **tool-level only - no library changes**, apart from one allocation fix described under
Memory. The sequence state already survives a change of split mode, because
`llama_state_seq_get_data` writes a layout-independent form: this was verified separately by
writing a `--prompt-cache` under `-sm layer` and restoring it under `-sm tensor`, which
produced byte-identical output.

The switch:

1. reads the sequence state with `llama_state_seq_get_data`,
2. releases the model and context, so the two never hold device memory at once,
3. reloads under the generation split mode, fitting the placement again for that mode,
4. writes the state back with `llama_state_seq_set_data`,
5. replays the prompt into the fresh sampler, so the repetition penalties are not empty.

The **last prompt token is deliberately held back** from the first phase. The state carries
the cache but not the logits, and the sampler needs those; letting the reloaded model decode
that one token produces them. Removing the last cache cell and replaying it instead does not
work on every model - Qwen3.5 rejects it with an M-RoPE position constraint.

## Memory

The two modes do not place the same bytes on the same device, so the switch has to be sized
for both. Peak per device from `nvidia-smi`, same model, `-c 65536`, q8_0 cache. The cards are
12282 MiB and 12288 MiB:

| config | CUDA0 | CUDA1 |
| --- | ---: | ---: |
| `-sm layer` | 10143 | 11289 |
| `-sm tensor -ts 50,50` | 10931 | 10863 |
| `-psm layer -sm tensor -ts 50,50` | 10897 | 11281 |

The switch costs the **per-device maximum of both modes**, not the larger of the two totals:
device 0 has to hold what tensor needs while device 1 holds what layer needs. The largest
context that runs under `-psm` is therefore smaller than under either pure mode. At `-c 98304`
the same pattern holds (layer 10815/11833, tensor 11537/11467, `-psm` 11497/11825), and
neither mode dominates - at `-c 114688 -ts 50,50` layer runs out on device 1 while tensor
still fits.

Three things follow, and this PR handles them:

**The fit has to run again for the second mode.** `common_fit_params` writes the placement it
finds back into `params.tensor_split` and the buft overrides. On the second load it then sees
them set and aborts with `tensor_split already set by user`, so the generation mode inherited
the placement of the prefill mode. That was an out of memory in the common case. The switch
now keeps the arguments and lets the fit run again, and pins `n_ctx` to the first phase so the
state is restored into a context of the same size.

**A mode that does not fit must not lose the request.** If the generation mode cannot be
loaded, the prompt is still in the state that was just read, so the tool reloads under the
prefill mode and finishes there with a warning. Before, an explicit `-ts` tuned for the
prefill mode killed the request after the prompt was already processed: `-c 65536 -ts 57,43`
fits under layer (11577/9839) and does not fit under tensor, and a 58.3k-token prompt was
discarded after 80 seconds of work.

**The meta buffer type has to report an allocation failure.** It asserted instead of returning
nullptr, so an out of memory under `-sm tensor` aborted the process and no fallback was
reachable. It now frees what it holds and returns nullptr, the same contract the CUDA buffer
type already follows. This is the only change outside the tool.

Verified, `-c 65536`, q8_0 cache, peak per device, all five producing the same output:

| run | rc | peak CUDA0/1 | switched | fell back |
| --- | ---: | ---: | :-: | :-: |
| auto, no `-ngl`/`-ts`, `-psm layer -sm tensor` | 0 | 10897/10829 | yes | no |
| auto, `-sm tensor` | 0 | 10937/10867 | - | - |
| `-ngl 99 -ts 50,50 -psm layer -sm tensor` | 0 | 10897/11281 | yes | no |
| `-ngl 99 -ts 57,43 -psm layer -sm tensor` | 0 | 11871/9899 | yes | **yes** |
| `-ngl 99 -sm layer` | 0 | 10143/11289 | - | - |

## Result

Same setup, wall clock for the whole request - the 58.3k-token prompt plus 128 generated
tokens, model load included:

| config | wall | generation |
| --- | ---: | ---: |
| `-sm tensor` | 153 s | 19.76 t/s |
| `-sm layer` | 86 s | 14.80 t/s |
| **`-psm layer -sm tensor`** | **91 s** | **19.62 t/s** |
| `-psm tensor -sm layer` (control, wrong way round) | 156 s | 14.82 t/s |

It gets both halves: layer's prefill and tensor's generation, the latter within 0.7% of what
a pure tensor run reaches. Against `-sm tensor` that is **40% off the wall clock** for the
same generation rate.

Against `-sm layer` it costs the 5 s reload and buys **+33% generation**, so it pays for
itself after about **300 generated tokens** - below that, plain `-sm layer` is better. The
reversed control is slower than either pure mode, which is the check that the gain is the
direction and not the reload.

The switch carried 2085 MiB of state and the reload took 5.2 s, measured between the log line
and the first sampled token.

## Cost

The switch is a full model reload. Measured at about 5 s for a 19.8 GB model from a warm page
cache, of which the device upload is the bulk. The state itself is cheap to move and, with
`--no-kv-offload`, never leaves host memory at all. It is held in host memory as one buffer
while the second model loads - 2085 MiB for the 58.3k-token prompt above, linear in the
context.

So the switch pays off when the prefill saving exceeds the reload, which for a prompt of this
size it does by an order of magnitude, and it does not pay off for short prompts. It is
opt-in and off by default.

## Why `-np 1`

`-psm` requires `--parallel 1` and is rejected otherwise. This is not a missing loop, it is
what a global mode switch can do at all. The trigger is a single linear walk over one prompt,
and with several slots there is no instant where none of them is generating; the split mode
belongs to the model, so a batch that mixes a prefill chunk with decode tokens has no single
right mode; and the state carry is one sequence, so a reload would silently destroy the cache
of every other one.

The gain also shrinks with the batch, which is the argument above running in reverse.
`llama-batched-bench`, `-c 32768`, q8_0 cache, `-npp 2048 -ntg 128`:

| npl | pp layer | pp tensor | tg layer | tg tensor | tensor tg edge |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 950.2 | 591.2 | 18.85 | 25.17 | +33.5% |
| 2 | 1011.0 | 590.9 | 33.09 | 41.78 | +26.3% |
| 4 | 1034.1 | 591.3 | 46.91 | 58.35 | +24.4% |
| 8 | 1041.5 | 591.3 | 57.60 | 71.10 | +23.4% |

Tensor's generation edge falls from +33.5% to +23.4% while layer's prefill edge grows from
+61% to +76%. On total throughput at this prompt to generation ratio layer is already ahead at
`npl=2` and by +26% at `npl=8`. The batch of one that this PR optimises is the largest gap
there is.

## Limitations

- Only `llama-completion`, and only `-np 1`. A server would want this per request, which needs
  the library version below.
- **`common_fit_params` has no implementation for `LLAMA_SPLIT_MODE_TENSOR`** and returns
  early (`common/fit.cpp:183`). The placement is therefore fitted only for a layer phase; a
  tensor phase loads with the default distribution, and what keeps that from failing hard is
  the fallback above, not a calculation.
- An explicit `-ts` applies to both phases and means different things in each - a share of the
  layers under a layer split, a share of every tensor under a tensor split. There is no
  `--prefill-tensor-split`; a `-ts` that suits one phase can make the other one not fit, and
  the fallback is what catches that.
- **A layer split is unreliable on this model**, independently of this PR: it intermittently
  produces all-`!` output, at 2-5 runs in 10. Reported in detail on GenerelSchwerz#57. Using a
  layer split for the prompt inherits that, so `-psm layer` is only as trustworthy as
  `-sm layer` is on a given model.
- The reload discards anything derived from the old model that this tool does not rebuild.
  It rebuilds the sampler, the chat templates, the memory handle and the vocab. Combining
  `-psm` with `--prompt-cache` is untested.
- The reload is a full one. A migration that moves only the weights that change device would
  be cheaper, and is the main thing the library version buys.

## The library version, for later

The tool version answers whether the idea is worth anything. If it is, the same thing belongs
in the library, where it can be per request and cheaper. Sketch, in the order it would have to
be built:

**1. Weight migration instead of a reload.** Under `LLAMA_SPLIT_MODE_LAYER` a device holds
whole layers; under `..._TENSOR` it holds a slice of every layer. Both placements are already
computed at load time - the first by `llama_model::load_tensors` through `get_layer_buft_list`,
the second by `llama_meta_device_get_split_state`. A migration walks the tensors, computes the
destination placement, allocates the destination buffers, copies through host memory where
there is no P2P, and frees the source. For a 2-GPU 50/50 layer-to-tensor move about half the
model changes device each way, so it moves less than a reload re-uploads, and it does not
touch the file at all. The cheap first cut is to keep the reload and only add the API, since
a reload from a warm page cache is already close to the transfer cost.

**2. Keeping the cache in place.** With `--no-kv-offload` there is nothing to do: the cache
sits in host memory in one global layout and the split happens at delivery, which is why the
state round-trip works today. A device-resident cache has to be re-split by head, which is the
operation `ggml_backend_meta_buffer_set_tensor` already performs for a host-resident cache
copy - the same segment and granularity rules apply, so this is a re-use, not a new mechanism.

**3. Rebuilding the scheduler.** `llama_context` owns `sched`, the compute buffers and the
graph-reuse state, all derived from the backend set. The sequence is: `synchronize()`, drop
the scheduler and its buffers, rebuild through the same path the constructor uses, invalidate
the reused graph. The reserve step has to run again because the workspace sizes differ between
the modes.

**4. The API.** `llama_context_set_split_mode(ctx, mode)` returning bool is enough for an
explicit caller. An automatic policy would be a cparam - switch when a batch crosses a size
threshold in either direction - but that should come after the explicit form has been used.
Whatever the API, it has to answer what the tool answers with a fallback: a mode that does not
fit must leave the caller with a usable context, not a freed one.

**5. A policy that does not thrash.** Per request the rule is simple, prompt then generation.
A server with several slots decoding while another prefills has no single answer, and would
need either a hysteresis or a rule that only switches when the whole batch agrees. The numbers
under `-np 1` above say what it is worth: at `npl=8` the generation edge is still +23%, but
the prefill loss is larger, so a policy that always picks tensor for decoding would be slower
overall than never switching.

**Risks to be aware of before starting.** The meta backend rotates a fixed set of per-buffer
compute containers and carries a FIXME saying so; that rotation assumes a stable buffer set
and is the first thing a mid-session rebuild would disturb. Anything holding a pointer into
the old model - samplers hold the vocab, adapters, mtmd contexts - has to be revalidated, and
the library cannot see those, so the API has to make the invalidation explicit.
