### PR TITLE
cuda: Windows MoE pin budget - layer-subset routing + chunked pinned store

### DIFF
--- a/ggml/src/ggml-cuda/moe-cache.cu
+++ b/ggml/src/ggml-cuda/moe-cache.cu
@@ -11023,24 +11023,65 @@ static void * ggml_cuda_moe_cached_pinned_malloc(size_t size) {
 #ifdef _WIN32
 // Windows WDDM pins have two limits: a per-allocation cap (a single tens-of-GiB
 // cudaMallocHost fails) and an aggregate quota near half of physical RAM. A
-// full-range VirtualAlloc + chunked cudaHostRegister (4 GiB pieces, well under
-// the per-allocation cap) yields one contiguous, fully pinned buffer that the
-// direct MMID source views can read. Every chunk must register or the whole
-// thing unwinds: a partially-pinned store crashes the kernels with illegal
-// memory access, so no partial successes are returned.
+// full-range VirtualAlloc + chunked cudaHostRegister (4 GiB pieces) yields one
+// contiguous, fully pinned buffer. Every chunk must register or the whole
+// thing unwinds: a partially-pinned store crashes the kernels.
 static const size_t MOE_WIN_PIN_CHUNK = 4ULL << 30;
+static const size_t MOE_WIN_PIN_CHUNK_MIN = 16ULL << 20;
 
-static size_t g_moe_win_pin_chunk = 0; // resolved per-allocation by the ladder
+// Per-allocation registration records: each allocation resolves its own chunk
+// size, so cleanup must walk the addresses that were actually registered.
+struct moe_win_pin_segment {
+    void * addr;
+    size_t bytes;
+};
 
-static void ggml_cuda_moe_cached_win_pinned_free(void * base, size_t size) {
-    const size_t chunk = g_moe_win_pin_chunk ? g_moe_win_pin_chunk : MOE_WIN_PIN_CHUNK;
-    for (size_t off = 0; off < size; off += chunk) {
-        cudaHostUnregister((char *) base + off);
+struct moe_win_pin_record {
+    void * base;
+    size_t size;
+    std::vector<moe_win_pin_segment> segments;
+};
+
+// Serializes pin and unpin: the WDDM quota is process-wide.
+static std::mutex g_moe_win_pin_mu;
+static std::vector<moe_win_pin_record> g_moe_win_pin_records;
+
+// Caller must hold g_moe_win_pin_mu. VirtualFree runs only when all
+// unregisters succeed: freeing a range the driver still has registered
+// is worse than leaking the VA range.
+static bool moe_win_pin_release(void * base) {
+    for (auto it = g_moe_win_pin_records.begin(); it != g_moe_win_pin_records.end(); ++it) {
+        if (it->base != base) {
+            continue;
+        }
+        bool ok = true;
+        for (auto seg = it->segments.rbegin(); seg != it->segments.rend(); ++seg) {
+            cudaError_t err = cudaHostUnregister(seg->addr);
+            if (err != cudaSuccess) {
+                (void)cudaGetLastError();
+                GGML_LOG_WARN("moe-cache: win pin cudaHostUnregister of %zu MiB failed: %s\n",
+                              seg->bytes >> 20, cudaGetErrorString(err));
+                ok = false;
+            }
+        }
+        if (ok && !VirtualFree(base, 0, MEM_RELEASE)) {
+            GGML_LOG_ERROR("moe-cache: win pin VirtualFree failed: %lu\n", GetLastError());
+            ok = false;
+        }
+        g_moe_win_pin_records.erase(it);
+        return ok;
     }
-    VirtualFree(base, 0, MEM_RELEASE);
+    GGML_LOG_WARN("moe-cache: no win pin record for base %p\n", base);
+    return false;
 }
 
 static void * ggml_cuda_moe_cached_win_pinned_malloc(size_t size) {
+    if (getenv("GGML_CUDA_NO_PINNED") != nullptr) {
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(g_moe_win_pin_mu);
+
     void * base = VirtualAlloc(nullptr, size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
     if (base == nullptr) {
         GGML_LOG_DEBUG("%s: VirtualAlloc of %.2f MiB failed\n", __func__, size / 1024.0 / 1024.0);
@@ -11048,28 +11089,33 @@ static void * ggml_cuda_moe_cached_win_pinned_malloc(size_t size) {
     }
 
     // The in-process WDDM pin ceiling depends on how much the CUDA context has
-    // already allocated, so probe downward from the preferred chunk size and
-    // use the largest size that still registers.
+    // already allocated, so probe downward and use the largest chunk that registers.
     size_t chunk = MOE_WIN_PIN_CHUNK;
-    while (chunk >= (16ULL << 20)) {
+    while (chunk >= MOE_WIN_PIN_CHUNK_MIN) {
         // Touch the probe range first: cudaHostRegister needs resident pages.
         unsigned char * p = (unsigned char *) base;
         for (size_t off = 0; off < chunk && off < size; off += 4096) { p[off] = 0; }
         cudaError_t e = cudaHostRegister(base, std::min(chunk, size), cudaHostRegisterDefault);
         if (e == cudaSuccess) {
-            cudaHostUnregister(base);
+            if (cudaHostUnregister(base) != cudaSuccess) {
+                (void)cudaGetLastError();
+                // Range stays registered: freeing it would fault. Leak the VA range.
+                GGML_LOG_ERROR("%s: probe cudaHostUnregister failed - leaking the range\n", __func__);
+                return nullptr;
+            }
             break;
         }
         (void)cudaGetLastError();
         chunk >>= 1;
     }
-    if (chunk < (16ULL << 20)) {
-        GGML_LOG_DEBUG("%s: even a 16 MiB pin fails in this process - WDDM pin path exhausted\n", __func__);
+    if (chunk < MOE_WIN_PIN_CHUNK_MIN) {
+        GGML_LOG_DEBUG("%s: even a %zu MiB pin fails in this process - WDDM pin path exhausted\n",
+                       __func__, MOE_WIN_PIN_CHUNK_MIN >> 20);
         VirtualFree(base, 0, MEM_RELEASE);
         return nullptr;
     }
-    g_moe_win_pin_chunk = chunk;
 
+    std::vector<moe_win_pin_segment> segments;
     size_t registered = 0;
     while (registered < size) {
         size_t n = std::min(chunk, size - registered);
@@ -11084,29 +11130,55 @@ static void * ggml_cuda_moe_cached_win_pinned_malloc(size_t size) {
                            "(aggregate pinned quota reached?)\n",
                            __func__, n / 1024.0 / 1024.0, registered / 1024.0 / 1024.0 / 1024.0,
                            cudaGetErrorString(err));
-            ggml_cuda_moe_cached_win_pinned_free(base, registered);
+            // Unwind the segments already registered, in reverse order.
+            bool ok = true;
+            for (auto seg = segments.rbegin(); seg != segments.rend(); ++seg) {
+                cudaError_t uerr = cudaHostUnregister(seg->addr);
+                if (uerr != cudaSuccess) {
+                    (void)cudaGetLastError();
+                    GGML_LOG_WARN("%s: unwind cudaHostUnregister of %zu MiB failed: %s\n",
+                                  __func__, seg->bytes >> 20, cudaGetErrorString(uerr));
+                    ok = false;
+                }
+            }
+            if (ok) {
+                VirtualFree(base, 0, MEM_RELEASE);
+            } else {
+                GGML_LOG_ERROR("%s: incomplete unwind - leaking the VA range\n", __func__);
+            }
             return nullptr;
         }
+        segments.push_back({p, n});
         registered += n;
     }
+
+    g_moe_win_pin_records.push_back({base, size, std::move(segments)});
 
     GGML_LOG_INFO("moe-cache: Windows chunked pin engaged - %.2f GiB fully pinned in %zu MiB chunks\n",
                   size / 1024.0 / 1024.0 / 1024.0, chunk >> 20);
     return base;
 }
-#endif // _WIN32
 
 static void ggml_backend_cuda_moe_cached_win_pinned_free_buffer(ggml_backend_buffer_t buffer) {
-    if (buffer != nullptr && buffer->context != nullptr) {
-        ggml_cuda_moe_cached_win_pinned_free(buffer->context, buffer->size);
+    if (buffer == nullptr || buffer->context == nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_moe_win_pin_mu);
+    if (!moe_win_pin_release(buffer->context)) {
+        GGML_LOG_ERROR("moe-cache: win pin cleanup incomplete for base %p (%.2f GiB) - "
+                       "pinned quota may be held until process exit\n",
+                       buffer->context, buffer->size / 1024.0 / 1024.0 / 1024.0);
     }
 }
+#endif // _WIN32
 
 static ggml_backend_buffer_t ggml_backend_cuda_moe_cached_buffer_type_alloc_buffer(
         ggml_backend_buffer_type_t buft, size_t size) {
 
     void * ptr = nullptr;
+#ifdef _WIN32
     bool win_chunked = false;
+#endif
 
 #ifdef _WIN32
     // Windows: a failed tens-of-GiB cudaMallocHost appears to poison the WDDM
@@ -11130,8 +11202,12 @@ static ggml_backend_buffer_t ggml_backend_cuda_moe_cached_buffer_type_alloc_buff
 
     ggml_backend_buffer_t buffer = ggml_backend_cpu_buffer_from_ptr(ptr, size);
     buffer->buft             = buft;
-    buffer->iface.free_buffer = win_chunked ? ggml_backend_cuda_moe_cached_win_pinned_free_buffer
-                                            : ggml_backend_cuda_moe_cached_buffer_free_buffer;
+    buffer->iface.free_buffer = ggml_backend_cuda_moe_cached_buffer_free_buffer;
+#ifdef _WIN32
+    if (win_chunked) {
+        buffer->iface.free_buffer = ggml_backend_cuda_moe_cached_win_pinned_free_buffer;
+    }
+#endif
     return buffer;
 }
 

--- a/ggml/src/ggml-cuda/moe-cache.cu
+++ b/ggml/src/ggml-cuda/moe-cache.cu
@@ -30,6 +30,10 @@
 #include "ggml-cuda.h"
 #include "ggml.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -11016,10 +11020,107 @@ static void * ggml_cuda_moe_cached_pinned_malloc(size_t size) {
     return ptr;
 }
 
+#ifdef _WIN32
+// Windows WDDM pins have two limits: a per-allocation cap (a single tens-of-GiB
+// cudaMallocHost fails) and an aggregate quota near half of physical RAM. A
+// full-range VirtualAlloc + chunked cudaHostRegister (4 GiB pieces, well under
+// the per-allocation cap) yields one contiguous, fully pinned buffer that the
+// direct MMID source views can read. Every chunk must register or the whole
+// thing unwinds: a partially-pinned store crashes the kernels with illegal
+// memory access, so no partial successes are returned.
+static const size_t MOE_WIN_PIN_CHUNK = 4ULL << 30;
+
+static size_t g_moe_win_pin_chunk = 0; // resolved per-allocation by the ladder
+
+static void ggml_cuda_moe_cached_win_pinned_free(void * base, size_t size) {
+    const size_t chunk = g_moe_win_pin_chunk ? g_moe_win_pin_chunk : MOE_WIN_PIN_CHUNK;
+    for (size_t off = 0; off < size; off += chunk) {
+        cudaHostUnregister((char *) base + off);
+    }
+    VirtualFree(base, 0, MEM_RELEASE);
+}
+
+static void * ggml_cuda_moe_cached_win_pinned_malloc(size_t size) {
+    void * base = VirtualAlloc(nullptr, size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+    if (base == nullptr) {
+        GGML_LOG_DEBUG("%s: VirtualAlloc of %.2f MiB failed\n", __func__, size / 1024.0 / 1024.0);
+        return nullptr;
+    }
+
+    // The in-process WDDM pin ceiling depends on how much the CUDA context has
+    // already allocated, so probe downward from the preferred chunk size and
+    // use the largest size that still registers.
+    size_t chunk = MOE_WIN_PIN_CHUNK;
+    while (chunk >= (16ULL << 20)) {
+        // Touch the probe range first: cudaHostRegister needs resident pages.
+        unsigned char * p = (unsigned char *) base;
+        for (size_t off = 0; off < chunk && off < size; off += 4096) { p[off] = 0; }
+        cudaError_t e = cudaHostRegister(base, std::min(chunk, size), cudaHostRegisterDefault);
+        if (e == cudaSuccess) {
+            cudaHostUnregister(base);
+            break;
+        }
+        (void)cudaGetLastError();
+        chunk >>= 1;
+    }
+    if (chunk < (16ULL << 20)) {
+        GGML_LOG_DEBUG("%s: even a 16 MiB pin fails in this process - WDDM pin path exhausted\n", __func__);
+        VirtualFree(base, 0, MEM_RELEASE);
+        return nullptr;
+    }
+    g_moe_win_pin_chunk = chunk;
+
+    size_t registered = 0;
+    while (registered < size) {
+        size_t n = std::min(chunk, size - registered);
+        // Touch the range first: cudaHostRegister needs resident committed pages.
+        unsigned char * p = (unsigned char *) base + registered;
+        for (size_t off = 0; off < n; off += 4096) { p[off] = 0; }
+
+        cudaError_t err = cudaHostRegister(p, n, cudaHostRegisterDefault);
+        if (err != cudaSuccess) {
+            (void)cudaGetLastError();
+            GGML_LOG_DEBUG("%s: cudaHostRegister of %.2f MiB at offset %.2f GiB failed: %s "
+                           "(aggregate pinned quota reached?)\n",
+                           __func__, n / 1024.0 / 1024.0, registered / 1024.0 / 1024.0 / 1024.0,
+                           cudaGetErrorString(err));
+            ggml_cuda_moe_cached_win_pinned_free(base, registered);
+            return nullptr;
+        }
+        registered += n;
+    }
+
+    GGML_LOG_INFO("moe-cache: Windows chunked pin engaged - %.2f GiB fully pinned in %zu MiB chunks\n",
+                  size / 1024.0 / 1024.0 / 1024.0, chunk >> 20);
+    return base;
+}
+#endif // _WIN32
+
+static void ggml_backend_cuda_moe_cached_win_pinned_free_buffer(ggml_backend_buffer_t buffer) {
+    if (buffer != nullptr && buffer->context != nullptr) {
+        ggml_cuda_moe_cached_win_pinned_free(buffer->context, buffer->size);
+    }
+}
+
 static ggml_backend_buffer_t ggml_backend_cuda_moe_cached_buffer_type_alloc_buffer(
         ggml_backend_buffer_type_t buft, size_t size) {
 
-    void * ptr = ggml_cuda_moe_cached_pinned_malloc(size);
+    void * ptr = nullptr;
+    bool win_chunked = false;
+
+#ifdef _WIN32
+    // Windows: a failed tens-of-GiB cudaMallocHost appears to poison the WDDM
+    // pin path for the rest of the process (subsequent cudaHostRegister of
+    // even one 4 GiB chunk fails with out-of-memory). Go chunked-first and
+    // keep cudaMallocHost as the small-allocation fallback.
+    ptr = ggml_cuda_moe_cached_win_pinned_malloc(size);
+    win_chunked = ptr != nullptr;
+    if (ptr == nullptr) {
+        ptr = ggml_cuda_moe_cached_pinned_malloc(size);
+    }
+#else
+    ptr = ggml_cuda_moe_cached_pinned_malloc(size);
+#endif
 
     if (ptr == nullptr) {
         // Pinned alloc failed -- fall back to a regular CPU buffer. This costs
@@ -11029,7 +11130,8 @@ static ggml_backend_buffer_t ggml_backend_cuda_moe_cached_buffer_type_alloc_buff
 
     ggml_backend_buffer_t buffer = ggml_backend_cpu_buffer_from_ptr(ptr, size);
     buffer->buft             = buft;
-    buffer->iface.free_buffer = ggml_backend_cuda_moe_cached_buffer_free_buffer;
+    buffer->iface.free_buffer = win_chunked ? ggml_backend_cuda_moe_cached_win_pinned_free_buffer
+                                            : ggml_backend_cuda_moe_cached_buffer_free_buffer;
     return buffer;
 }
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -357,11 +357,28 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
             // silently falls back to plain CPU buffers. GGML_CUDA_MOE_PIN_LAYERS=N
             // remedies this by routing only the first N layers' expert tensors through
             // the cached (pinned) buffer type - the subset then pins under the quota -
-            // while the remaining layers keep the plain CPU path. The MMID kernels read
-            // expert sources directly from pinned host memory, so the cached subset must
-            // pin in full: partial pins crash with illegal memory access.
+            // while the remaining layers follow their normal placement (the
+            // --n-gpu-layers window, or --cpu-moe / --n-cpu-moe where they match).
+            // The MMID kernels read expert sources directly from pinned host memory,
+            // so the cached subset must pin in full: partial pins crash.
+            int pin_layers = 0;
             const char * pin_layers_env = getenv("GGML_CUDA_MOE_PIN_LAYERS");
-            int pin_layers = pin_layers_env ? atoi(pin_layers_env) : 0;
+            if (pin_layers_env != nullptr && pin_layers_env[0] != '\0') {
+                char * end = nullptr;
+                long v = strtol(pin_layers_env, &end, 10);
+                if (end == pin_layers_env || end == nullptr || *end != '\0' || v <= 0) {
+                    LLAMA_LOG_WARN("GGML_CUDA_MOE_PIN_LAYERS=%s is not a positive integer - ignoring\n",
+                                   pin_layers_env);
+                } else {
+                    // The cap only bounds the regex size: a count above the model
+                    // depth is harmless, the extra alternations never match.
+                    if (v > 512) {
+                        LLAMA_LOG_WARN("GGML_CUDA_MOE_PIN_LAYERS=%ld clamped to 512\n", v);
+                        v = 512;
+                    }
+                    pin_layers = (int) v;
+                }
+            }
             if (pin_layers > 0) {
                 pin_pattern = "blk\\.(";
                 for (int i = 0; i < pin_layers; i++) {
@@ -371,7 +388,8 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
                 pin_pattern += ")\\.ffn_(up|down|gate|gate_up)_(ch|)exps";
                 effective_overrides.push_back({pin_pattern.c_str(), buffer_type_fn()});
                 LLAMA_LOG_INFO("moe expert cache: pin-budget mode - routing expert tensors of the first %d layers "
-                               "through the GPU LRU cache (remaining layers use plain CPU buffers)\n", pin_layers);
+                               "through the GPU LRU cache (remaining layers keep their normal placement: the "
+                               "--n-gpu-layers window, or --cpu-moe / --n-cpu-moe where they match)\n", pin_layers);
             } else {
                 static const char * MOE_EXPS_PATTERN =
                     "\\.ffn_(up|down|gate|gate_up)_(ch|)exps";
@@ -386,8 +404,15 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
                 }
             }
             if (had_user_overrides) {
-                LLAMA_LOG_WARN("--moe-expert-cache-size is set; expert tensors route through "
-                               "the GPU LRU cache regardless of --cpu-moe / --n-cpu-moe.\n");
+                if (pin_layers > 0) {
+                    LLAMA_LOG_WARN("--moe-expert-cache-size with GGML_CUDA_MOE_PIN_LAYERS: expert tensors of "
+                                   "the first %d layers route through the GPU LRU cache and override "
+                                   "--cpu-moe / --n-cpu-moe for those layers only; later layers keep "
+                                   "those overrides.\n", pin_layers);
+                } else {
+                    LLAMA_LOG_WARN("--moe-expert-cache-size is set; expert tensors route through "
+                                   "the GPU LRU cache regardless of --cpu-moe / --n-cpu-moe.\n");
+                }
             }
             effective_overrides.push_back({nullptr, nullptr});
             effective_overrides_ptr = effective_overrides.data();

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -325,6 +325,10 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
         // for the duration of this function, which outlives the loader's use
         // of the pointer.
         std::vector<llama_model_tensor_buft_override> effective_overrides;
+        // Function scope, like the vector: the loader dereferences these pattern
+        // pointers long after the block below closes - a block-scoped string
+        // would dangle its c_str() before the loader runs.
+        std::string pin_pattern;
         const llama_model_tensor_buft_override * effective_overrides_ptr = params.tensor_buft_overrides;
         if (params.moe_expert_cache_slots > 0) {
             ggml_backend_moe_cache_set_slots_t set_slots_fn = nullptr;
@@ -347,9 +351,32 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
             set_slots_fn(params.moe_expert_cache_slots);
             // Pattern matches the same expert tensors that --cpu-moe / --n-cpu-moe target.
             // Kept inline (not pulled from common.h) so libllama keeps no common/ dep.
-            static const char * MOE_EXPS_PATTERN =
-                "\\.ffn_(up|down|gate|gate_up)_(ch|)exps";
-            effective_overrides.push_back({MOE_EXPS_PATTERN, buffer_type_fn()});
+            //
+            // Windows WDDM caps TOTAL page-locked memory near ~50% of physical RAM, so
+            // pinning a full expert set (tens of GiB) fails there and the whole cache
+            // silently falls back to plain CPU buffers. GGML_CUDA_MOE_PIN_LAYERS=N
+            // remedies this by routing only the first N layers' expert tensors through
+            // the cached (pinned) buffer type - the subset then pins under the quota -
+            // while the remaining layers keep the plain CPU path. The MMID kernels read
+            // expert sources directly from pinned host memory, so the cached subset must
+            // pin in full: partial pins crash with illegal memory access.
+            const char * pin_layers_env = getenv("GGML_CUDA_MOE_PIN_LAYERS");
+            int pin_layers = pin_layers_env ? atoi(pin_layers_env) : 0;
+            if (pin_layers > 0) {
+                pin_pattern = "blk\\.(";
+                for (int i = 0; i < pin_layers; i++) {
+                    if (i > 0) pin_pattern += "|";
+                    pin_pattern += std::to_string(i);
+                }
+                pin_pattern += ")\\.ffn_(up|down|gate|gate_up)_(ch|)exps";
+                effective_overrides.push_back({pin_pattern.c_str(), buffer_type_fn()});
+                LLAMA_LOG_INFO("moe expert cache: pin-budget mode - routing expert tensors of the first %d layers "
+                               "through the GPU LRU cache (remaining layers use plain CPU buffers)\n", pin_layers);
+            } else {
+                static const char * MOE_EXPS_PATTERN =
+                    "\\.ffn_(up|down|gate|gate_up)_(ch|)exps";
+                effective_overrides.push_back({MOE_EXPS_PATTERN, buffer_type_fn()});
+            }
 
             bool had_user_overrides = false;
             if (params.tensor_buft_overrides) {

--- a/tests/test-moe-cache.cpp
+++ b/tests/test-moe-cache.cpp
@@ -12017,6 +12017,26 @@ static void test_moe_cache_proc_api() {
     fprintf(stderr, "test-moe-cache: dynamic backend procedure API OK\n");
 }
 
+#ifdef _WIN32
+// Repeated interleaved alloc/free of the cached buffer type: each allocation
+// records its own registered segments, so out-of-order frees must clean up by
+// record, not by a process-wide stride.
+static void test_win_pin_alloc_free_cycles() {
+    for (int cycle = 0; cycle < 3; cycle++) {
+        ggml_backend_buffer_t big = ggml_backend_buft_alloc_buffer(
+            ggml_backend_cuda_moe_cached_buffer_type(), 512ULL << 20);
+        ggml_backend_buffer_t small = ggml_backend_buft_alloc_buffer(
+            ggml_backend_cuda_moe_cached_buffer_type(), 64ULL << 20);
+        CHECK(big != nullptr && small != nullptr);
+        memset(ggml_backend_buffer_get_base(big), 0, 4096);
+        memset(ggml_backend_buffer_get_base(small), 0, 4096);
+        ggml_backend_buffer_free(big);
+        ggml_backend_buffer_free(small);
+    }
+    fprintf(stderr, "test-moe-cache: win pin alloc/free cycles OK\n");
+}
+#endif
+
 int main(int argc, char ** argv) {
     const bool registry_only = argc == 2 && strcmp(argv[1], "--registry-only") == 0;
     const bool registry_bench = argc == 2 && strcmp(argv[1], "--registry-bench") == 0;
@@ -12029,7 +12049,16 @@ int main(int argc, char ** argv) {
     const bool legacy_phase_telemetry_only = argc == 2 && strcmp(argv[1], "--legacy-phase-telemetry-only") == 0;
     const bool gemma_q4_parity_only = argc == 2 && strcmp(argv[1], "--gemma-q4-parity-only") == 0;
     const bool prefill_resident_only = argc == 2 && strcmp(argv[1], "--prefill-resident-only") == 0;
+    const bool win_pin_only = argc == 2 && strcmp(argv[1], "--win-pin-only") == 0;
     test_moe_cache_proc_api();
+#ifdef _WIN32
+    if (win_pin_only) {
+        ggml_backend_ptr backend(ggml_backend_cuda_init(0));
+        CHECK(backend != nullptr);
+        test_win_pin_alloc_free_cycles();
+        return 0;
+    }
+#endif
     if (prefill_resident_only) {
         test_prefill_resident_biases();
         return 0;
@@ -12475,6 +12504,10 @@ int main(int argc, char ** argv) {
 
     CUDA_OK(cudaStreamDestroy(copy_stream));
     CUDA_OK(cudaFreeHost(host_experts));
+
+#ifdef _WIN32
+    test_win_pin_alloc_free_cycles();
+#endif
 
     fprintf(stderr, "test-moe-cache: OK\n");
     return 0;


### PR DESCRIPTION
Complements #76 (bounded pin budget) with a Windows-tested layer-subset router and a chunked pinned-store allocator, plus the WDDM measurements behind them.

## Problem

On Windows the expert cache's full-set pin silently falls back to plain CPU buffers when the driver refuses the allocation — all-zero `tensors/covered` counters, no warning, uncached speed. WDDM caps page-locked host memory far below what a full expert-set pin needs.

## Measured on this rig (RTX 5070 Ti 16GB, 64 GB RAM, CUDA 13.1, Windows 11)

- Bare process: aggregate `cudaHostRegister` ~= **28 GB** obtainable
- Inside a loaded server: per-call limit collapses to **~2 GB**, aggregate **~2-4 GB total** per process
- Full Flash-Next UD-Q3_K_XL pin = **52.2 GiB request, never grantable** on 64 GB WDDM (verified with 52.9 GB free)
- Pin pool is sticky: once spent, even 256 MB fails; pool is shared with the CUDA context (~24 GB/process ceiling on bigger boxes)
- Driver probe: `PageableMemoryAccess=0`, `HostRegisterSupported=1`

## What this patch adds

1. **`GGML_CUDA_MOE_PIN_LAYERS` subset routing** — pin a chosen subset of layers when the full expert set cannot fit, instead of nothing. 66/66 tensors claimed on Flash-Next UD-Q3_K_XL. Includes a scope fix: the pattern string must outlive the loader (otherwise a dangling pointer silently drops claims).
2. **Adaptive chunked `cudaHostRegister` allocator** — ladder of shrinking chunk sizes. Doubles as a diagnostic of what a given box/driver actually grants, turning silent fallback into measurable data.

## Honest scope

This does **not** reach the full cached path on 64 GB WDDM — the in-process grant is 2-4 GB versus the ~24 GB the cached path wants. Where it helps: bigger-RAM Windows boxes (128 GB: AnimaLoraStudio measured the ~50% cap; vetchahoo's box pins fine) and anyone diagnosing WDDM grant limits. Possible follow-up: tensor data pointers are 64B- rather than 4KB-aligned — `cudaHostRegister` wants 4K alignment, so alignment fixup may improve grant sizes.

The compute-sanitizer report and full env diagnostics were shared on Discord earlier; happy to attach here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)