### PR TITLE
cuda: fail closed grouped decode ROUTE to cached mmid

### DIFF
--- a/ggml/src/ggml-cuda/moe-cache.cu
+++ b/ggml/src/ggml-cuda/moe-cache.cu
@@ -7200,16 +7200,19 @@ void ggml_cuda_moe_grouped_context::compile_graph_plan(
             record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_EXECUTION;
         const bool consumer_legacy = decode_group &&
             record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_CONSUMER_EQUIVALENCE;
+        // layer-split decode graphs often keep argsort on one device; fail closed to cached mmid
+        const bool route_legacy = decode_group &&
+            record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_ROUTE;
         mixed_certificate = mixed_certificate &&
             ((prefill_group && record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_PREFILL) ||
                 (decode_group && (record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_ELIGIBLE ||
-                    materialization_legacy || execution_legacy || consumer_legacy)));
+                    materialization_legacy || execution_legacy || consumer_legacy || route_legacy)));
         decode_certificate = decode_certificate && decode_group &&
             record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_ELIGIBLE;
         decode_legacy_certificate = decode_legacy_certificate && decode_group &&
             (record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_ELIGIBLE ||
-                materialization_legacy || execution_legacy || consumer_legacy);
-        legacy_groups += materialization_legacy || execution_legacy || consumer_legacy;
+                materialization_legacy || execution_legacy || consumer_legacy || route_legacy);
+        legacy_groups += materialization_legacy || execution_legacy || consumer_legacy || route_legacy;
     }
     decode_legacy_certificate = decode_legacy_certificate && legacy_groups != 0;
     plan->outcome_ = call_prefill && !call_decode ? GGML_CUDA_MOE_GRAPH_OUTCOME_PREFILL_LEGACY :
@@ -7222,6 +7225,9 @@ void ggml_cuda_moe_grouped_context::compile_graph_plan(
     if (mixed_certificate || decode_certificate || decode_legacy_certificate) {
         for (uint32_t record_index = 0; record_index < plan->n_groups_; ++record_index) {
             const auto & record = plan->groups_[record_index];
+            if (record.reason == ggml_cuda_moe_graph_plan::GROUP_REASON_ROUTE) {
+                continue;
+            }
             const auto & group = impl_->table.groups[record.candidate.group_index];
             auto & dispatch = execution->groups_[record_index];
             dispatch.key.ids = record.ids;

--- a/tests/test-moe-cache.cpp
+++ b/tests/test-moe-cache.cpp
@@ -3677,6 +3677,7 @@ static void test_grouped_graph_preflight(bool benchmark) {
     ggml_cgraph * external_graph = candidate_graph(fixture, {external_gate_up_node, external_down_node});
     registry.compile_graph_plan(external_graph, 46, &plan, &execution);
     CHECK(plan.size() == 1 && execution.size() == 1 && !execution.find(external_gate_up_node, nullptr));
+    CHECK(execution.outcome() == GGML_CUDA_MOE_GRAPH_OUTCOME_DECODE_LEGACY);
 
     ggml_tensor * copied_ids = fixture.tensor(GGML_TYPE_I32, 2, ids_ne);
     copied_ids->op = GGML_OP_CPY;


### PR DESCRIPTION
## Overview

Layer-split + MoE expert cache would load and prefill, then abort on the first decode token with:

```
moe-cache: grouped decode certificate failed: semantic_group=25 ... tensor=blk.25.ffn_gate_exps.weight graph=route(8)
llama_decode: failed to decode, ret = -3
Compute error.
```

The grouped planner requires a local `argsort` to certify the expert-id route. With `--split-mode layer`, that `argsort` often lives on one GPU while later layers run on the other, so GPU1 groups fail `GROUP_REASON_ROUTE`. Prefill already used cached `mul_mat_id`. Decode treated `ROUTE` as `OUTCOME_ERROR` and aborted the whole graph instead of failing closed.

This treats `ROUTE` as a legacy-safe decode reason (same as materialization / execution / consumer-equivalence) and skips binding those groups so cached `mul_mat_id` can run.

Reproduced on dual RTX 5070 Ti with Qwen3.8-Flash-Next UD-IQ3_XXS, `--moe-expert-cache-size 80`, `--split-mode layer`. After the change, decode returns tokens. `test-moe-cache` passes.

## Additional information

The README already says unsupported grouped-decode layouts fail closed to cached `mul_mat_id`. This closes that hole for layer-split.

This is **not** tensor-split. Tensor-split of cached expert weights is still unsupported.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Grok 4.6 (DeepSeek Harness) reproduced the crash, identified the missing fail-closed reason, wrote the patch, and opened this PR. I reviewed the diagnosis and the change.