### PR TITLE
llama : switch the split mode of a live context

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -898,12 +898,6 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         throw std::invalid_argument("error: --prompt-cache-all not supported in interactive mode yet\n");
     }
 
-    // the switch carries the state of the whole context, so there must be a moment where nothing is
-    // generating. that does not hold once several sequences share the context
-    if (params.prefill_split_mode >= 0 && params.n_parallel != 1) {
-        throw std::invalid_argument("error: --prefill-split-mode requires --parallel 1\n");
-    }
-
     // the switch happens once, after the prompt. an interactive session has more prompts after that
     if (params.prefill_split_mode >= 0 && (params.interactive || params.interactive_first)) {
         throw std::invalid_argument("error: --prefill-split-mode is not supported in interactive mode\n");

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -898,6 +898,12 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         throw std::invalid_argument("error: --prompt-cache-all not supported in interactive mode yet\n");
     }
 
+    // the switch carries the state of the whole context, so there must be a moment where nothing is
+    // generating. that does not hold once several sequences share the context
+    if (params.prefill_split_mode >= 0 && params.n_parallel != 1) {
+        throw std::invalid_argument("error: --prefill-split-mode requires --parallel 1\n");
+    }
+
     const bool skip_model_download =
         // server will call common_params_handle_models() later, so we skip it here
         ctx_arg.ex == LLAMA_EXAMPLE_SERVER ||
@@ -2903,6 +2909,26 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             }
         }
     ).set_env("LLAMA_ARG_SPLIT_MODE"));
+    add_opt(common_arg(
+        {"-psm", "--prefill-split-mode"}, "{none,layer,row,tensor}",
+        "split mode to process the prompt under, before switching to --split-mode to generate. A large batch "
+        "pays for the collective a tensor split needs and a single token does not, so the two phases can "
+        "prefer different modes. The weights are placed again once between the two, the cache is carried "
+        "over (default: use --split-mode throughout)",
+        [](common_params & params, const std::string & value) {
+            if (value == "none") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_NONE;
+            } else if (value == "layer") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_LAYER;
+            } else if (value == "row") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_ROW;
+            } else if (value == "tensor") {
+                params.prefill_split_mode = LLAMA_SPLIT_MODE_TENSOR;
+            } else {
+                throw std::invalid_argument("invalid value");
+            }
+        }
+    ).set_env("LLAMA_ARG_PREFILL_SPLIT_MODE").set_examples({LLAMA_EXAMPLE_COMPLETION}));
     add_opt(common_arg(
         {"-ts", "--tensor-split"}, "N0,N1,N2,...",
         "fraction of the model to offload to each GPU, comma-separated list of proportions, e.g. 3,1",

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -904,6 +904,11 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         throw std::invalid_argument("error: --prefill-split-mode requires --parallel 1\n");
     }
 
+    // the switch happens once, after the prompt. an interactive session has more prompts after that
+    if (params.prefill_split_mode >= 0 && (params.interactive || params.interactive_first)) {
+        throw std::invalid_argument("error: --prefill-split-mode is not supported in interactive mode\n");
+    }
+
     const bool skip_model_download =
         // server will call common_params_handle_models() later, so we skip it here
         ctx_arg.ex == LLAMA_EXAMPLE_SERVER ||

--- a/common/common.h
+++ b/common/common.h
@@ -494,6 +494,7 @@ struct common_params {
     std::vector<size_t> fit_params_target = std::vector<size_t>(llama_max_devices(), 1024 * 1024*1024);
 
     enum llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER; // how to split the model across GPUs
+    int32_t prefill_split_mode = -1; // split mode to process the prompt under, -1 to use split_mode throughout
     enum llama_load_mode  load_mode  = LLAMA_LOAD_MODE_AUTO; // how to load the model
 
     enum llama_lazy_mode lazy_mode = LLAMA_LAZY_MODE_AUTO; // on-demand reading of tensors marked by the arch

--- a/docs/multi-gpu.md
+++ b/docs/multi-gpu.md
@@ -123,6 +123,13 @@ serves several requests from one context keeps every slot's cache across the swi
 cannot do is run two split modes at once - the split mode belongs to the model - or run while a
 `llama_decode` is in flight.
 
+`-psm` fires once, at the boundary between prompt and generation of a single request, so it does
+nothing for a server where one slot prefills while another decodes. The gap it exploits is still
+there at any number of parallel sequences - measured with `llama-batched-bench` on the setup above,
+`-npp 2048 -ntg 128`, the layer split leads prefill by 65% to 81% and the tensor split leads decoding
+by 12% to 26% from 1 to 8 parallel sequences - but taking both halves would need a scheduler that
+separates the phases, plus a policy that does not switch too often. Neither is here.
+
 Points to be aware of:
 
 - The switch costs one placement of the weights, which reads them from the model file again. It pays

--- a/docs/multi-gpu.md
+++ b/docs/multi-gpu.md
@@ -118,18 +118,47 @@ if (!llama_context_set_split_mode(ctx, LLAMA_SPLIT_MODE_TENSOR, NULL)) {
 llama-completion -m model.gguf -psm layer -sm tensor -ctk f16 -ctv f16 -np 1 -f long-prompt.txt
 ```
 
+All sequences of the context are carried, not only the one that was generating, so a caller that
+serves several requests from one context keeps every slot's cache across the switch. What the switch
+cannot do is run two split modes at once - the split mode belongs to the model - or run while a
+`llama_decode` is in flight.
+
 Points to be aware of:
 
 - The switch costs one placement of the weights, which reads them from the model file again. It pays
   off once the prefill saving is larger than that, so it is for long prompts, not short ones.
-- Both modes have to fit on the devices, and they do not place the same bytes on the same device.
-  If the second mode does not fit, the call returns false and the context keeps running under the
-  mode it already had.
 - A `-ts` is a share of the layers under a layer split and a share of every tensor under a tensor
   split. The library call takes a `tensor_split` of its own for that reason; `-psm` uses the one the
   model already has.
 - The model must not be shared with another context, and must have no LoRA adapter or control vector
   loaded. Every `llama_memory_t` taken from the context before the switch is invalid after it.
+
+#### Device memory
+
+The old placement is freed before the new one is asked for, so the devices never hold both. The peak
+is the **per-device maximum of the two modes**, not their sum, and not the maximum of the two totals:
+one device can be at its layer-split peak while the other is at its tensor-split peak. Measured on an
+RTX 4070 + RTX 3060, `Qwen3.8-27B-UD-IQ2_M` at `-c 20480` with an f16 cache, sampled at 10 Hz:
+
+| config | GPU0 peak | GPU1 peak |
+| --- | ---: | ---: |
+| `-sm layer` | 5806 MiB | 6188 MiB |
+| `-sm tensor` | 6418 MiB | 6164 MiB |
+| `-psm layer -sm tensor` | 6362 MiB | 6180 MiB |
+
+So the largest context that survives a switch is smaller than what either pure mode could hold. Size
+for the maximum of the two, per device.
+
+If the new mode does not fit anyway, the allocation failure is caught: the previous placement is put
+back, the context is built on it again and the memory is restored, and the call returns false. The
+request is not lost. Checked by holding 5976 MiB on GPU0 with a helper process, which leaves room for
+the layer split but not for the tensor split:
+
+| run | result |
+| --- | --- |
+| `-sm layer` | generates |
+| `-sm tensor` | out of memory at load, request lost |
+| `-psm layer -sm tensor` | out of memory during the switch, warns, generates under the layer split |
 
 ### 6. With NCCL
 

--- a/docs/multi-gpu.md
+++ b/docs/multi-gpu.md
@@ -36,6 +36,7 @@ Set with `--split-mode` / `-sm`.
 |---|---|---|---|---|
 | `-sm` | `--split-mode` | `none` \| `layer` \| `tensor` | `layer` | See modes above. |
 | `-ts` | `--tensor-split` | comma-separated proportions, e.g. `3,1` | mode-dependent | How much of the model goes to each GPU. If omitted, `layer`/`row` use automatic splitting proportional to memory, while `tensor` splits tensor segments evenly. With `3,1` on two GPUs, GPU 0 gets 75 %, GPU 1 gets 25 %. The values follow the order in `--device`. |
+| `-psm` | `--prefill-split-mode` | `none` \| `layer` \| `tensor` | unset | Split mode to process the prompt under, before switching to `--split-mode` to generate. See "Switching the split mode at runtime" below. `llama-completion` only, and requires `--parallel 1`. |
 | `-mg` | `--main-gpu` | integer device index | `0` | The single GPU used in `--split-mode none`. |
 | `-ngl` | `--n-gpu-layers` / `--gpu-layers` | integer \| `auto` \| `all` | `auto` | Maximum number of layers to keep in VRAM. Use `999` or `all` to push everything possible to the GPUs. |
 | `-dev` | `--device` | comma-separated device names, or `none` | auto | Restrict which devices llama.cpp may use. See `--list-devices` for names. |
@@ -92,7 +93,45 @@ llama-cli -m model.gguf -sm tensor -ctk f16 -ctv f16
   - **State-space / RWKV-style:** Mamba, Mamba2 (and the hybrid Mamba-attention models above)
   - **Other:** PLAMO2, MiniCPM3, Gemma-3n, OLMo2, BitNet, T5
 
-### 5. With NCCL
+### 5. Switching the split mode at runtime
+
+A prompt and a single generated token do not want the same split. Tensor parallelism pays for a
+collective per layer: the cost of that collective scales with the batch, the benefit does not. A
+layer split pays no collective but runs the devices one after the other, so a batch of one gets no
+parallelism from it. Prefill therefore prefers `layer` and generation prefers `tensor`, and the gap
+can be tens of percent in both directions.
+
+`llama_context_set_split_mode` places the weights again for another split mode without dropping the
+context. The KV cache, the logits and the output ids are carried across, so a caller can process the
+prompt under one mode and generate under the other:
+
+```c
+// the prompt is in the cache, now generate under the mode that suits a batch of one
+if (!llama_context_set_split_mode(ctx, LLAMA_SPLIT_MODE_TENSOR, NULL)) {
+    // the mode does not fit on the devices - the context is still usable under the old one
+}
+```
+
+`llama-completion` exposes this as `--prefill-split-mode` / `-psm`:
+
+```bash
+llama-completion -m model.gguf -psm layer -sm tensor -ctk f16 -ctv f16 -np 1 -f long-prompt.txt
+```
+
+Points to be aware of:
+
+- The switch costs one placement of the weights, which reads them from the model file again. It pays
+  off once the prefill saving is larger than that, so it is for long prompts, not short ones.
+- Both modes have to fit on the devices, and they do not place the same bytes on the same device.
+  If the second mode does not fit, the call returns false and the context keeps running under the
+  mode it already had.
+- A `-ts` is a share of the layers under a layer split and a share of every tensor under a tensor
+  split. The library call takes a `tensor_split` of its own for that reason; `-psm` uses the one the
+  model already has.
+- The model must not be shared with another context, and must have no LoRA adapter or control vector
+  loaded. Every `llama_memory_t` taken from the context before the switch is invalid after it.
+
+### 6. With NCCL
 
 There's no runtime flag for NCCL - it's selected at build time (`-DGGML_CUDA_NCCL=ON`, this is the default). Note that NCCL is **not** automatically distributed with CUDA and you may need to install it manually - when in doubt check the CMake log to see whether or not it can find the package. When llama.cpp is compiled with NCCL support it uses it automatically for cross-GPU reductions in `tensor` mode. When NCCL is missing on a multi-GPU build, you'll see this one-time warning and performance will be lower:
 
@@ -101,7 +140,7 @@ NVIDIA Collective Communications Library (NCCL) is unavailable, multi GPU perfor
 ```
 
 When using the "ROCm" backend (which is the ggml CUDA code translated for AMD via HIP), the AMD equivalent RCCL can be used by compiling with `-DGGML_HIP_RCCL=ON`. Note that RCCL is by default *disabled* because (unlike NCCL) it was not universally beneficial during testing.
-### 6. With CUDA peer-to-peer access (`GGML_CUDA_P2P`)
+### 7. With CUDA peer-to-peer access (`GGML_CUDA_P2P`)
 
 CUDA peer-to-peer (P2P) lets GPUs transfer data directly between each other instead of going through system memory, which generally improves multi-GPU performance. It is **opt-in** at runtime - set the environment variable `GGML_CUDA_P2P` to any value to enable it:
 

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1700,9 +1700,15 @@ static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_bac
     std::vector<ggml_backend_buffer_t> bufs;
     bufs.reserve(n_simple_bufts);
     for (size_t i = 0; i < n_simple_bufts; i++) {
-        bufs.push_back(ggml_backend_buft_alloc_buffer(ggml_backend_meta_buft_simple_buft(buft, i), size));
-        GGML_ASSERT(bufs.back() != nullptr);
-        max_size = std::max(max_size, ggml_backend_buffer_get_size(bufs.back()));
+        ggml_backend_buffer_t buf = ggml_backend_buft_alloc_buffer(ggml_backend_meta_buft_simple_buft(buft, i), size);
+        if (buf == nullptr) {
+            for (ggml_backend_buffer_t b : bufs) {
+                ggml_backend_buffer_free(b);
+            }
+            return nullptr;
+        }
+        bufs.push_back(buf);
+        max_size = std::max(max_size, ggml_backend_buffer_get_size(buf));
     }
     ggml_backend_meta_buffer_context * buf_ctx = new ggml_backend_meta_buffer_context(stc_static, stc_compute_0, stc_compute_1, bufs);
 
@@ -1757,7 +1763,10 @@ struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struc
                 t->buffer = meta_buf_ctx->bufs[i].get();
             }
         }
-        GGML_ASSERT(meta_buf_ctx->bufs[i]);
+        if (meta_buf_ctx->bufs[i] == nullptr) {
+            ggml_backend_buffer_free(meta_buf);
+            return nullptr;
+        }
         meta_buf->size = std::max(meta_buf->size, ggml_backend_buffer_get_size(meta_buf_ctx->bufs[i].get()));
     }
     return meta_buf;

