### PR TITLE
cuda/moe-cache: pinned-alloc fallback puts experts on the CPU backend

### DIFF
--- a/ggml/src/ggml-cuda/moe-cache.cu
+++ b/ggml/src/ggml-cuda/moe-cache.cu
@@ -10951,27 +10951,81 @@ static const char * ggml_backend_cuda_moe_cached_buffer_type_name(ggml_backend_b
     return GGML_CUDA_NAME "_MoE_Cached";
 }
 
+// Pinned bytes currently handed out for expert sources, checked against an optional budget.
+// WSL2 caps pinned host memory well below RAM (about 80% of the VM's memory, measured), and a
+// cudaMallocHost failure late in the load would also take the cache's own staging buffers
+// down with it. A budget makes the pageable spill a decision instead of an accident.
+static std::atomic<size_t> g_moe_cache_pinned_source_bytes{0};
+
 static void ggml_backend_cuda_moe_cached_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     CUDA_CHECK(cudaFreeHost(buffer->context));
+    g_moe_cache_pinned_source_bytes.fetch_sub(buffer->size, std::memory_order_relaxed);
 }
 
 static void ggml_backend_cuda_moe_cached_mmap_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     moe_cache_unregister_mmap_range(buffer->context, buffer->size);
 }
 
+static size_t moe_cache_pinned_source_budget_bytes() {
+    static const size_t budget = [] {
+        const char * env = getenv("GGML_CUDA_MOE_PINNED_BUDGET_MIB");
+        if (env == nullptr || *env == '\0') {
+            return (size_t) SIZE_MAX;
+        }
+        const long long mib = atoll(env);
+        return mib <= 0 ? (size_t) 0 : (size_t) mib << 20;
+    }();
+    return budget;
+}
+
 static void * ggml_cuda_moe_cached_pinned_malloc(size_t size) {
     if (getenv("GGML_CUDA_NO_PINNED") != nullptr) {
+        return nullptr;
+    }
+    const size_t budget  = moe_cache_pinned_source_budget_bytes();
+    const size_t already = g_moe_cache_pinned_source_bytes.load(std::memory_order_relaxed);
+    if (size > budget || already > budget - size) {
+        GGML_LOG_INFO("moe-cache: pinned source budget reached (%.2f MiB pinned, budget %.2f MiB); "
+                      "%.2f MiB buffer stays pageable but cached\n",
+                      already / 1024.0 / 1024.0,
+                      budget == SIZE_MAX ? -1.0 : budget / 1024.0 / 1024.0,
+                      size / 1024.0 / 1024.0);
         return nullptr;
     }
     void * ptr = nullptr;
     cudaError_t err = cudaMallocHost((void **) &ptr, size);
     if (err != cudaSuccess) {
         (void)cudaGetLastError();
-        GGML_LOG_DEBUG("%s: failed to allocate %.2f MiB of pinned memory: %s\n",
-                       __func__, size / 1024.0 / 1024.0, cudaGetErrorString(err));
+        GGML_LOG_WARN("%s: failed to allocate %.2f MiB of pinned memory: %s; "
+                      "buffer stays pageable but cached\n",
+                      __func__, size / 1024.0 / 1024.0, cudaGetErrorString(err));
         return nullptr;
     }
+    g_moe_cache_pinned_source_bytes.fetch_add(size, std::memory_order_relaxed);
+    GGML_LOG_INFO("moe-cache: pinned %.2f MiB of expert source (%.2f MiB pinned so far)\n",
+                  size / 1024.0 / 1024.0,
+                  (already + size) / 1024.0 / 1024.0);
     return ptr;
+}
+
+static void ggml_backend_cuda_moe_cached_pageable_buffer_free_buffer(ggml_backend_buffer_t buffer) {
+    ggml_aligned_free(buffer->context, buffer->size);
+}
+
+// Optional cap on a single expert-source buffer. ggml splits a tensor context into several
+// buffers when one would exceed the buffer type's max size, which is what lets part of the
+// source be pinned when all of it cannot be. Unset means one buffer, as upstream.
+static size_t ggml_backend_cuda_moe_cached_buffer_type_get_max_size(ggml_backend_buffer_type_t buft) {
+    GGML_UNUSED(buft);
+    static const size_t max_size = [] {
+        const char * env = getenv("GGML_CUDA_MOE_SOURCE_CHUNK_MIB");
+        if (env == nullptr || *env == '\0') {
+            return (size_t) SIZE_MAX;
+        }
+        const long long mib = atoll(env);
+        return mib <= 0 ? (size_t) SIZE_MAX : (size_t) mib << 20;
+    }();
+    return max_size;
 }
 
 static ggml_backend_buffer_t ggml_backend_cuda_moe_cached_buffer_type_alloc_buffer(
@@ -10980,9 +11034,22 @@ static ggml_backend_buffer_t ggml_backend_cuda_moe_cached_buffer_type_alloc_buff
     void * ptr = ggml_cuda_moe_cached_pinned_malloc(size);
 
     if (ptr == nullptr) {
-        // Pinned alloc failed -- fall back to a regular CPU buffer. This costs
-        // PCIe bandwidth on cache miss but keeps the model loadable.
-        return ggml_backend_buft_alloc_buffer(ggml_backend_cpu_buffer_type(), size);
+        if (size == 0) {
+            // The loader's memory-fit pass asks for a zero-byte dummy buffer; nothing to cache.
+            return ggml_backend_buft_alloc_buffer(ggml_backend_cpu_buffer_type(), size);
+        }
+        // Pinned alloc failed or the budget is spent. Keep the buffer under THIS buffer type
+        // so the CUDA dispatch hook still owns mul_mat_id for these experts; only the H2D
+        // copies change (pageable source). Returning a plain CPU buffer type here, as before,
+        // made ggml's scheduler run the experts on the CPU backend and bypass the cache.
+        void * pageable = ggml_aligned_malloc(size);
+        if (pageable == nullptr) {
+            return nullptr;
+        }
+        ggml_backend_buffer_t buffer = ggml_backend_cpu_buffer_from_ptr(pageable, size);
+        buffer->buft              = buft;
+        buffer->iface.free_buffer = ggml_backend_cuda_moe_cached_pageable_buffer_free_buffer;
+        return buffer;
     }
 
     ggml_backend_buffer_t buffer = ggml_backend_cpu_buffer_from_ptr(ptr, size);
@@ -11009,7 +11076,7 @@ ggml_backend_buffer_type_t ggml_backend_cuda_moe_cached_buffer_type(void) {
             /* .get_name         = */ ggml_backend_cuda_moe_cached_buffer_type_name,
             /* .alloc_buffer     = */ ggml_backend_cuda_moe_cached_buffer_type_alloc_buffer,
             /* .get_alignment    = */ ggml_backend_cpu_buffer_type()->iface.get_alignment,
-            /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
+            /* .get_max_size     = */ ggml_backend_cuda_moe_cached_buffer_type_get_max_size,
             /* .get_alloc_size   = */ ggml_backend_cpu_buffer_type()->iface.get_alloc_size,
             /* .is_host          = */ ggml_backend_cuda_moe_cached_buffer_type_is_host,
         },


### PR DESCRIPTION
Thanks for the moe-cache work, and for writing up Notable Runs the way you did — exact commit, exact request, output hashes, and an honest list of reasons someone else's machine might differ. That is what made it possible to find this rather than just conclude my box was slow.

### The fallback does not do what its comment says

In `ggml_backend_cuda_moe_cached_buffer_type_alloc_buffer`, current tip:

```c
if (ptr == nullptr) {
    // Pinned alloc failed -- fall back to a regular CPU buffer. This costs
    // PCIe bandwidth on cache miss but keeps the model loadable.
    return ggml_backend_buft_alloc_buffer(ggml_backend_cpu_buffer_type(), size);
}
```

The intent in that comment is a slower path: experts still executing on the GPU, paying extra PCIe traffic on a miss. But returning `ggml_backend_cpu_buffer_type()` changes the buffer's backend, so ggml's scheduler assigns those ops to the CPU. The experts stop running on the GPU entirely and the expert cache never engages.

So the actual cost is not the documented one. Measured here: 17-20 tok/s instead of 47, `moe-cache-experts: tensors=0`, GPU ~19% busy, ~7 GB VRAM instead of ~14 GB.

It is also quiet. Every symptom reads as host overhead, and the line that explains it is at `GGML_LOG_DEBUG` — below the `-lv 3` your guide recommends, so at the recommended verbosity there is nothing to see.

### The fix

On pinned-alloc failure, allocate pageable host memory but keep the buffer under this buffer type (`buffer->buft = buft`). The CUDA dispatch hook keeps ownership of `mul_mat_id`, so the experts stay on the cache path and only the H2D copies become pageable — which is what the comment intended. The alloc-failure log is promoted `DEBUG` -> `WARN`.

This part is independent of any platform. It matters wherever the fallback fires at all.

### Two additions you may not want

The branch also carries two opt-in knobs, because on my host the fallback fires for the whole expert source at once and partial pinning is worth a lot:

- `GGML_CUDA_MOE_SOURCE_CHUNK_MIB` — a `get_max_size` hook so ggml splits the expert source into several buffers, which is what allows part of it to be pinned when all of it cannot be.
- `GGML_CUDA_MOE_PINNED_BUDGET_MIB` — pinned-byte accounting against a budget, so the spill is a decision rather than an allocation failure late in the load that would also take the cache's staging buffers down with it.

Both unset preserves current behaviour exactly: one buffer, pin all of it, no budget check. Happy to drop these and keep only the fallback fix if you would rather not carry the env knobs.

### Where I hit it

Windows 11 -> WSL2 -> Docker Desktop, same GPU and RAM as your entry. WSL2 caps pinned host memory at roughly 80% of the VM's RAM — 47.0 GiB measured on a 60 GiB VM, same through `cudaHostRegister`, and it scales with VM size. `UD-Q3_K_XL`'s ~52 GiB source therefore cannot be pinned at any VM size that fits in 64 GB, so the fallback fires every time.

I have only measured WSL2 and am not going to claim which other hosts reach this.

### Why it is a throughput issue, not just a loadability one

Grouped decode is all-or-nothing across layers, as you document. One 2 GiB chunk deliberately left pageable takes `covered` from 48/48 to 0, and decode from 47.6 to 25.9 tok/s on `UD-IQ3_XXS`.

### Results

RTX 5070 Ti 16 GB (also driving the display), i7-14700F, 64 GB DDR5-6000. Your `request.json`, your `measure.py`, cold server, first request.

| | this box (WSL2) | your entry (CachyOS) |
|---|---|---|
| Quant | `UD-IQ3_XXS` | `UD-Q3_K_XL` |
| Decode | 47.63 tok/s | 47.00 tok/s |
| Prefill | 73.91 tok/s | 95.31 tok/s |
| GPU loaded / peak | 14,774 / 15,126 MiB | 13,908 / 14,384 MiB |
| Min available RAM | 10,172 MiB | 2,290 MiB |
| Cache slots / threads | 96 / 16 | 80 / 12 |
| Grouped decode | `registered=48 covered=48`, `fallback=0` | same |

Warm, 20 back-to-back requests with `cache_prompt: false`: 52.6-53.2 tok/s, identical content hash all 20 times.

On your quant, `UD-Q3_K_XL`, this box gets 25.1 tok/s with the cache engaged and an output hash matching yours (`b6f509be`) — same computation, legacy path, because 52 GiB cannot pin under the cap. That is why the quant differs above: a constraint, not a preference.

Full setup, all 173 raw logs and the measurement table are under [`wsl2/`](https://github.com/LokenSI/llama.cpp/tree/moe-cache-wsl2/wsl2) on my fork.