### PR TITLE
qwen4exp: prefetch requested lazy PLE pages (upstream reference)

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -661,16 +661,82 @@ struct llama_mmap::impl {
 
     void * addr;
     size_t size;
+    llama_mmap::ranges lazy_ranges;
 };
 
 llama_mmap::llama_mmap(struct llama_file * file, size_t prefetch, bool numa,
-        const ranges & lazy_ranges) : pimpl(std::make_unique<impl>(file, prefetch, numa, lazy_ranges)) {}
+        const ranges & lazy_ranges) : pimpl(std::make_unique<impl>(file, prefetch, numa, lazy_ranges)) {
+    pimpl->lazy_ranges = lazy_ranges;
+}
 llama_mmap::~llama_mmap() = default;
 
 size_t llama_mmap::size() const { return pimpl->size; }
 void * llama_mmap::addr() const { return pimpl->addr; }
 
 void llama_mmap::unmap_fragment(size_t first, size_t last) { pimpl->unmap_fragment(first, last); }
+
+void llama_mmap::prefetch_rows(const void * data, size_t row_size, const int32_t * rows, size_t n_rows) const {
+#if defined(_POSIX_MAPPED_FILES) && defined(POSIX_MADV_WILLNEED)
+    const uintptr_t base = reinterpret_cast<uintptr_t>(addr());
+    const uintptr_t ptr  = reinterpret_cast<uintptr_t>(data);
+    if (!data || !rows || row_size == 0 || ptr < base || ptr - base >= size()) {
+        return;
+    }
+    const size_t offset = ptr - base;
+    size_t limit = offset;
+    for (const auto & range : pimpl->lazy_ranges) {
+        if (offset >= range.first && offset < range.second) {
+            limit = std::min(range.second, size());
+            break;
+        }
+    }
+    if (limit <= offset || row_size > limit - offset) {
+        return;
+    }
+    static const long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        return;
+    }
+
+    // Keep scratch bounded and merge only overlapping or adjacent requested pages.
+    std::pair<size_t, size_t> pages[256];
+    while (n_rows > 0) {
+        const size_t count = std::min(n_rows, size_t(256));
+        size_t n_pages = 0;
+        for (size_t i = 0; i < count; ++i) {
+            if (rows[i] < 0 || size_t(rows[i]) >= (limit - offset) / row_size) {
+                continue;
+            }
+            const size_t first = offset + size_t(rows[i]) * row_size;
+            const size_t end = first + row_size;
+            const size_t padding = (page_size - end % page_size) % page_size;
+            pages[n_pages++] = {first - first % page_size, end + std::min(padding, size() - end)};
+        }
+        std::sort(pages, pages + n_pages);
+        for (size_t i = 0; i < n_pages; ++i) {
+            const size_t first = pages[i].first;
+            size_t end = pages[i].second;
+            while (i + 1 < n_pages && pages[i + 1].first <= end) {
+                end = std::max(end, pages[++i].second);
+            }
+            for (const auto & fragment : pimpl->mapped_fragments) {
+                if (first >= fragment.first && end <= fragment.second) {
+                    // Advice failure leaves the ordinary demand-paged gather intact.
+                    (void) posix_madvise((char *) addr() + first, end - first, POSIX_MADV_WILLNEED);
+                    break;
+                }
+            }
+        }
+        rows += count;
+        n_rows -= count;
+    }
+#else
+    GGML_UNUSED(data);
+    GGML_UNUSED(row_size);
+    GGML_UNUSED(rows);
+    GGML_UNUSED(n_rows);
+#endif
+}
 
 #if defined(_POSIX_MEMLOCK_RANGE) || defined(_WIN32)
 const bool llama_mmap::SUPPORTED  = true;

--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -55,6 +55,8 @@ struct llama_mmap {
 
     void unmap_fragment(size_t first, size_t last);
 
+    void prefetch_rows(const void * data, size_t row_size, const int32_t * rows, size_t n_rows) const;
+
     static const bool SUPPORTED;
 
 private:

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1862,6 +1862,15 @@ ggml_tensor * llama_model_base::create_tensor(llama_model_loader & ml, const LLM
         tn, ne, flags);
 }
 