--- a/include/llama.h
+++ b/include/llama.h
@@ -202,6 +202,8 @@ extern "C" {
         LLAMA_SPLIT_MODE_TENSOR = 3,
     };
 
+    LLAMA_API const char * llama_split_mode_name(enum llama_split_mode split_mode);
+
     enum llama_load_mode {
         LLAMA_LOAD_MODE_AUTO       = -1, // auto-detect based on device capabilities
         LLAMA_LOAD_MODE_NONE       =  0, // no special loading mode
@@ -588,6 +590,21 @@ extern "C" {
 
     LLAMA_API const struct llama_vocab * llama_model_get_vocab(const struct llama_model * model);
     LLAMA_API enum llama_rope_type       llama_model_rope_type(const struct llama_model * model);
+
+    LLAMA_API enum llama_split_mode llama_model_get_split_mode(const struct llama_model * model);
+
+    // Place the model weights again for a different split mode, keeping the model object.
+    // The weights are read from the file the model was loaded from, so that path must still be readable
+    // and the model must not have been loaded from a FILE * or from metadata.
+    // tensor_split may be NULL to keep the current one. Note that it means a share of the layers under
+    // a layer split and a share of every tensor under a tensor split.
+    // Every tensor pointer inside the model is replaced, so every context and adapter built on it is
+    // invalid afterwards. Use llama_context_set_split_mode when a context exists.
+    // Returns false and puts the previous placement back if the new split mode does not fit.
+    LLAMA_API bool llama_model_set_split_mode(
+              struct llama_model * model,
+             enum llama_split_mode split_mode,
+                      const float * tensor_split);
 
     LLAMA_API int32_t llama_model_n_ctx_train  (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_embd       (const struct llama_model * model);

--- a/include/llama.h
+++ b/include/llama.h
@@ -556,6 +556,21 @@ extern "C" {
     // Frees all allocated memory
     LLAMA_API void llama_free(struct llama_context * ctx);
 
+    // Place the model weights for another split mode and build the context again on top of them.
+    // A large batch and a single token do not want the same split, so a caller that knows which phase
+    // it is in can pick the split mode per phase instead of once per model.
+    // The memory, the logits and the output ids are carried across, so the context keeps working on
+    // whatever it already holds. The llama_memory_t of the context is replaced, so a cached one must
+    // be read again with llama_get_memory.
+    // The model must not be shared with another context and must have no LoRA adapter or control
+    // vector loaded. tensor_split may be NULL to keep the current one.
+    // Returns false and leaves the context in a usable state under the split mode it had before if
+    // the new split mode does not fit.
+    LLAMA_API bool llama_context_set_split_mode(
+            struct llama_context * ctx,
+             enum llama_split_mode split_mode,
+                      const float * tensor_split);
+
     LLAMA_API int64_t llama_time_us(void);
 
     LLAMA_API size_t llama_max_devices(void);

--- a/include/llama.h
+++ b/include/llama.h
@@ -563,9 +563,12 @@ extern "C" {
     // whatever it already holds. The llama_memory_t of the context is replaced, so a cached one must
     // be read again with llama_get_memory.
     // The model must not be shared with another context and must have no LoRA adapter or control
-    // vector loaded. tensor_split may be NULL to keep the current one.
-    // Returns false and leaves the context in a usable state under the split mode it had before if
-    // the new split mode does not fit.
+    // vector loaded. tensor_split may be NULL to keep the current one. A backend sampler is bound to
+    // the output device and is dropped by the switch if the new split mode cannot take it.
+    // Returns false if the new split mode does not fit, which leaves the context under the one it
+    // had with its memory intact - compare llama_model_get_split_mode to tell that case apart from
+    // the rarer one where the switch happened but the memory could not be carried over, which
+    // leaves the context empty and is reported in the log.
     LLAMA_API bool llama_context_set_split_mode(
             struct llama_context * ctx,
              enum llama_split_mode split_mode,

--- a/src/llama-adapter.h
+++ b/src/llama-adapter.h
@@ -15,6 +15,8 @@
 //
 
 struct llama_adapter_cvec {
+    bool is_empty() const { return tensors.empty(); }
+
     ggml_tensor * tensor_for(int il) const;
 
     ggml_tensor * apply_to(ggml_context * ctx, ggml_tensor * cur, int  il) const;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -153,6 +153,8 @@ llama_context::llama_context(
 
     // a split mode switch builds the context again and has to start from what was asked for
     recurrent_state_offload_req = params.recurrent_state_offload;
+    offload_attn_compute_req    = cparams.offload_attn_compute;
+    live_context_workspace_req  = params.live_context_workspace;
     flash_attn_type             = params.flash_attn_type;
 
     // +1: id n_layer() taps the output of the last layer ("input" of the head)
@@ -260,9 +262,12 @@ llama_context::llama_context(
         cparams.causal_attn = params.attention_type == LLAMA_ATTENTION_TYPE_CAUSAL;
     }
 
-    cparams.flash_attn                         = params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED;
+    // a tensor split needs flash attention, so there is nothing left to resolve there
+    const bool fa_forced = model.split_mode() == LLAMA_SPLIT_MODE_TENSOR;
+
+    cparams.flash_attn                         = fa_forced || params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED;
     cparams.flash_attn_causal_prefix_supported = false;
-    cparams.auto_fa                            = params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO;
+    cparams.auto_fa                            = !fa_forced && params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO;
 
     cparams.fused_gdn_ar = true;
     cparams.fused_gdn_ch = true;
@@ -789,8 +794,9 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
         return false;
     }
 
-    if (split_mode == LLAMA_SPLIT_MODE_TENSOR && flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED) {
-        LLAMA_LOG_ERROR("%s: split mode tensor requires flash_attn to be enabled\n", __func__);
+    if (split_mode == LLAMA_SPLIT_MODE_TENSOR &&
+            (flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED || (!cparams.flash_attn && !cparams.auto_fa))) {
+        LLAMA_LOG_ERROR("%s: split mode tensor requires flash_attn, which is off for this context\n", __func__);
         return false;
     }
 
@@ -806,8 +812,10 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
 
     // the memory and the outputs live on buffers that the new placement does not have, so take
     // everything out of them before anything is freed
+    // state_write_data always writes at least the arch, so a zero size is a failure and not an
+    // empty memory - bail before anything is freed
     std::vector<uint8_t> state(state_get_size());
-    if (!state.empty() && state_get_data(state.data(), state.size()) != state.size()) {
+    if (state.empty() || state_get_data(state.data(), state.size()) != state.size()) {
         LLAMA_LOG_ERROR("%s: failed to read the context state\n", __func__);
         return false;
     }
@@ -861,9 +869,21 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
 
         set_abort_callback(abort_callback, abort_callback_data);
 
+        // a backend sampler is bound to the buffer type of the output device, and a tensor split
+        // does not take one at all, so let set_sampler decide again
+        const auto samplers = sampling.samplers;
+        sampling.samplers.clear();
+        for (const auto & [seq_id, sampler] : samplers) {
+            set_sampler(seq_id, sampler);
+        }
+
         if (output_reserve(n_outputs_max) < n_outputs_max) {
             throw std::runtime_error("failed to reserve the output buffer");
         }
+
+        // these only ever grow once the context is built, so start them from what was asked for
+        cparams.offload_attn_compute   = offload_attn_compute_req;
+        cparams.live_context_workspace = live_context_workspace_req;
 
         cparams.recurrent_state_offload = recurrent_state_offload_req;
         if (!cparams.recurrent_state_offload && model.split_mode() == LLAMA_SPLIT_MODE_TENSOR &&
@@ -892,8 +912,9 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
 
     release();
 
-    bool ok = model.set_split_mode(split_mode, tensor_split);
+    const bool placed = model.set_split_mode(split_mode, tensor_split);
 
+    bool ok = placed;
     if (ok) {
         try {
             rebuild();
@@ -908,10 +929,9 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
         // a rebuild that threw may have got half way, so start from nothing again
         release();
 
-        // llama_model::set_split_mode puts the weights back itself, the context only follows it there
-        if (model.split_mode() != prev_mode &&
-                !model.set_split_mode(prev_mode, prev_tensor_split.data())) {
-            LLAMA_LOG_ERROR("%s: the previous split mode could not be restored\n", __func__);
+        // llama_model::set_split_mode puts the weights back itself when it is the one that failed
+        if (placed && !model.set_split_mode(prev_mode, prev_tensor_split.data())) {
+            LLAMA_LOG_ERROR("%s: the previous placement could not be restored - this context is done\n", __func__);
             return false;
         }
 
@@ -935,8 +955,12 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
     sampling.probs_count      = probs_count_saved;
     sampling.candidates_count = candidates_count_saved;
 
-    if (!state.empty() && state_set_data(state.data(), state.size()) == 0) {
-        LLAMA_LOG_ERROR("%s: the memory could not be restored after the switch\n", __func__);
+    if (state_set_data(state.data(), state.size()) == 0) {
+        // the memory may hold a part of what was restored, so leave it empty rather than wrong
+        if (memory) {
+            memory->clear(true);
+        }
+        LLAMA_LOG_ERROR("%s: the memory could not be restored after the switch and is now empty\n", __func__);
         return false;
     }
 
@@ -4300,13 +4324,14 @@ llama_context * llama_init_from_model(
     }
 
     if (model->split_mode() == LLAMA_SPLIT_MODE_TENSOR) {
-        if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO) {
-            LLAMA_LOG_INFO("%s: enabling flash_attn since it is required for SPLIT_MODE_TENSOR\n", __func__);
-            params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
-        }
-        if (params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_ENABLED) {
+        if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED) {
             LLAMA_LOG_ERROR("%s: SPLIT_MODE_TENSOR requires flash_attn to be enabled\n", __func__);
             return nullptr;
+        }
+        if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO) {
+            // the context enables it, the type is kept as asked for so that a later split mode
+            // switch can resolve it again
+            LLAMA_LOG_INFO("%s: enabling flash_attn since it is required for SPLIT_MODE_TENSOR\n", __func__);
         }
     }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -105,7 +105,7 @@ static bool llama_sched_supports_flash_attn_causal_prefix(ggml_backend_sched_t s
 }
 
 llama_context::llama_context(
-        const llama_model & model,
+              llama_model & model,
               llama_context_params params) :
     model(model),
     cvec(std::make_unique<llama_adapter_cvec>()),
@@ -150,6 +150,10 @@ llama_context::llama_context(
     cparams.live_context_workspace  = params.live_context_workspace;
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
+
+    // a split mode switch builds the context again and has to start from what was asked for
+    recurrent_state_offload_req = params.recurrent_state_offload;
+    flash_attn_type             = params.flash_attn_type;
 
     // +1: id n_layer() taps the output of the last layer ("input" of the head)
     cparams.embeddings_layer_inp.resize(hparams.n_layer() + 1, false);
@@ -362,45 +366,7 @@ llama_context::llama_context(
     }
 
     if (!hparams.vocab_only) {
-        // GPU backends
-        for (const auto & dev : model.devices) {
-            ggml_backend_t backend = ggml_backend_dev_init(dev.dev, nullptr);
-            if (backend == nullptr) {
-                throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev.dev)));
-            }
-            backends.emplace_back(backend);
-        }
-
-        // add ACCEL backends (such as BLAS)
-        for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-            ggml_backend_dev_t dev = ggml_backend_dev_get(i);
-            if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_ACCEL) {
-                ggml_backend_t backend = ggml_backend_dev_init(dev, nullptr);
-                if (backend == nullptr) {
-                    throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev)));
-                }
-                backends.emplace_back(backend);
-            }
-        }
-
-        // add CPU backend
-        backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
-        if (backend_cpu == nullptr) {
-            throw std::runtime_error("failed to initialize CPU backend");
-        }
-        backends.emplace_back(backend_cpu);
-
-        // create a list of the set_n_threads functions in the backends
-        for (auto & backend : backends) {
-            ggml_backend_dev_t dev = ggml_backend_get_device(backend.get());
-            ggml_backend_reg_t reg = dev ? ggml_backend_dev_backend_reg(dev) : nullptr;
-            if (reg) {
-                auto ggml_backend_set_n_threads_fn = (ggml_backend_set_n_threads_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_set_n_threads");
-                if (ggml_backend_set_n_threads_fn) {
-                    set_n_threads_fns.emplace_back(backend.get(), ggml_backend_set_n_threads_fn);
-                }
-            }
-        }
+        init_backends();
 
         llama_set_abort_callback(this, params.abort_callback, params.abort_callback_data);
 
@@ -418,7 +384,7 @@ llama_context::llama_context(
 
     // init the memory module
     if (!hparams.vocab_only) {
-        llama_memory_params params_mem = {
+        mparams_mem = {
             /*.type_k    =*/ params.type_k,
             /*.type_v    =*/ params.type_v,
             /*.swa_full  =*/ params.swa_full,
@@ -426,88 +392,12 @@ llama_context::llama_context(
             /*.mem_other =*/ llama_get_memory(cparams.ctx_other),
         };
 
-        memory.reset(model.create_memory(params_mem, cparams));
-
-        if (cparams.live_context_workspace && hparams.no_alloc) {
-            cparams.live_context_workspace = false;
-        } else if (cparams.live_context_workspace && (!memory || memory->get_attn_reserve_capacity() == 0)) {
-            LLAMA_LOG_WARN("%s: live-context workspace sizing unsupported; using full-context reserve\n", __func__);
-            cparams.live_context_workspace = false;
-        }
-
-        if (!cparams.offload_kqv && cparams.kv_gpu_layers > 0) {
-            if (memory && memory->get_supports_partial_kv()) {
-                cparams.offload_attn_compute = cparams.offload_attn_compute || cparams.op_offload;
-            } else {
-                LLAMA_LOG_WARN("%s: partial GPU KV residency is not supported for this memory layout; ignoring kv_gpu_layers\n", __func__);
-            }
-        }
+        init_memory();
     }
 
     // init backends
     if (!hparams.vocab_only) {
-        LLAMA_LOG_DEBUG("%s: enumerating backends\n", __func__);
-
-        backend_buft.clear();
-        backend_ptrs.clear();
-        backend_buf_exp_size.clear();
-
-        for (auto & backend : backends) {
-            auto * buft = ggml_backend_get_default_buffer_type(backend.get());
-            auto backend_type = ggml_backend_dev_type(ggml_backend_get_device(backend.get()));
-
-            if (backend_type == GGML_BACKEND_DEVICE_TYPE_CPU && !model.devices.empty()) {
-                // use the host buffer of the first device CPU for faster transfer of the intermediate state
-                const auto & dev = model.devices[0];
-                auto * host_buft = ggml_backend_dev_host_buffer_type(dev.dev);
-                if (host_buft) {
-                    buft = host_buft;
-                }
-            }
-
-            backend_buft.push_back(buft);
-            backend_ptrs.push_back(backend.get());
-            backend_buf_exp_size.push_back(0);
-        }
-
-        LLAMA_LOG_DEBUG("%s: backend_ptrs.size() = %zu\n", __func__, backend_ptrs.size());
-
-        // TODO: move these checks to ggml_backend_sched
-        // enabling pipeline parallelism in the scheduler increases memory usage, so it is only done when necessary
-        bool pipeline_parallel =
-            model.n_devices() > 1 &&
-            model.n_gpu_layers() > model.hparams.n_layer_all &&
-            model.split_mode() == LLAMA_SPLIT_MODE_LAYER &&
-            cparams.offload_kqv &&
-            !model.has_tensor_overrides();
-
-        // pipeline parallelism requires support for async compute and events in all devices
-        if (pipeline_parallel) {
-            for (auto & backend : backends) {
-                auto dev_type = ggml_backend_dev_type(ggml_backend_get_device(backend.get()));
-                if (dev_type == GGML_BACKEND_DEVICE_TYPE_CPU) {
-                    // ignore CPU backend
-                    // TODO: should we ignore ACCEL types too?
-                    continue;
-                }
-                auto * dev = ggml_backend_get_device(backend.get());
-                ggml_backend_dev_props props;
-                ggml_backend_dev_get_props(dev, &props);
-                if (!props.caps.async || !props.caps.events) {
-                    // device does not support async compute or events
-                    pipeline_parallel = false;
-                    break;
-                }
-            }
-        }
-
-        cparams.pipeline_parallel = pipeline_parallel;
-
-        if (cparams.pipeline_parallel) {
-            LLAMA_LOG_INFO("%s: pipeline parallelism enabled\n", __func__);
-        }
-
-        sched_reserve();
+        init_sched();
 
         if (!cparams.flash_attn) {
             if (ggml_is_quantized(params.type_v)) {
@@ -525,6 +415,134 @@ llama_context::llama_context(
             sampling.token_ids_full_vocab[i] = i;
         }
     }
+}
+
+void llama_context::init_backends() {
+    // GPU backends
+    for (const auto & dev : model.devices) {
+        ggml_backend_t backend = ggml_backend_dev_init(dev.dev, nullptr);
+        if (backend == nullptr) {
+            throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev.dev)));
+        }
+        backends.emplace_back(backend);
+    }
+
+    // add ACCEL backends (such as BLAS)
+    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_ACCEL) {
+            ggml_backend_t backend = ggml_backend_dev_init(dev, nullptr);
+            if (backend == nullptr) {
+                throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev)));
+            }
+            backends.emplace_back(backend);
+        }
+    }
+
+    // add CPU backend
+    backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (backend_cpu == nullptr) {
+        throw std::runtime_error("failed to initialize CPU backend");
+    }
+    backends.emplace_back(backend_cpu);
+
+    // create a list of the set_n_threads functions in the backends
+    for (auto & backend : backends) {
+        ggml_backend_dev_t dev = ggml_backend_get_device(backend.get());
+        ggml_backend_reg_t reg = dev ? ggml_backend_dev_backend_reg(dev) : nullptr;
+        if (reg) {
+            auto ggml_backend_set_n_threads_fn = (ggml_backend_set_n_threads_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_set_n_threads");
+            if (ggml_backend_set_n_threads_fn) {
+                set_n_threads_fns.emplace_back(backend.get(), ggml_backend_set_n_threads_fn);
+            }
+        }
+    }
+}
+
+void llama_context::init_memory() {
+    const auto & hparams = model.hparams;
+
+    memory.reset(model.create_memory(mparams_mem, cparams));
+
+    if (cparams.live_context_workspace && hparams.no_alloc) {
+        cparams.live_context_workspace = false;
+    } else if (cparams.live_context_workspace && (!memory || memory->get_attn_reserve_capacity() == 0)) {
+        LLAMA_LOG_WARN("%s: live-context workspace sizing unsupported; using full-context reserve\n", __func__);
+        cparams.live_context_workspace = false;
+    }
+
+    if (!cparams.offload_kqv && cparams.kv_gpu_layers > 0) {
+        if (memory && memory->get_supports_partial_kv()) {
+            cparams.offload_attn_compute = cparams.offload_attn_compute || cparams.op_offload;
+        } else {
+            LLAMA_LOG_WARN("%s: partial GPU KV residency is not supported for this memory layout; ignoring kv_gpu_layers\n", __func__);
+        }
+    }
+}
+
+void llama_context::init_sched() {
+    LLAMA_LOG_DEBUG("%s: enumerating backends\n", __func__);
+
+    backend_buft.clear();
+    backend_ptrs.clear();
+    backend_buf_exp_size.clear();
+
+    for (auto & backend : backends) {
+        auto * buft = ggml_backend_get_default_buffer_type(backend.get());
+        auto backend_type = ggml_backend_dev_type(ggml_backend_get_device(backend.get()));
+
+        if (backend_type == GGML_BACKEND_DEVICE_TYPE_CPU && !model.devices.empty()) {
+            // use the host buffer of the first device CPU for faster transfer of the intermediate state
+            const auto & dev = model.devices[0];
+            auto * host_buft = ggml_backend_dev_host_buffer_type(dev.dev);
+            if (host_buft) {
+                buft = host_buft;
+            }
+        }
+
+        backend_buft.push_back(buft);
+        backend_ptrs.push_back(backend.get());
+        backend_buf_exp_size.push_back(0);
+    }
+
+    LLAMA_LOG_DEBUG("%s: backend_ptrs.size() = %zu\n", __func__, backend_ptrs.size());
+
+    // TODO: move these checks to ggml_backend_sched
+    // enabling pipeline parallelism in the scheduler increases memory usage, so it is only done when necessary
+    bool pipeline_parallel =
+        model.n_devices() > 1 &&
+        model.n_gpu_layers() > model.hparams.n_layer_all &&
+        model.split_mode() == LLAMA_SPLIT_MODE_LAYER &&
+        cparams.offload_kqv &&
+        !model.has_tensor_overrides();
+
+    // pipeline parallelism requires support for async compute and events in all devices
+    if (pipeline_parallel) {
+        for (auto & backend : backends) {
+            auto dev_type = ggml_backend_dev_type(ggml_backend_get_device(backend.get()));
+            if (dev_type == GGML_BACKEND_DEVICE_TYPE_CPU) {
+                // ignore CPU backend
+                // TODO: should we ignore ACCEL types too?
+                continue;
+            }
+            auto * dev = ggml_backend_get_device(backend.get());
+            ggml_backend_dev_props props;
+            ggml_backend_dev_get_props(dev, &props);
+            if (!props.caps.async || !props.caps.events) {
+                // device does not support async compute or events
+                pipeline_parallel = false;
+                break;
+            }
+        }
+    }
+
+    cparams.pipeline_parallel = pipeline_parallel;
+
+    if (cparams.pipeline_parallel) {
+        LLAMA_LOG_INFO("%s: pipeline parallelism enabled\n", __func__);
+    }
+
+    sched_reserve();
 }
 
 llama_context::~llama_context() {
@@ -741,6 +759,188 @@ llama_context::sched_reserve_plan llama_context::make_sched_reserve_plan(
 
 llama_context * llama_context::shared_workspace_peer() const {
     return sched_buffer_owner != nullptr ? sched_buffer_owner : sched_buffer_borrower;
+}
+
+bool llama_context::set_split_mode(llama_split_mode split_mode, const float * tensor_split) {
+    const auto & hparams = model.hparams;
+
+    if (model.split_mode() == split_mode && tensor_split == nullptr) {
+        return true;
+    }
+
+    if (hparams.vocab_only || hparams.no_alloc) {
+        LLAMA_LOG_ERROR("%s: this context holds no weights\n", __func__);
+        return false;
+    }
+
+    if (opt_ctx != nullptr || cparams.ctx_other != nullptr || shared_workspace_peer() != nullptr) {
+        LLAMA_LOG_ERROR("%s: not supported for a context that is tied to another context\n", __func__);
+        return false;
+    }
+
+    // both keep tensors of their own on the devices of the old placement
+    if (!model.loras.empty() || !cvec->is_empty()) {
+        LLAMA_LOG_ERROR("%s: not supported while a LoRA adapter or a control vector is loaded\n", __func__);
+        return false;
+    }
+
+    // checked here so that a split mode the model cannot take costs nothing
+    if (!model.split_mode_supported(split_mode)) {
+        return false;
+    }
+
+    if (split_mode == LLAMA_SPLIT_MODE_TENSOR && flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED) {
+        LLAMA_LOG_ERROR("%s: split mode tensor requires flash_attn to be enabled\n", __func__);
+        return false;
+    }
+
+    synchronize();
+
+    const llama_split_mode prev_mode = model.split_mode();
+
+    // all zero means "split by free memory", which is what a model without a tensor split does
+    std::vector<float> prev_tensor_split(llama_max_devices(), 0.0f);
+    if (model.tensor_split() != nullptr) {
+        std::copy(model.tensor_split(), model.tensor_split() + llama_max_devices(), prev_tensor_split.begin());
+    }
+
+    // the memory and the outputs live on buffers that the new placement does not have, so take
+    // everything out of them before anything is freed
+    std::vector<uint8_t> state(state_get_size());
+    if (!state.empty() && state_get_data(state.data(), state.size()) != state.size()) {
+        LLAMA_LOG_ERROR("%s: failed to read the context state\n", __func__);
+        return false;
+    }
+
+    const int64_t n_vocab = model.vocab.n_tokens();
+    uint32_t n_outputs_max = n_seq_max();
+    if (logits.size > 0 && n_vocab > 0) {
+        n_outputs_max = (uint32_t) (logits.size / n_vocab);
+    }
+
+    std::vector<uint8_t> outputs(buf_output ? ggml_backend_buffer_get_size(buf_output.get()) : 0);
+    if (!outputs.empty()) {
+        memcpy(outputs.data(), ggml_backend_buffer_get_base(buf_output.get()), outputs.size());
+    }
+
+    const uint32_t               n_outputs_saved        = n_outputs;
+    const std::vector<int32_t>   output_ids_saved       = output_ids;
+    const std::vector<swap_info> output_swaps_saved     = output_swaps;
+    const std::vector<uint32_t>  logits_count_saved     = sampling.logits_count;
+    const std::vector<uint32_t>  probs_count_saved      = sampling.probs_count;
+    const std::vector<uint32_t>  candidates_count_saved = sampling.candidates_count;
+
+    auto release = [&]() {
+        mem_storage.clear();
+        memory.reset();
+
+        reset_sched_workspace();
+
+        buf_output.reset();
+        logits     = {nullptr, 0};
+        embd       = {nullptr, 0};
+        embd_nextn = {nullptr, 0};
+        for (auto & layer_inp : embd_layer_inp) {
+            layer_inp = {nullptr, 0};
+        }
+        sampling.logits     = {nullptr, 0};
+        sampling.probs      = {nullptr, 0};
+        sampling.sampled    = {nullptr, 0};
+        sampling.candidates = {nullptr, 0};
+
+        set_n_threads_fns.clear();
+        backend_ptrs.clear();
+        backend_buft.clear();
+        backend_buf_exp_size.clear();
+        backend_cpu = nullptr;
+        backends.clear();
+    };
+
+    auto rebuild = [&]() {
+        init_backends();
+
+        set_abort_callback(abort_callback, abort_callback_data);
+
+        if (output_reserve(n_outputs_max) < n_outputs_max) {
+            throw std::runtime_error("failed to reserve the output buffer");
+        }
+
+        cparams.recurrent_state_offload = recurrent_state_offload_req;
+        if (!cparams.recurrent_state_offload && model.split_mode() == LLAMA_SPLIT_MODE_TENSOR &&
+                (llm_arch_is_recurrent(model.arch) || llm_arch_is_hybrid(model.arch))) {
+            cparams.recurrent_state_offload = true;
+        }
+
+        // the split mode decides where an op can run, so resolve the automatic choices again.
+        // this has to happen before the memory module is built, because the cache layout follows
+        // flash_attn as it was asked for, not as it was resolved
+        const bool fa_forced = model.split_mode() == LLAMA_SPLIT_MODE_TENSOR;
+
+        cparams.flash_attn         = fa_forced || flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED;
+        cparams.auto_fa            = !fa_forced && flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO;
+        cparams.fused_dsv4_hc_pre  = true;
+        cparams.fused_dsv4_hc_comb = true;
+        cparams.fused_dsv4_hc_post = true;
+        cparams.auto_fhc           = true;
+
+        init_memory();
+        init_sched();
+    };
+
+    LLAMA_LOG_INFO("%s: switching the split mode from %s to %s, carrying %.2f MiB of state\n", __func__,
+            llama_split_mode_name(prev_mode), llama_split_mode_name(split_mode), state.size()/1024.0/1024.0);
+
+    release();
+
+    bool ok = model.set_split_mode(split_mode, tensor_split);
+
+    if (ok) {
+        try {
+            rebuild();
+        } catch (const std::exception & err) {
+            LLAMA_LOG_ERROR("%s: failed to build the context for split mode %s: %s\n", __func__,
+                    llama_split_mode_name(split_mode), err.what());
+            ok = false;
+        }
+    }
+
+    if (!ok) {
+        // a rebuild that threw may have got half way, so start from nothing again
+        release();
+
+        // llama_model::set_split_mode puts the weights back itself, the context only follows it there
+        if (model.split_mode() != prev_mode &&
+                !model.set_split_mode(prev_mode, prev_tensor_split.data())) {
+            LLAMA_LOG_ERROR("%s: the previous split mode could not be restored\n", __func__);
+            return false;
+        }
+
+        try {
+            rebuild();
+        } catch (const std::exception & err) {
+            LLAMA_LOG_ERROR("%s: the context could not be built again: %s\n", __func__, err.what());
+            return false;
+        }
+    }
+
+    if (!outputs.empty()) {
+        const size_t n_bytes = std::min(outputs.size(), ggml_backend_buffer_get_size(buf_output.get()));
+        memcpy(ggml_backend_buffer_get_base(buf_output.get()), outputs.data(), n_bytes);
+    }
+
+    n_outputs                 = n_outputs_saved;
+    output_ids                = output_ids_saved;
+    output_swaps              = output_swaps_saved;
+    sampling.logits_count     = logits_count_saved;
+    sampling.probs_count      = probs_count_saved;
+    sampling.candidates_count = candidates_count_saved;
+
+    if (!state.empty() && state_set_data(state.data(), state.size()) == 0) {
+        LLAMA_LOG_ERROR("%s: the memory could not be restored after the switch\n", __func__);
+        return false;
+    }
+
+    return ok;
 }
 
 void llama_context::reset_sched_workspace() {
@@ -4170,6 +4370,10 @@ llama_context * llama_init_from_model(
     }
 
     return nullptr;
+}
+
+bool llama_context_set_split_mode(llama_context * ctx, enum llama_split_mode split_mode, const float * tensor_split) {
+    return ctx->set_split_mode(split_mode, tensor_split);
 }
 
 // deprecated

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -766,6 +766,23 @@ llama_context * llama_context::shared_workspace_peer() const {
     return sched_buffer_owner != nullptr ? sched_buffer_owner : sched_buffer_borrower;
 }
 
+// the two split modes do not put the same bytes on the same device, so report what is left where
+static void llama_log_device_memory(const char * func, const char * when) {
+    for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) {
+            continue;
+        }
+
+        size_t free = 0;
+        size_t total = 0;
+        ggml_backend_dev_memory(dev, &free, &total);
+
+        LLAMA_LOG_INFO("%s: %s the switch: %s has %zu MiB of %zu MiB free\n", func, when,
+                ggml_backend_dev_name(dev), free/1024/1024, total/1024/1024);
+    }
+}
+
 bool llama_context::set_split_mode(llama_split_mode split_mode, const float * tensor_split) {
     const auto & hparams = model.hparams;
 
@@ -910,6 +927,9 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
     LLAMA_LOG_INFO("%s: switching the split mode from %s to %s, carrying %.2f MiB of state\n", __func__,
             llama_split_mode_name(prev_mode), llama_split_mode_name(split_mode), state.size()/1024.0/1024.0);
 
+    llama_log_device_memory(__func__, "before");
+
+    // the old placement goes first, so the devices never hold both at once
     release();
 
     const bool placed = model.set_split_mode(split_mode, tensor_split);
@@ -954,6 +974,8 @@ bool llama_context::set_split_mode(llama_split_mode split_mode, const float * te
     sampling.logits_count     = logits_count_saved;
     sampling.probs_count      = probs_count_saved;
     sampling.candidates_count = candidates_count_saved;
+
+    llama_log_device_memory(__func__, "after");
 
     if (state_set_data(state.data(), state.size()) == 0) {
         // the memory may hold a part of what was restored, so leave it empty rather than wrong

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -318,6 +318,8 @@ private:
     llama_memory_params        mparams_mem     = {};
     enum llama_flash_attn_type flash_attn_type = LLAMA_FLASH_ATTN_TYPE_AUTO;
     bool                       recurrent_state_offload_req = false;
+    bool                       offload_attn_compute_req    = false;
+    bool                       live_context_workspace_req  = false;
 
     llama_adapter_cvec_ptr  cvec;
     llama_adapter_loras_ptr loras;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -52,7 +52,7 @@ struct llama_context {
 
     // init scheduler and compute buffers, reserve worst-case graphs
     llama_context(
-            const llama_model & model,
+                  llama_model & model,
                   llama_context_params params);
 
     ~llama_context();
@@ -270,7 +270,18 @@ public:
 
     bool set_sampler(llama_seq_id seq_id, llama_sampler * sampler);
 
+    // place the model weights for another split mode and build this context again on top of them
+    // the memory, the logits and the output ids are carried across
+    // on failure the previous split mode is restored and false is returned
+    bool set_split_mode(llama_split_mode split_mode, const float * tensor_split);
+
 private:
+    // the three steps that build everything derived from the model devices, shared by the
+    // constructor and by set_split_mode
+    void init_backends();
+    void init_memory();
+    void init_sched();
+
     void reset_sched_workspace();
     llama_context * shared_workspace_peer() const;
     void acquire_shared_workspace();
@@ -299,9 +310,14 @@ private:
     // members
     //
 
-    const llama_model & model;
+    llama_model & model;
 
     llama_cparams cparams;
+
+    // kept so that the context can be built again after the model weights are placed differently
+    llama_memory_params        mparams_mem     = {};
+    enum llama_flash_attn_type flash_attn_type = LLAMA_FLASH_ATTN_TYPE_AUTO;
+    bool                       recurrent_state_offload_req = false;
 
     llama_adapter_cvec_ptr  cvec;
     llama_adapter_loras_ptr loras;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1170,6 +1170,16 @@ struct llama_model::impl {
     bool has_tensor_overrides;
 
     std::vector<float> tensor_split_owned;
+
+    // the pointers in llama_model_params are borrowed, but placing the weights again needs them,
+    // so keep an owned copy of everything that a reload reads
+    std::vector<ggml_backend_dev_t>                 devices_owned;
+    std::vector<llama_model_kv_override>            kv_overrides_owned;
+    std::vector<llama_model_tensor_buft_override>   tensor_buft_overrides_owned;
+    std::vector<std::string>                        tensor_buft_override_patterns;
+
+    std::string              load_path;
+    std::vector<std::string> load_splits;
 };
 
 llama_model::llama_model(const llama_model_params & params) : params(params), pimpl(std::make_unique<impl>()) {
@@ -1178,6 +1188,32 @@ llama_model::llama_model(const llama_model_params & params) : params(params), pi
         // may need it later for tensor-parallel KV-cache split metadata.
         pimpl->tensor_split_owned.assign(params.tensor_split, params.tensor_split + llama_max_devices());
         this->params.tensor_split = pimpl->tensor_split_owned.data();
+    }
+    if (params.devices != nullptr) {
+        for (ggml_backend_dev_t * dev = params.devices; *dev; ++dev) {
+            pimpl->devices_owned.push_back(*dev);
+        }
+        pimpl->devices_owned.push_back(nullptr);
+        this->params.devices = pimpl->devices_owned.data();
+    }
+    if (params.kv_overrides != nullptr) {
+        for (const auto * ov = params.kv_overrides; ov->key[0] != 0; ++ov) {
+            pimpl->kv_overrides_owned.push_back(*ov);
+        }
+        pimpl->kv_overrides_owned.push_back({});
+        this->params.kv_overrides = pimpl->kv_overrides_owned.data();
+    }
+    if (params.tensor_buft_overrides != nullptr) {
+        for (const auto * ov = params.tensor_buft_overrides; ov->pattern != nullptr; ++ov) {
+            pimpl->tensor_buft_override_patterns.emplace_back(ov->pattern);
+            pimpl->tensor_buft_overrides_owned.push_back({ nullptr, ov->buft });
+        }
+        // the patterns must not move any more before their addresses are taken
+        for (size_t i = 0; i < pimpl->tensor_buft_override_patterns.size(); ++i) {
+            pimpl->tensor_buft_overrides_owned[i].pattern = pimpl->tensor_buft_override_patterns[i].c_str();
+        }
+        pimpl->tensor_buft_overrides_owned.push_back({ nullptr, nullptr });
+        this->params.tensor_buft_overrides = pimpl->tensor_buft_overrides_owned.data();
     }
     pimpl->has_tensor_overrides = params.tensor_buft_overrides && params.tensor_buft_overrides[0].pattern;
 }
@@ -1866,6 +1902,109 @@ uint32_t llama_model::n_gpu_layers() const {
 
 llama_split_mode llama_model::split_mode() const {
     return params.split_mode;
+}
+
+void llama_model::set_reload_source(const std::string & path, const std::vector<std::string> & splits) {
+    pimpl->load_path   = path;
+    pimpl->load_splits = splits;
+
+    // the progress callback belongs to the load that just finished and may point at a stack frame
+    // that is gone by the time the weights are placed again
+    params.progress_callback           = nullptr;
+    params.progress_callback_user_data = nullptr;
+}
+
+bool llama_model::place_tensors(llama_split_mode split_mode, const float * tensor_split) {
+    // release the current placement first, so that the new one can use the same device memory
+    pimpl->ctxs_bufs.clear();
+    pimpl->mappings.clear();
+    pimpl->mlock_bufs.clear();
+    pimpl->mlock_mmaps.clear();
+    pimpl->cpu_buft_list.clear();
+    pimpl->gpu_buft_list.clear();
+    pimpl->dev_layer.clear();
+    pimpl->dev_input  = {};
+    pimpl->dev_output = {};
+
+    tensors_by_name.clear();
+    layers.clear();
+    static_cast<llama_model_tensors &>(*this) = llama_model_tensors();
+
+    devices.clear();
+    get_split_state_ud = {};
+
+    params.split_mode = split_mode;
+    if (tensor_split != nullptr) {
+        pimpl->tensor_split_owned.assign(tensor_split, tensor_split + llama_max_devices());
+        params.tensor_split = pimpl->tensor_split_owned.data();
+    }
+
+    if (!llama_prepare_model_devices(params, this)) {
+        return false;
+    }
+
+    try {
+        std::vector<std::string> splits = pimpl->load_splits;
+
+        llama_model_loader ml(nullptr, nullptr, nullptr, pimpl->load_path, splits, nullptr, params.load_mode,
+                params.check_tensors, params.no_alloc, params.load_mtp, params.kv_overrides, params.tensor_buft_overrides);
+        ml.lazy_mode = params.lazy_mode;
+
+        return load_tensors(ml);
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: error placing the model tensors: %s\n", __func__, err.what());
+        return false;
+    }
+}
+
+bool llama_model::split_mode_supported(llama_split_mode split_mode) const {
+    if (hparams.vocab_only || hparams.no_alloc) {
+        LLAMA_LOG_ERROR("%s: the model holds no weights to place\n", __func__);
+        return false;
+    }
+
+    if (pimpl->load_path.empty()) {
+        LLAMA_LOG_ERROR("%s: the model was not loaded from a path, so the weights cannot be placed again\n", __func__);
+        return false;
+    }
+
+    if (split_mode == LLAMA_SPLIT_MODE_TENSOR && !llm_arch_supports_sm_tensor(arch)) {
+        LLAMA_LOG_ERROR("%s: split mode tensor is not implemented for architecture '%s'\n", __func__, llm_arch_name(arch));
+        return false;
+    }
+
+    return true;
+}
+
+bool llama_model::set_split_mode(llama_split_mode split_mode, const float * tensor_split) {
+    if (!split_mode_supported(split_mode)) {
+        return false;
+    }
+
+    const llama_split_mode prev_mode = params.split_mode;
+
+    // all zero means "split by free memory", which is what a model without a tensor split does
+    std::vector<float> prev_split(llama_max_devices(), 0.0f);
+    if (params.tensor_split != nullptr) {
+        std::copy(params.tensor_split, params.tensor_split + llama_max_devices(), prev_split.begin());
+    }
+
+    const int64_t t_start_us = ggml_time_us();
+
+    if (place_tensors(split_mode, tensor_split)) {
+        LLAMA_LOG_INFO("%s: placed the weights for split mode %s in %.2f s\n", __func__,
+                llama_split_mode_name(split_mode), (ggml_time_us() - t_start_us)/1e6);
+        return true;
+    }
+
+    LLAMA_LOG_WARN("%s: split mode %s does not fit, going back to %s\n", __func__,
+            llama_split_mode_name(split_mode), llama_split_mode_name(prev_mode));
+
+    if (!place_tensors(prev_mode, prev_split.data())) {
+        LLAMA_LOG_ERROR("%s: the previous placement could not be restored either - the model is now unusable\n", __func__);
+    }
+
+    return false;
 }
 
 std::map<ggml_backend_buffer_type_t, size_t> llama_model::memory_breakdown() const {
@@ -2733,6 +2872,14 @@ void llama_free_model(llama_model * model) {
 
 void llama_model_free(llama_model * model) {
     delete model;
+}
+
+enum llama_split_mode llama_model_get_split_mode(const llama_model * model) {
+    return model->split_mode();
+}
+
+bool llama_model_set_split_mode(llama_model * model, enum llama_split_mode split_mode, const float * tensor_split) {
+    return model->set_split_mode(split_mode, tensor_split);
 }
 
 int32_t llama_model_n_ctx_train(const llama_model * model) {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -604,18 +604,9 @@ struct llama_meta_device_get_split_state_userdata {
 
 struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const struct ggml_tensor * tensor, void * userdata);
 
-struct llama_model {
-    llm_type type = LLM_TYPE_UNKNOWN;
-    llm_arch arch = LLM_ARCH_UNKNOWN;
-
-    std::string name = "n/a";
-
-    llama_hparams hparams = {};
-    llama_vocab   vocab;
-
-    // for classifier models
-    std::vector<std::string> classifier_labels;
-
+// tensors owned by the model as a whole, in one struct so that a re-place of the weights can
+// reset them together - see llama_model::set_split_mode
+struct llama_model_tensors {
     struct ggml_tensor * tok_embd   = nullptr;
     struct ggml_tensor * type_embd  = nullptr;
     struct ggml_tensor * pos_embd   = nullptr;
@@ -680,17 +671,30 @@ struct llama_model {
     struct ggml_tensor * dflash_selector_next   = nullptr;
     struct ggml_tensor * dflash_selector_hidden = nullptr;
 
-    // unified vector to store target-model extracted layer ids in eagle3, dflash, etc.
-    std::vector<int32_t> target_layer_ids;
-
-    std::vector<llama_layer> layers;
-
     //Dense linear projections for SentenceTransformers models like embeddinggemma
     // For Sentence Transformers models structure see
     // https://sbert.net/docs/sentence_transformer/usage/custom_models.html#structure-of-sentence-transformer-models
     struct ggml_tensor * dense_2_out_layers   = nullptr;
     struct ggml_tensor * dense_2_out_layers_b = nullptr;
     struct ggml_tensor * dense_3_out_layers   = nullptr;
+};
+
+struct llama_model : public llama_model_tensors {
+    llm_type type = LLM_TYPE_UNKNOWN;
+    llm_arch arch = LLM_ARCH_UNKNOWN;
+
+    std::string name = "n/a";
+
+    llama_hparams hparams = {};
+    llama_vocab   vocab;
+
+    // for classifier models
+    std::vector<std::string> classifier_labels;
+
+    // unified vector to store target-model extracted layer ids in eagle3, dflash, etc.
+    std::vector<int32_t> target_layer_ids;
+
+    std::vector<llama_layer> layers;
 
     // gguf metadata
     std::unordered_map<std::string, std::string> gguf_kv;
@@ -727,6 +731,18 @@ struct llama_model {
 
     uint32_t n_gpu_layers() const;
     llama_split_mode split_mode() const;
+
+    // remember where the weights came from, so that they can be placed again later
+    void set_reload_source(const std::string & path, const std::vector<std::string> & splits);
+
+    // whether the weights can be placed again under this split mode at all, checked without moving anything
+    bool split_mode_supported(llama_split_mode split_mode) const;
+
+    // place the weights again for a different split mode, keeping the model object alive
+    // tensor_split may be null to keep the current one
+    // every tensor pointer in the model is replaced, so anything derived from the old ones must be rebuilt
+    // on failure the previous placement is restored and false is returned
+    bool set_split_mode(llama_split_mode split_mode, const float * tensor_split);
 
     std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const;
 
@@ -766,11 +782,17 @@ struct llama_model {
     virtual bool graph_supports_recurrent_sparse_snapshots() const;
 
 protected:
+    // free the current placement and load the weights again under the given split mode
+    bool place_tensors(llama_split_mode split_mode, const float * tensor_split);
+
     llama_model_params params;
 
     struct impl;
     std::unique_ptr<impl> pimpl;
 };
+
+// returns true on success
+bool llama_prepare_model_devices(const llama_model_params & params, llama_model * model);
 
 llama_model * llama_model_create(llm_arch arch, const llama_model_params & params);
 llama_model * llama_model_create(llama_model_loader & ml, const llama_model_params & params);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -46,6 +46,20 @@ const char * llama_flash_attn_type_name(enum llama_flash_attn_type flash_attn_ty
     GGML_ABORT("fatal error");
 }
 
+const char * llama_split_mode_name(enum llama_split_mode split_mode) {
+    switch (split_mode) {
+        case LLAMA_SPLIT_MODE_NONE:
+            return "none";
+        case LLAMA_SPLIT_MODE_LAYER:
+            return "layer";
+        case LLAMA_SPLIT_MODE_ROW:
+            return "row";
+        case LLAMA_SPLIT_MODE_TENSOR:
+            return "tensor";
+    }
+    GGML_ABORT("fatal error");
+}
+
 const char * llama_load_mode_name(enum llama_load_mode load_mode) {
     switch (load_mode) {
         case LLAMA_LOAD_MODE_AUTO:
@@ -153,8 +167,7 @@ int64_t llama_time_us(void) {
     return ggml_time_us();
 }
 
-// returns true on success
-static bool llama_prepare_model_devices(const llama_model_params & params, llama_model * model) {
+bool llama_prepare_model_devices(const llama_model_params & params, llama_model * model) {
     // create list of devices to use with this model
     if (params.devices) {
         if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR) {
@@ -367,6 +380,11 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
 
         if (!model->load_tensors(ml)) {
             return {-2, nullptr};
+        }
+
+        // a later llama_model_set_split_mode reads the weights again from here
+        if (!fname.empty()) {
+            model->set_reload_source(fname, splits);
         }
 
         return {0, model_ptr.release()};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,6 +150,7 @@ endif ()
 
 llama_build(test-recurrent-state-rollback.cpp)
 llama_build(test-save-load-state.cpp)
+llama_build(test-split-mode-switch.cpp)
 
 if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     target_compile_definitions(test-recurrent-state-rollback PRIVATE LLAMA_TEST_RECURRENT_INTERNALS)
@@ -262,6 +263,31 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
         ARGS --models "${MODEL_DIR}"
     )
     set_tests_properties(test-save-load-state PROPERTIES FIXTURES_REQUIRED generate-models)
+
+    # Test the runtime split mode switch - skips itself when there is no GPU.
+    # --models DIR runs the whole directory, which is the way to sweep every architecture by hand
+    llama_test(
+        test-split-mode-switch
+        LABEL main
+        ARGS -m "${MODEL_DIR}/llama-dense.gguf"
+    )
+    set_tests_properties(test-split-mode-switch PROPERTIES FIXTURES_REQUIRED generate-models)
+
+    llama_test(
+        test-split-mode-switch
+        NAME test-split-mode-switch-moe
+        LABEL main
+        ARGS -m "${MODEL_DIR}/qwen3moe-moe.gguf"
+    )
+    set_tests_properties(test-split-mode-switch-moe PROPERTIES FIXTURES_REQUIRED generate-models)
+
+    llama_test(
+        test-split-mode-switch
+        NAME test-split-mode-switch-iswa
+        LABEL main
+        ARGS -m "${MODEL_DIR}/gemma2-dense.gguf"
+    )
+    set_tests_properties(test-split-mode-switch-iswa PROPERTIES FIXTURES_REQUIRED generate-models)
 endif()
 
 llama_build_and_test(test-chat-peg-parser.cpp peg-parser/simple-tokenize.cpp)

--- a/tests/test-split-mode-switch.cpp
+++ b/tests/test-split-mode-switch.cpp
@@ -1,0 +1,644 @@
+// Tests llama_context_set_split_mode: the weights are placed again for another split mode while the
+// context keeps its memory, its logits and its identity.
+//
+// The check that matters is that a context which switched into a mode continues exactly like a
+// context that was in that mode all along and was handed the same memory state.
+
+#include "arg.h"
+#include "common.h"
+#include "log.h"
+#include "llama-cpp.h"
+
+#include <algorithm>
+#include <clocale>
+#include <cstring>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <vector>
+
+struct llama_batch_ptr {
+    llama_batch batch;
+
+    llama_batch_ptr(int32_t n_tokens, int32_t embd, int32_t n_seq_max)
+        : batch{llama_batch_init(n_tokens, embd, n_seq_max)} {}
+
+    ~llama_batch_ptr() { llama_batch_free(batch); }
+
+    llama_batch_ptr(const llama_batch_ptr &) = delete;
+    llama_batch_ptr & operator=(const llama_batch_ptr &) = delete;
+
+    llama_batch & get() { return batch; }
+};
+
+static bool has_gpu_device() {
+    for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+        if (ggml_backend_dev_type(ggml_backend_dev_get(i)) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static llama_model * load_model(const std::string & path, common_params & params, llama_split_mode split_mode) {
+    auto mparams = common_model_params_to_llama(params);
+    mparams.split_mode = split_mode;
+
+    return llama_model_load_from_file(path.c_str(), mparams);
+}
+
+static llama_context * make_context(llama_model * model, const common_params & params) {
+    auto cparams = common_context_params_to_llama(params);
+    return llama_init_from_model(model, cparams);
+}
+
+static bool decode_tokens(llama_context * ctx, const llama_tokens & tokens, int & n_past, int32_t n_batch) {
+    llama_batch_ptr batch(n_batch, 0, 1);
+
+    for (size_t i = 0; i < tokens.size(); i += n_batch) {
+        const size_t n = std::min<size_t>(n_batch, tokens.size() - i);
+
+        common_batch_clear(batch.get());
+        for (size_t j = 0; j < n; j++) {
+            common_batch_add(batch.get(), tokens[i + j], n_past + (int) j, {0}, i + j == tokens.size() - 1);
+        }
+
+        if (llama_decode(ctx, batch.get())) {
+            LOG_ERR("%s: failed to decode\n", __func__);
+            return false;
+        }
+        n_past += (int) n;
+    }
+
+    return true;
+}
+
+static llama_tokens generate_greedy(llama_context * ctx, int & n_past, int32_t n_predict) {
+    auto sparams = llama_sampler_chain_default_params();
+    auto smpl = llama_sampler_ptr{llama_sampler_chain_init(sparams)};
+    llama_sampler_chain_add(smpl.get(), llama_sampler_init_greedy());
+
+    llama_tokens result;
+    llama_batch_ptr batch(1, 0, 1);
+
+    for (int i = 0; i < n_predict; i++) {
+        const llama_token id = llama_sampler_sample(smpl.get(), ctx, -1);
+        result.push_back(id);
+
+        common_batch_clear(batch.get());
+        common_batch_add(batch.get(), id, n_past, {0}, true);
+
+        if (llama_decode(ctx, batch.get())) {
+            LOG_ERR("%s: failed to decode\n", __func__);
+            return {};
+        }
+        n_past++;
+    }
+
+    return result;
+}
+
+// the logits of the last decode live in a host buffer of the context and must survive the switch,
+// otherwise a caller would have to decode a token again before it can sample
+// compared as raw bytes, because a dummy model can produce NaN logits and those never compare equal
+static std::vector<uint8_t> get_last_logits(llama_context * ctx, const llama_model * model) {
+    const float * logits = llama_get_logits_ith(ctx, -1);
+    if (logits == nullptr) {
+        return {};
+    }
+    const size_t n_bytes = llama_vocab_n_tokens(llama_model_get_vocab(model)) * sizeof(float);
+    return std::vector<uint8_t>((const uint8_t *) logits, (const uint8_t *) logits + n_bytes);
+}
+
+static std::vector<uint8_t> get_state(llama_context * ctx) {
+    std::vector<uint8_t> state(llama_state_get_size(ctx));
+    if (!state.empty() && llama_state_get_data(ctx, state.data(), state.size()) != state.size()) {
+        return {};
+    }
+    return state;
+}
+
+// generate under `sm` from a memory state that was produced elsewhere, so that the result can be
+// compared against a context that reached the same state by switching into `sm`
+static llama_tokens generate_from_state(
+        const std::string & path, common_params & params, llama_split_mode sm,
+        const std::vector<uint8_t> & state, llama_token last, int n_past) {
+    llama_model_ptr model{load_model(path, params, sm)};
+    if (!model) {
+        LOG_ERR("%s: failed to load the model under split mode %s\n", __func__, llama_split_mode_name(sm));
+        return {};
+    }
+
+    llama_context_ptr ctx{make_context(model.get(), params)};
+    if (!ctx) {
+        LOG_ERR("%s: failed to create the context under split mode %s\n", __func__, llama_split_mode_name(sm));
+        return {};
+    }
+
+    if (llama_state_set_data(ctx.get(), state.data(), state.size()) != state.size()) {
+        LOG_ERR("%s: failed to restore the state\n", __func__);
+        return {};
+    }
+
+    if (!decode_tokens(ctx.get(), {last}, n_past, params.n_batch)) {
+        return {};
+    }
+
+    return generate_greedy(ctx.get(), n_past, params.n_predict);
+}
+
+struct test_ctx {
+    std::string   path;
+    common_params params;
+    llama_tokens  prompt;
+
+    size_t n_pass = 0;
+    size_t n_fail = 0;
+    size_t n_skip = 0;
+
+    void pass(const std::string & name) {
+        LOG_INF("  PASS  %s\n", name.c_str());
+        n_pass++;
+    }
+
+    void fail(const std::string & name, const std::string & why) {
+        LOG_ERR("  FAIL  %s: %s\n", name.c_str(), why.c_str());
+        n_fail++;
+    }
+
+    void skip(const std::string & name, const std::string & why) {
+        LOG_INF("  SKIP  %s: %s\n", name.c_str(), why.c_str());
+        n_skip++;
+    }
+};
+
+// the whole prompt but its last token goes in under `from`, then the context switches to `to` and
+// the last token plus the generation run there
+static void test_switch(test_ctx & t, llama_split_mode from, llama_split_mode to) {
+    const std::string name = std::string("switch ") + llama_split_mode_name(from) + " -> " + llama_split_mode_name(to);
+
+    llama_model_ptr model{load_model(t.path, t.params, from)};
+    if (!model) {
+        t.skip(name, "the model does not load under the first split mode");
+        return;
+    }
+
+    llama_context_ptr ctx{make_context(model.get(), t.params)};
+    if (!ctx) {
+        t.skip(name, "the context does not build under the first split mode");
+        return;
+    }
+
+    llama_tokens head(t.prompt.begin(), t.prompt.end() - 1);
+    const llama_token last = t.prompt.back();
+
+    int n_past = 0;
+    if (!decode_tokens(ctx.get(), head, n_past, t.params.n_batch)) {
+        t.fail(name, "failed to decode the prompt");
+        return;
+    }
+
+    const std::vector<uint8_t> state_before  = get_state(ctx.get());
+    const std::vector<uint8_t> logits_before = get_last_logits(ctx.get(), model.get());
+    if (state_before.empty() || logits_before.empty()) {
+        t.fail(name, "failed to read the state before the switch");
+        return;
+    }
+
+    if (!llama_context_set_split_mode(ctx.get(), to, nullptr)) {
+        t.skip(name, "the split mode was rejected");
+        return;
+    }
+
+    if (llama_model_get_split_mode(model.get()) != to) {
+        t.fail(name, "the model reports the wrong split mode after the switch");
+        return;
+    }
+
+    const std::vector<uint8_t> state_after = get_state(ctx.get());
+    if (state_after != state_before) {
+        t.fail(name, "the state is not the same after the switch");
+        return;
+    }
+
+    if (get_last_logits(ctx.get(), model.get()) != logits_before) {
+        t.fail(name, "the logits of the last decode did not survive the switch");
+        return;
+    }
+
+    int n_past_switch = n_past;
+    if (!decode_tokens(ctx.get(), {last}, n_past_switch, t.params.n_batch)) {
+        t.fail(name, "failed to decode the last prompt token after the switch");
+        return;
+    }
+
+    const llama_tokens got = generate_greedy(ctx.get(), n_past_switch, t.params.n_predict);
+    if (got.empty()) {
+        t.fail(name, "failed to generate after the switch");
+        return;
+    }
+
+    // free the switched model before the reference asks for the same device memory
+    ctx.reset();
+    model.reset();
+
+    const llama_tokens want = generate_from_state(t.path, t.params, to, state_before, last, n_past);
+    if (want.empty()) {
+        t.fail(name, "failed to generate the reference");
+        return;
+    }
+
+    if (got != want) {
+        t.fail(name, "the generation after the switch differs from the reference");
+        return;
+    }
+
+    t.pass(name);
+}
+
+// a switch out and back must leave the context exactly where it was
+static void test_round_trip(test_ctx & t, llama_split_mode from, llama_split_mode via) {
+    const std::string name = std::string("round trip ") + llama_split_mode_name(from) + " -> " + llama_split_mode_name(via) + " -> " + llama_split_mode_name(from);
+
+    llama_model_ptr model{load_model(t.path, t.params, from)};
+    if (!model) {
+        t.skip(name, "the model does not load under the split mode");
+        return;
+    }
+
+    llama_context_ptr ctx{make_context(model.get(), t.params)};
+    if (!ctx) {
+        t.skip(name, "the context does not build under the split mode");
+        return;
+    }
+
+    llama_tokens head(t.prompt.begin(), t.prompt.end() - 1);
+    const llama_token last = t.prompt.back();
+
+    int n_past = 0;
+    if (!decode_tokens(ctx.get(), head, n_past, t.params.n_batch)) {
+        t.fail(name, "failed to decode the prompt");
+        return;
+    }
+
+    const std::vector<uint8_t> state = get_state(ctx.get());
+    if (state.empty()) {
+        t.fail(name, "failed to read the state");
+        return;
+    }
+
+    if (!llama_context_set_split_mode(ctx.get(), via, nullptr)) {
+        t.skip(name, "the split mode was rejected");
+        return;
+    }
+
+    if (!llama_context_set_split_mode(ctx.get(), from, nullptr)) {
+        t.fail(name, "failed to switch back");
+        return;
+    }
+
+    if (get_state(ctx.get()) != state) {
+        t.fail(name, "the state is not the same after the round trip");
+        return;
+    }
+
+    int n_past_rt = n_past;
+    if (!decode_tokens(ctx.get(), {last}, n_past_rt, t.params.n_batch)) {
+        t.fail(name, "failed to decode the last prompt token after the round trip");
+        return;
+    }
+
+    const llama_tokens got = generate_greedy(ctx.get(), n_past_rt, t.params.n_predict);
+    if (got.empty()) {
+        t.fail(name, "failed to generate after the round trip");
+        return;
+    }
+
+    ctx.reset();
+    model.reset();
+
+    const llama_tokens want = generate_from_state(t.path, t.params, from, state, last, n_past);
+    if (want.empty()) {
+        t.fail(name, "failed to generate the reference");
+        return;
+    }
+
+    if (got != want) {
+        t.fail(name, "the generation after the round trip differs from the reference");
+        return;
+    }
+
+    t.pass(name);
+}
+
+// a switch to the split mode the context already has changes nothing, and a split mode that the
+// model cannot take leaves a context that still works
+static void test_no_change(test_ctx & t, llama_split_mode sm, llama_split_mode unsupported) {
+    const std::string name = std::string("no change under ") + llama_split_mode_name(sm);
+
+    llama_model_ptr model{load_model(t.path, t.params, sm)};
+    if (!model) {
+        t.skip(name, "the model does not load under the split mode");
+        return;
+    }
+
+    llama_context_ptr ctx{make_context(model.get(), t.params)};
+    if (!ctx) {
+        t.skip(name, "the context does not build under the split mode");
+        return;
+    }
+
+    int n_past = 0;
+    if (!decode_tokens(ctx.get(), t.prompt, n_past, t.params.n_batch)) {
+        t.fail(name, "failed to decode the prompt");
+        return;
+    }
+
+    const std::vector<uint8_t> state = get_state(ctx.get());
+
+    if (!llama_context_set_split_mode(ctx.get(), sm, nullptr)) {
+        t.fail(name, "a switch to the current split mode was rejected");
+        return;
+    }
+
+    if (unsupported != sm && llama_context_set_split_mode(ctx.get(), unsupported, nullptr)) {
+        // the model took it after all, which is not a failure of this test
+        LOG_INF("  note: %s was accepted, skipping the rejection check\n", llama_split_mode_name(unsupported));
+        if (!llama_context_set_split_mode(ctx.get(), sm, nullptr)) {
+            t.fail(name, "failed to switch back");
+            return;
+        }
+    }
+
+    if (llama_model_get_split_mode(model.get()) != sm) {
+        t.fail(name, "the split mode changed although nothing should have");
+        return;
+    }
+
+    if (get_state(ctx.get()) != state) {
+        t.fail(name, "the state changed although nothing should have");
+        return;
+    }
+
+    int n_past_check = n_past;
+    const llama_tokens got = generate_greedy(ctx.get(), n_past_check, t.params.n_predict);
+    if (got.empty()) {
+        t.fail(name, "the context no longer generates");
+        return;
+    }
+
+    t.pass(name);
+}
+
+// a switch may also give the new mode a tensor split of its own, because a share of the layers and
+// a share of every tensor are not the same thing
+static void test_tensor_split(test_ctx & t, llama_split_mode from, llama_split_mode to) {
+    const std::string name = std::string("tensor split ") + llama_split_mode_name(from) + " -> " + llama_split_mode_name(to);
+
+    llama_model_ptr model{load_model(t.path, t.params, from)};
+    if (!model) {
+        t.skip(name, "the model does not load under the split mode");
+        return;
+    }
+
+    llama_context_ptr ctx{make_context(model.get(), t.params)};
+    if (!ctx) {
+        t.skip(name, "the context does not build under the split mode");
+        return;
+    }
+
+    llama_tokens head(t.prompt.begin(), t.prompt.end() - 1);
+    const llama_token last = t.prompt.back();
+
+    int n_past = 0;
+    if (!decode_tokens(ctx.get(), head, n_past, t.params.n_batch)) {
+        t.fail(name, "failed to decode the prompt");
+        return;
+    }
+
+    const std::vector<uint8_t> state = get_state(ctx.get());
+    if (state.empty()) {
+        t.fail(name, "failed to read the state");
+        return;
+    }
+
+    std::vector<float> tensor_split(llama_max_devices(), 0.0f);
+    tensor_split[0] = 0.7f;
+    tensor_split[1] = 0.3f;
+
+    if (!llama_context_set_split_mode(ctx.get(), to, tensor_split.data())) {
+        t.skip(name, "the split mode was rejected");
+        return;
+    }
+
+    if (get_state(ctx.get()) != state) {
+        t.fail(name, "the state is not the same after the switch");
+        return;
+    }
+
+    int n_past_switch = n_past;
+    if (!decode_tokens(ctx.get(), {last}, n_past_switch, t.params.n_batch)) {
+        t.fail(name, "failed to decode the last prompt token after the switch");
+        return;
+    }
+
+    if (generate_greedy(ctx.get(), n_past_switch, t.params.n_predict).empty()) {
+        t.fail(name, "failed to generate after the switch");
+        return;
+    }
+
+    t.pass(name);
+}
+
+// the model level API on its own, without a context on top of it
+static void test_model_only(test_ctx & t, llama_split_mode from, llama_split_mode to) {
+    const std::string name = std::string("model only ") + llama_split_mode_name(from) + " -> " + llama_split_mode_name(to);
+
+    llama_model_ptr model{load_model(t.path, t.params, from)};
+    if (!model) {
+        t.skip(name, "the model does not load under the split mode");
+        return;
+    }
+
+    if (!llama_model_set_split_mode(model.get(), to, nullptr)) {
+        t.skip(name, "the split mode was rejected");
+        return;
+    }
+
+    if (llama_model_get_split_mode(model.get()) != to) {
+        t.fail(name, "the model reports the wrong split mode");
+        return;
+    }
+
+    llama_context_ptr ctx{make_context(model.get(), t.params)};
+    if (!ctx) {
+        t.fail(name, "the context does not build on the placed weights");
+        return;
+    }
+
+    int n_past = 0;
+    if (!decode_tokens(ctx.get(), t.prompt, n_past, t.params.n_batch)) {
+        t.fail(name, "failed to decode the prompt on the placed weights");
+        return;
+    }
+
+    const llama_tokens got = generate_greedy(ctx.get(), n_past, t.params.n_predict);
+
+    ctx.reset();
+
+    llama_tokens want;
+    {
+        llama_model_ptr model_ref{load_model(t.path, t.params, to)};
+        if (!model_ref) {
+            t.fail(name, "failed to load the reference model");
+            return;
+        }
+        llama_context_ptr ctx_ref{make_context(model_ref.get(), t.params)};
+        if (!ctx_ref) {
+            t.fail(name, "failed to create the reference context");
+            return;
+        }
+        int n_past_ref = 0;
+        if (!decode_tokens(ctx_ref.get(), t.prompt, n_past_ref, t.params.n_batch)) {
+            t.fail(name, "failed to decode the prompt on the reference");
+            return;
+        }
+        want = generate_greedy(ctx_ref.get(), n_past_ref, t.params.n_predict);
+    }
+
+    if (got.empty() || got != want) {
+        t.fail(name, "the placed weights do not generate like a model loaded under the same split mode");
+        return;
+    }
+
+    t.pass(name);
+}
+
+static bool run_tests_for_model(const std::string & path, const common_params & base_params, size_t & n_pass, size_t & n_fail, size_t & n_skip) {
+    test_ctx t;
+    t.path   = path;
+    t.params = base_params;
+    t.params.model.path = path;
+
+    {
+        llama_model_ptr model{load_model(path, t.params, LLAMA_SPLIT_MODE_LAYER)};
+        if (!model) {
+            LOG_ERR("%s: failed to load '%s'\n", __func__, path.c_str());
+            return false;
+        }
+
+        const auto * vocab = llama_model_get_vocab(model.get());
+        const auto n_vocab = llama_vocab_n_tokens(vocab);
+
+        std::mt19937 rng(t.params.sampling.seed);
+        std::uniform_int_distribution<llama_token> dist(0, n_vocab - 1);
+        for (int i = 0; i < t.params.n_batch; i++) {
+            t.prompt.push_back(dist(rng));
+        }
+    }
+
+    test_switch    (t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR);
+    test_switch    (t, LLAMA_SPLIT_MODE_TENSOR, LLAMA_SPLIT_MODE_LAYER);
+    test_round_trip(t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR);
+    test_round_trip(t, LLAMA_SPLIT_MODE_TENSOR, LLAMA_SPLIT_MODE_LAYER);
+    test_no_change (t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR);
+    test_tensor_split(t, LLAMA_SPLIT_MODE_LAYER, LLAMA_SPLIT_MODE_TENSOR);
+    test_model_only(t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR);
+
+    n_pass += t.n_pass;
+    n_fail += t.n_fail;
+    n_skip += t.n_skip;
+
+    return t.n_fail == 0;
+}
+
+int main(int argc, char ** argv) {
+    std::setlocale(LC_NUMERIC, "C");
+
+    common_params params;
+    params.prompt        = "";
+    params.n_batch       = 32;
+    params.n_ctx         = 256;
+    params.n_predict     = 8;
+    params.n_parallel    = 1;
+    params.kv_unified    = true;
+    params.fit_params    = false;
+    params.sampling.seed = 1234;
+
+    common_init();
+
+    // extract our own --models DIR option before handing the rest to the common arg parser
+    std::string models_dir;
+    std::vector<char *> filtered_argv;
+    filtered_argv.push_back(argv[0]);
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--models") == 0) {
+            if (i + 1 >= argc) {
+                LOG_ERR("%s: --models requires a directory argument\n", __func__);
+                return 1;
+            }
+            models_dir = argv[i + 1];
+            i++;
+        } else {
+            filtered_argv.push_back(argv[i]);
+        }
+    }
+    filtered_argv.push_back(nullptr);
+    const int fargc = (int) filtered_argv.size() - 1;
+
+    if (!models_dir.empty()) {
+        params.model.path = models_dir;
+    }
+
+    if (!common_params_parse(fargc, filtered_argv.data(), params, LLAMA_EXAMPLE_COMMON)) {
+        return 1;
+    }
+
+    ggml_backend_load_all();
+
+    if (!has_gpu_device()) {
+        LOG_INF("%s: no GPU device found, a split mode switch has nothing to move - skipping\n", __func__);
+        return 0;
+    }
+
+    std::vector<std::string> models;
+    if (!models_dir.empty()) {
+        if (!std::filesystem::exists(models_dir) || !std::filesystem::is_directory(models_dir)) {
+            LOG_ERR("%s: models directory '%s' does not exist\n", __func__, models_dir.c_str());
+            return 1;
+        }
+        for (const auto & entry : std::filesystem::directory_iterator(models_dir)) {
+            if (entry.is_regular_file() && entry.path().extension() == ".gguf") {
+                models.push_back(entry.path().string());
+            }
+        }
+        std::sort(models.begin(), models.end());
+
+        if (models.empty()) {
+            LOG_ERR("%s: no .gguf models found in '%s'\n", __func__, models_dir.c_str());
+            return 1;
+        }
+    } else {
+        models.push_back(params.model.path);
+    }
+
+    size_t n_pass = 0;
+    size_t n_fail = 0;
+    size_t n_skip = 0;
+    size_t n_models_failed = 0;
+
+    for (const auto & model_path : models) {
+        LOG("\n================================================================\n");
+        LOG_INF("%s: model %s\n", __func__, model_path.c_str());
+
+        if (!run_tests_for_model(model_path, params, n_pass, n_fail, n_skip)) {
+            n_models_failed++;
+        }
+    }
+
+    LOG("\n================================================================\n");
+    LOG_INF("%s: summary: %zu passed, %zu failed, %zu skipped over %zu models\n",
+            __func__, n_pass, n_fail, n_skip, models.size());
+
+    return n_models_failed == 0 ? 0 : 1;
+}

--- a/tests/test-split-mode-switch.cpp
+++ b/tests/test-split-mode-switch.cpp
@@ -52,7 +52,7 @@ static llama_context * make_context(llama_model * model, const common_params & p
     return llama_init_from_model(model, cparams);
 }
 
-static bool decode_tokens(llama_context * ctx, const llama_tokens & tokens, int & n_past, int32_t n_batch) {
+static bool decode_tokens(llama_context * ctx, const llama_tokens & tokens, int & n_past, int32_t n_batch, llama_seq_id seq_id = 0) {
     llama_batch_ptr batch(n_batch, 0, 1);
 
     for (size_t i = 0; i < tokens.size(); i += n_batch) {
@@ -60,7 +60,7 @@ static bool decode_tokens(llama_context * ctx, const llama_tokens & tokens, int 
 
         common_batch_clear(batch.get());
         for (size_t j = 0; j < n; j++) {
-            common_batch_add(batch.get(), tokens[i + j], n_past + (int) j, {0}, i + j == tokens.size() - 1);
+            common_batch_add(batch.get(), tokens[i + j], n_past + (int) j, {seq_id}, i + j == tokens.size() - 1);
         }
 
         if (llama_decode(ctx, batch.get())) {
@@ -73,7 +73,7 @@ static bool decode_tokens(llama_context * ctx, const llama_tokens & tokens, int 
     return true;
 }
 
-static llama_tokens generate_greedy(llama_context * ctx, int & n_past, int32_t n_predict) {
+static llama_tokens generate_greedy(llama_context * ctx, int & n_past, int32_t n_predict, llama_seq_id seq_id = 0) {
     auto sparams = llama_sampler_chain_default_params();
     auto smpl = llama_sampler_ptr{llama_sampler_chain_init(sparams)};
     llama_sampler_chain_add(smpl.get(), llama_sampler_init_greedy());
@@ -86,7 +86,7 @@ static llama_tokens generate_greedy(llama_context * ctx, int & n_past, int32_t n
         result.push_back(id);
 
         common_batch_clear(batch.get());
-        common_batch_add(batch.get(), id, n_past, {0}, true);
+        common_batch_add(batch.get(), id, n_past, {seq_id}, true);
 
         if (llama_decode(ctx, batch.get())) {
             LOG_ERR("%s: failed to decode\n", __func__);
@@ -450,6 +450,113 @@ static void test_tensor_split(test_ctx & t, llama_split_mode from, llama_split_m
     t.pass(name);
 }
 
+// several sequences share one context, which is the case a server is in: the switch has to carry
+// all of them, not just the one that happens to be generating
+static void test_multi_seq(test_ctx & t, llama_split_mode from, llama_split_mode to, bool kv_unified) {
+    const std::string name = std::string("multi seq ") + llama_split_mode_name(from) + " -> " +
+        llama_split_mode_name(to) + (kv_unified ? " (unified kv)" : " (kv per seq)");
+
+    const int32_t n_seqs = 4;
+
+    common_params params = t.params;
+    params.n_parallel = n_seqs;
+    params.kv_unified = kv_unified;
+    params.n_ctx      = t.params.n_ctx * n_seqs;
+
+    llama_model_ptr model{load_model(t.path, params, from)};
+    if (!model) {
+        t.skip(name, "the model does not load under the first split mode");
+        return;
+    }
+
+    llama_context_ptr ctx{make_context(model.get(), params)};
+    if (!ctx) {
+        t.skip(name, "the context does not build under the first split mode");
+        return;
+    }
+
+    // one prompt per sequence, each a different slice of the token pool
+    std::vector<llama_tokens> heads(n_seqs);
+    std::vector<llama_token>  last(n_seqs);
+    std::vector<int>          n_past(n_seqs, 0);
+
+    for (int s = 0; s < n_seqs; s++) {
+        llama_tokens prompt(t.prompt.begin(), t.prompt.end());
+        std::rotate(prompt.begin(), prompt.begin() + s + 1, prompt.end());
+
+        heads[s].assign(prompt.begin(), prompt.end() - 1);
+        last[s] = prompt.back();
+
+        if (!decode_tokens(ctx.get(), heads[s], n_past[s], params.n_batch, s)) {
+            t.fail(name, "failed to decode the prompt of a sequence");
+            return;
+        }
+    }
+
+    const std::vector<uint8_t> state = get_state(ctx.get());
+    if (state.empty()) {
+        t.fail(name, "failed to read the state");
+        return;
+    }
+
+    if (!llama_context_set_split_mode(ctx.get(), to, nullptr)) {
+        t.skip(name, "the split mode was rejected");
+        return;
+    }
+
+    if (get_state(ctx.get()) != state) {
+        t.fail(name, "the state of all sequences is not the same after the switch");
+        return;
+    }
+
+    std::vector<llama_tokens> got(n_seqs);
+    for (int s = 0; s < n_seqs; s++) {
+        int n_past_s = n_past[s];
+        if (!decode_tokens(ctx.get(), {last[s]}, n_past_s, params.n_batch, s)) {
+            t.fail(name, "failed to decode the last prompt token of a sequence");
+            return;
+        }
+        got[s] = generate_greedy(ctx.get(), n_past_s, params.n_predict, s);
+        if (got[s].empty()) {
+            t.fail(name, "failed to generate for a sequence");
+            return;
+        }
+    }
+
+    ctx.reset();
+    model.reset();
+
+    // the reference reaches the same state without ever switching
+    llama_model_ptr model_ref{load_model(t.path, params, to)};
+    if (!model_ref) {
+        t.fail(name, "failed to load the reference model");
+        return;
+    }
+    llama_context_ptr ctx_ref{make_context(model_ref.get(), params)};
+    if (!ctx_ref) {
+        t.fail(name, "failed to create the reference context");
+        return;
+    }
+    if (llama_state_set_data(ctx_ref.get(), state.data(), state.size()) != state.size()) {
+        t.fail(name, "failed to restore the state into the reference");
+        return;
+    }
+
+    for (int s = 0; s < n_seqs; s++) {
+        int n_past_s = n_past[s];
+        if (!decode_tokens(ctx_ref.get(), {last[s]}, n_past_s, params.n_batch, s)) {
+            t.fail(name, "failed to decode the last prompt token on the reference");
+            return;
+        }
+        if (generate_greedy(ctx_ref.get(), n_past_s, params.n_predict, s) != got[s]) {
+            t.fail(name, "a sequence generates differently after the switch");
+            return;
+        }
+    }
+
+    t.pass(name);
+}
+
 // the model level API on its own, without a context on top of it
 static void test_model_only(test_ctx & t, llama_split_mode from, llama_split_mode to) {
     const std::string name = std::string("model only ") + llama_split_mode_name(from) + " -> " + llama_split_mode_name(to);
@@ -543,6 +650,9 @@ static bool run_tests_for_model(const std::string & path, const common_params & 
     test_round_trip(t, LLAMA_SPLIT_MODE_TENSOR, LLAMA_SPLIT_MODE_LAYER);
     test_no_change (t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR);
     test_tensor_split(t, LLAMA_SPLIT_MODE_LAYER, LLAMA_SPLIT_MODE_TENSOR);
+    test_multi_seq (t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR, /*kv_unified =*/ true);
+    test_multi_seq (t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR, /*kv_unified =*/ false);
+    test_multi_seq (t, LLAMA_SPLIT_MODE_TENSOR, LLAMA_SPLIT_MODE_LAYER,  /*kv_unified =*/ false);
     test_model_only(t, LLAMA_SPLIT_MODE_LAYER,  LLAMA_SPLIT_MODE_TENSOR);
 
     n_pass += t.n_pass;

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -677,6 +677,10 @@ int llama_completion(int argc, char ** argv) {
             split_mode_switch_pending = false;
 
             if (!llama_context_set_split_mode(ctx, split_mode_gen, nullptr)) {
+                if (llama_model_get_split_mode(model) == split_mode_gen) {
+                    LOG_ERR("%s: the split mode switch lost the prompt, giving up\n", __func__);
+                    return 1;
+                }
                 LOG_WRN("%s: the generation split mode does not fit, generating under the prefill split mode\n", __func__);
             }
             mem = llama_get_memory(ctx);

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -140,6 +140,15 @@ int llama_completion(int argc, char ** argv) {
     // load the model and apply lora adapter, if any
     LOG_INF("%s: load the model and apply lora adapter, if any\n", __func__);
 
+    // the prompt and the generation do not want the same thing from a multi-GPU split, so the prompt
+    // may be processed under a split mode of its own
+    const llama_split_mode split_mode_gen = params.split_mode;
+    bool split_mode_switch_pending = false;
+    if (params.prefill_split_mode >= 0 && (llama_split_mode) params.prefill_split_mode != params.split_mode) {
+        params.split_mode = (llama_split_mode) params.prefill_split_mode;
+        split_mode_switch_pending = true;
+    }
+
     auto llama_init = common_init_from_params(params);
 
     ctx   = llama_init->context();
@@ -662,6 +671,16 @@ int llama_completion(int argc, char ** argv) {
         }
 
         embd.clear();
+
+        // the whole prompt is in the cache now, so move the weights to what generation wants
+        if (split_mode_switch_pending && (int) embd_inp.size() <= n_consumed) {
+            split_mode_switch_pending = false;
+
+            if (!llama_context_set_split_mode(ctx, split_mode_gen, nullptr)) {
+                LOG_WRN("%s: the generation split mode does not fit, generating under the prefill split mode\n", __func__);
+            }
+            mem = llama_get_memory(ctx);
+        }
 
         if ((int) embd_inp.size() <= n_consumed && !is_interacting) {
 


### PR DESCRIPTION
Places the model weights again for a different split mode while the context stays alive, so a
request can process its prompt under one split and generate under the other.

Supersedes GenerelSchwerz#58, which did the same thing entirely inside `llama-completion` by
tearing down and rebuilding everything. That version answered whether the idea is worth anything;
this one is the library version its "for later" section sketched.

## Why

Tensor parallelism splits every layer across the devices and pays for a collective per layer. The
cost of that collective scales with the batch, the benefit does not: at a batch of one there is
almost nothing to exchange and both devices work on the same token, while at a prompt-sized batch
the exchange dominates. A layer split is the mirror image - no collective at all, but the devices
run one after the other, so a single token gets no parallelism.

Prefill wants the layer split, generation wants the tensor split, and nothing in the design forces
one choice for a whole request.

Measured on an RTX 4070 + RTX 3060, `Qwen3.8-27B-UD-IQ2_M`, a 17055-token prompt plus 128 generated
tokens at `-c 20480` with an f16 cache. Wall clock is the whole request, model load included:

| config | prefill | generation | wall |
| --- | ---: | ---: | ---: |
| `-sm layer` | **1000.44 t/s** | 24.77 t/s | 25 s |
| `-sm tensor` | 576.12 t/s | **29.14 t/s** | 37 s |
| **`-psm layer -sm tensor`** | **991.04 t/s** | **28.86 t/s** | **27 s** |
| `-psm tensor -sm layer` (control, wrong way round) | 574.64 t/s | 24.81 t/s | 41 s |

The switch keeps 99.1% of layer's prefill and 99.0% of tensor's generation: 27% off the wall clock
against `-sm tensor` at the same generation rate, or +16.5% generation against `-sm layer` for two
seconds. The reversed control is slower than either pure mode, which is the check that the gain is
the direction and not the switch.

The switch itself carried 1216 MiB of state and placed the weights of the 9.6 GB model in 2.21 s
from a warm page cache.

## What this adds

```c
LLAMA_API bool llama_context_set_split_mode(
        struct llama_context * ctx,
         enum llama_split_mode split_mode,
                  const float * tensor_split);

LLAMA_API bool llama_model_set_split_mode(
          struct llama_model * model,
         enum llama_split_mode split_mode,
                  const float * tensor_split);

LLAMA_API enum llama_split_mode llama_model_get_split_mode(const struct llama_model * model);
LLAMA_API const char * llama_split_mode_name(enum llama_split_mode split_mode);
```

`llama_context_set_split_mode` keeps the context object and everything the caller holds on to. The
memory, the logits of the last decode and the output ids are carried across, so the caller can
sample straight after the switch. It goes through four steps:

1. **Take the state out.** `llama_state_get_data` writes a layout-independent form of the memory,
   which is what makes the carry work at all: the same bytes restore into a cache that is split by
   layer or split by head. The host copy of the output buffer comes out the same way.
2. **Place the weights again.** `llama_model::set_split_mode` frees the current placement first and
   then loads the weights under the new one, so the devices never hold both at once. The model
   object survives, only the tensors inside it are replaced.
3. **Build the context again.** The backends, the compute scheduler, the output buffer and the
   memory module all follow the devices of the model, so all four are rebuilt through the same code
   the constructor uses - it was factored into `init_backends`, `init_memory` and `init_sched` for
   that.
4. **Put the state back**, and re-resolve the automatic choices that depend on where an op can run.

**A mode that does not fit must not lose the request.** If the new placement or the rebuild fails,
the previous split mode is placed again, the context is rebuilt on it and the state goes back in.
The call returns false and the caller still has a working context with its cache intact.

## The tool

`llama-completion` gets `--prefill-split-mode` / `-psm`, which takes the same values as
`--split-mode`. Against #58, the tool side is now nine lines: the model, the context, the sampler
and the chat templates all survive, and the last prompt token no longer has to be held back to
produce logits, because the logits are carried.

`-psm` is rejected in interactive mode, where there is more than one prompt and the switch happens
only once.

## Several sequences at once

The switch takes out and puts back the state of **all** sequences, not only the one that happens to
be generating, so a context that serves several requests keeps every slot's cache across it. Tested
with four sequences, with a unified cache and with one stream per sequence, in both directions:
each sequence continues exactly like the same sequence in a context that was in the target mode all
along and was handed the same state.

What the switch cannot do is run two split modes at once - the split mode belongs to the model - or
run while a `llama_decode` is in flight. Those are the real limits for a server, not the state carry.

**`-psm` itself gives nothing to a server**, and not because of a missing loop: it fires once, at the
boundary between prompt and generation of one linear request, and that boundary does not exist when
one slot prefills while another decodes. The library call is the part a server needs; the policy that
would decide when to use it is not here.

The reason to want it does survive parallelism, though. `llama-batched-bench`, same model, `-c 32768`,
f16 cache, `-npp 2048 -ntg 128`:

| npl | pp layer | pp tensor | layer prefill edge | tg layer | tg tensor | tensor decode edge |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 989.4 | 598.5 | +65.3% | 26.47 | 30.42 | +14.9% |
| 2 | 1046.4 | 601.5 | +74.0% | 43.55 | 48.94 | +12.4% |
| 4 | 1074.1 | 599.9 | +79.0% | 59.58 | 68.63 | +15.2% |
| 8 | 1085.3 | 600.1 | +80.9% | 72.57 | 91.51 | +26.1% |

Both edges hold at every level, so the two phases still want different modes however many sequences
are in flight. Note that this does not match #58's measurement, where the decode edge shrank from
+33.5% to +23.4% as the batch grew - different quantisation and cache type, so the shape of the
tradeoff is setup-specific and worth measuring before relying on it.

On total throughput at this prompt-to-generation ratio the layer split wins everywhere (315 -> 596
t/s against 285 -> 452 t/s), because prefill dominates the mix. A server that wanted both halves
would have to batch its prefills and its decodes into separate phases first, which is a scheduler
change, not this one.

## Device memory

The old placement is freed before the new one is asked for, so the devices never hold both. Peak per
device, sampled at 10 Hz over the whole run, `Qwen3.8-27B-UD-IQ2_M` at `-c 20480`:

| config | GPU0 peak | GPU1 peak |
| --- | ---: | ---: |
| `-sm layer` | 5806 MiB | 6188 MiB |
| `-sm tensor` | 6418 MiB | 6164 MiB |
| `-psm layer -sm tensor` | 6362 MiB | 6180 MiB |

The switch costs the per-device **maximum** of the two modes, not their sum: 6362 against a layer
peak of 5806 and a tensor peak of 6418 on GPU0. The largest context that survives a switch is
therefore smaller than what either pure mode could hold.

When the new mode does not fit anyway, the allocation failure is caught rather than fatal. Checked by
holding 5976 MiB on GPU0 with a helper process, which leaves room for the layer split but not for the
tensor split:

| run | result |
| --- | --- |
| `-sm layer` | generates |
| `-sm tensor` | `cudaMalloc failed: out of memory` at load, request lost |
| `-psm layer -sm tensor` | same out of memory during the switch, warns, generates under the layer split |

The third row is the point: the 17055-token prompt was already in the cache, the tensor placement
failed on a 505 MiB allocation, the layer placement was put back, the context was built on it again
and the cache was restored - and the request finished. That path needs the ggml change below to be
reachable at all.

## What is deliberately not here

- **Moving tensors between devices instead of reading them again.** The weights come from the model
  file, which is in the page cache after the first load. A true device-to-device migration would
  need both placements to exist at the same time, which raises the peak device memory - the opposite
  of what a switch under memory pressure needs.
- **Re-splitting the cache in place.** The serialized form is layout-independent and already
  exercised; it costs one host round trip of the cache and no new mechanism.
- **An automatic policy.** #58's sketch says a cparam that switches on batch size should come after
  the explicit form has been used, and that a server with several slots has no single right answer.
  The explicit call is here; the policy is not.

## Tests

`tests/test-split-mode-switch.cpp` runs against the dummy models that `test-llama-archs` generates.
Three of them are registered with ctest, following the pattern `test-recurrent-state-rollback`
already uses; `--models DIR` sweeps the whole directory, which is how every architecture gets
covered by hand. It skips itself when there is no GPU, so it costs nothing in CI.

The check that matters compares a context that switched into a mode against a context that was in
that mode all along and was handed the same memory state: both then decode the same token and
generate greedily, and the tokens must be identical. On top of that it checks that the serialized
state and the logits of the last decode are byte-identical across the switch, that a switch out and
back leaves the context exactly where it was, that a rejected split mode leaves a working context,
and that the model-level call on its own produces a model that generates like one loaded under that
split mode from the start.

The sweep over the generated models is 883 passed, 0 failed, 207 skipped over 109 models. The skips
are the architectures where a tensor split is not implemented, where the switch is refused and the
context has to keep working - that path is checked too.

One model is left out of the sweep: `qwen3-dense.gguf` cannot be run at all, because
a plain `llama-bench -m qwen3-dense.gguf -sm tensor -n 4` aborts on `origin/llama/dev` with
`GGML_ASSERT(src_ss[0].axis != GGML_BACKEND_SPLIT_AXIS_0)` while generating. That is a pre-existing
tensor-split bug on a dummy model shape, unrelated to this change, and the only model of the 110
that is affected.

## Also here

One ggml change, taken from #58: the meta buffer type asserted on an allocation failure instead of
returning nullptr, so an out of memory under `-sm tensor` aborted the process and no fallback was
reachable. It now frees what it holds and returns nullptr, the same contract the CUDA buffer type
follows. Without it the fallback above cannot run.

## Note on flash attention

`llama_init_from_model` used to rewrite `--flash-attn auto` to `enabled` when the model was loaded
under a tensor split. The context now applies that rule itself, so the requested type survives and a
switch back to a layer split can resolve it again instead of running with flash attention forced on.
`-sm tensor -fa auto` behaves the same as before, checked against the same model.

## Limitations

- The model must not be shared with a second context, and must have no LoRA adapter or control
  vector loaded. Both keep tensors of their own on the devices of the old placement, and the library
  cannot rebuild them.
- The model has to have been loaded from a path. A model loaded from a `FILE *` or from metadata has
  nowhere to read the weights from.
- Every `llama_memory_t` taken from the context before the switch is invalid after it.
- A `-ts` means a share of the layers under a layer split and a share of every tensor under a tensor
  split. The library call takes a `tensor_split` for that reason; `-psm` keeps the one the model has.
- `common_fit_params` still has no implementation for `LLAMA_SPLIT_MODE_TENSOR`, so a tensor phase
  is not fitted, only caught by the fallback if it does not fit.

---

AI disclosure: Claude Opus 5 wrote the implementation, the test and this description from a design I
own. I have read and understand every line and can defend it without it.