+void llama_model::prefetch_rows(const ggml_tensor * tensor, const int32_t * rows, size_t n_rows) const {
+    if (!tensor || !tensor->data || !ggml_is_matrix(tensor) || !ggml_is_contiguous(tensor)) {
+        return;
+    }
+    for (const auto & mapping : pimpl->mappings) {
+        mapping->prefetch_rows(tensor->data, tensor->nb[1], rows, n_rows);
+    }
+}
+
 std::string llama_model::arch_name() const {
     return llm_arch_name(arch);
 }

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -747,6 +747,8 @@ struct llama_model {
 
     bool has_tensor_overrides() const;
 
+    void prefetch_rows(const ggml_tensor * tensor, const int32_t * rows, size_t n_rows) const;
+
     const struct ggml_tensor * get_tensor(const char * name) const;
 
     float get_rope_freq_base (const llama_cparams & cparams, int il) const;

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -1109,6 +1109,7 @@ void llm_graph_input_ple::set_input(const llama_ubatch * ubatch) {
         }
     }
 
+    pmodel.prefetch_rows(pmodel.per_layer_tok_embd, idx.data(), idx.size());
     ggml_backend_tensor_set(rows, idx.data(), 0, idx.size()*ggml_element_size(rows));
 }
 


### PR DESCRIPTION
## Overview

Lazy Qwen PLE gathers can wait on serial faults for sparse rows. Advise the pages for the current batch's known row indices before graph execution, preserving the existing mmap, GET_ROWS, and arithmetic. The mmap helper checks lazy ranges, file bounds, page crossings, and retained fragments; it merges requested pages in fixed 256-range chunks. Unsupported platforms use a no-op fallback. No worker pool, direct-reader mode, or generic GET_ROWS scheduling change is included.

Owner-authorized fork reference for a possible later manual upstream submission. This draft is based entirely on pristine upstream history, with no MoE-cache or partial-pinning dependencies.

- Pristine upstream and fork PR base: `df03399b885831b2a1603b3abb0d8c156808e363`.
- Head: `b5fd33bc9145ac7eefd056e8b7c6049c0b847acc`.
- Intended later upstream target: `ggml-org/llama.cpp:master`, refreshed and reviewed by the owner before submission.
- Related alternative: https://github.com/ggml-org/llama.cpp/pull/28136 (explicit buffered reads; still open when checked).

## Validation and limitations

CPU Release build passed. Existing IQ4_NL GET_ROWS tests passed 8/8. Standalone checks using the changed mmap implementation passed ASan/UBSan for bounds, page crossings, duplicate ranges, removed fragments, advice failure, and compile-time no-op fallback.

A bounded real-shard experiment using upstream IQ4_NL dequantization measured mean cold gather time of 4.13 -> 1.98 ms for 16 rows and 250.1 -> 22.7 ms for 1792 rows. Warm 16-row time increased from 4.9 to 11.8 us. F32 bytes matched on identical row indices in all 72 batches. Peak RSS was 167 MiB. Cold arms used separate nonresident row sets, selected with mincore without cache eviction; the experiment overlapped CPU compilation. These are exploratory gather measurements, not full-model throughput results. Advice itself can block and accounted for most remaining cold latency.

A CUDA full-model A/B used Qwen3.8 Flash Next UD-Q3_K_XL with `--load-mode none --lazy-mode on`, 4K context, 512/256 batches, Q8_0 KV, Flash Attention, 12 CPU threads, automatic offload, and a 1024 MiB fit margin. Each binary processed the same 800-token prompt twice and generated exactly 1024 tokens per request. All four generated token-ID arrays and response texts matched exactly.

First-request baseline -> patched results were 206.01 -> 258.55 prompt tok/s and 21.758 -> 23.129 decode tok/s. Immediate second-request results were 236.37 -> 296.74 prompt tok/s and 22.984 -> 22.746 decode tok/s. Across both requests, prompt time fell 20.33%, decode time fell 2.53%, and combined prompt plus decode time fell 3.84%. Peak GPU use was 14825 MiB. The 8 GiB available-memory guard did not fire, both servers stopped cleanly, and both ports closed.

Only the PLE byte range was selectively evicted before each server; no global cache flush was used. Minimum available host memory was 8.71-8.96 GiB, and PLE residency remained low, so the immediate second request is not proven fully page-warm. This is one baseline-then-patched server pair, not a statistical or sustained-pressure benchmark. Windows currently takes the no-op fallback. Advice bounds requested I/O and scratch, but does not cap accumulated OS page-cache residency.

Local reproducibility artifacts: `/home/gencoolpc/llama-ple-prefetch-upstream/build-ple-validation/REPORT.md`, with exact commands, baseline source archive, test harnesses, request/response JSON, token hashes, memory samples, residency snapshots, raw CSV, and logs. No new tests/* files.

## Requirements

- Contributing guidelines reviewed under the owner's fork automation exception; the owner remains responsible for reviewing, understanding, and maintaining the change.
- AI usage disclosure: YES. Codex implemented the owner-approved design, ran local checks, and prepared this fork reference commit and PR. Any upstream submission will be handled personally by the owner.
